### PR TITLE
allow authorizedCallback to accept an hash parameter

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -164,14 +164,14 @@ export class OidcSecurityService {
         window.location.href = url;
     }
 
-    authorizedCallback() {
+    authorizedCallback(hash?: string) {
         let silentRenew = this.oidcSecurityCommon.retrieve(this.oidcSecurityCommon.storage_silent_renew_running);
         let isRenewProcess = (silentRenew === 'running');
 
         this.oidcSecurityCommon.logDebug('BEGIN authorizedCallback, no auth data');
         this.resetAuthorizationData(isRenewProcess);
 
-        let hash = window.location.hash.substr(1);
+        hash = hash || window.location.hash.substr(1);
 
         let result: any = hash.split('&').reduce(function (result: any, item: string) {
             let parts = item.split('=');


### PR DESCRIPTION
Hi, 

I am having some issue with your library and my application.
For some reasons, we are using angular-router with the `{useHash: true}` option. 

Because of this, I can't have another hash in my URL and I am redirected to something like `/#/homeid_token=....` by the sts server.

I was using this little hack to make sure your library was able to find the `id_token` hash param : 

```
if (typeof location !== 'undefined' && window.location.hash) {
            const indexHash = window.location.hash.indexOf('id_token');
            if (indexHash > -1) {
                window.location.hash = window.location.hash.substr(indexHash);
           }
}
```
The issue is that Internet Explorer does not allow me to set the value of `window.location.hash`. 
It would be so much easier if you could provide you the hash substring that works.

Have fun,

Max