### PR TITLE
Allow DI of a custom Storage implementation.

### DIFF
--- a/src/services/oidc.security.common.ts
+++ b/src/services/oidc.security.common.ts
@@ -14,8 +14,11 @@ export class OidcSecurityCommon {
     storage_auth_state_control = 'authStateControl';
     storage_well_known_endpoints = 'wellknownendpoints';
 
-    constructor(private authConfiguration: AuthConfiguration) {
-        if (typeof Storage !== 'undefined') { this.storage = sessionStorage; } //localStorage;
+    constructor(private authConfiguration: AuthConfiguration, private injectedStorage: Storage) {
+        if (typeof Storage !== 'undefined') {
+            if (injectedStorage) { this.storage = injectedStorage; }
+            else { this.storage = sessionStorage; }
+        }
     }
 
     retrieve(key: string): any {


### PR DESCRIPTION
This change to `oidc.security.common` allows it to accept a custom implementation of Storage from angular DI.

For example, you can get angular-auth-oidc-client to store access tokens in Cookies by downloading and adding [Cookie-Storage](https://github.com/bouzuya/cookie-storage) to your project, creating a factory method to provide it:
```
let cookieStorageFactory = () => {
    return new CookieStorage();
}
```
..and then adding it to the providers array in @NgModule:
`{ provide: Storage, useFactory: cookieStorageFactory }`