### PR TITLE
Fix http headers

### DIFF
--- a/src/services/auth.well-known-endpoints.ts
+++ b/src/services/auth.well-known-endpoints.ts
@@ -97,7 +97,6 @@ export class AuthWellKnownEndpoints {
     private getWellKnownEndpoints = (): Observable<any> => {
 
         let headers = new Headers();
-        headers.append('Content-Type', 'application/json');
         headers.append('Accept', 'application/json');
 
         let url = this.authConfiguration.stsServer + '/.well-known/openid-configuration';

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -1,7 +1,7 @@
 ﻿import { PLATFORM_ID, Inject } from '@angular/core';
 import { isPlatformBrowser, isPlatformServer } from '@angular/common';
 import { Injectable, EventEmitter, Output } from '@angular/core';
-import { Http, Response, Headers } from '@angular/http';
+import { Http, Response } from '@angular/http';
 import 'rxjs/add/operator/map';
 import 'rxjs/add/operator/catch';
 import { Observable } from 'rxjs/Rx';
@@ -29,7 +29,6 @@ export class OidcSecurityService {
     private _userData = new BehaviorSubject<any>('');
     private _userDataValue: boolean;
 
-    private headers: Headers;
     private oidcSecurityValidation: OidcSecurityValidation;
     private errorMessage: string;
     private jwtKeys: JwtKeys;
@@ -61,10 +60,6 @@ export class OidcSecurityService {
         if (this.oidcSecurityCommon.retrieve(this.oidcSecurityCommon.storage_user_data) !== '') {
             this.setUserData(this.oidcSecurityCommon.retrieve(this.oidcSecurityCommon.storage_user_data));
         }
-
-        this.headers = new Headers();
-        this.headers.append('Content-Type', 'application/json');
-        this.headers.append('Accept', 'application/json');
 
         if (this.oidcSecurityCommon.retrieve(this.oidcSecurityCommon.storage_is_authorized) !== '') {
             this.setIsAuthorized(this.oidcSecurityCommon.retrieve(this.oidcSecurityCommon.storage_is_authorized));

--- a/src/services/oidc.security.user-service.ts
+++ b/src/services/oidc.security.user-service.ts
@@ -32,7 +32,6 @@ export class OidcSecurityUserService {
     private getIdentityUserData = (): Observable<any> => {
 
         let headers = new Headers();
-        headers.append('Content-Type', 'application/json');
         headers.append('Accept', 'application/json');
 
         let token = this.oidcSecurityCommon.getAccessToken();


### PR DESCRIPTION
The header 'Content-Type', 'application/json' causes the following error:

Response to preflight request doesn't pass access control check: No 'Access-Control-Allow-Origin' header is present on the requested resource.

I encountered this issue while using this library with Azure B2C as authorization server.