### PR TITLE
Add option to trigger event on authorization resolution instead of automatic redirect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,4395 @@
+{
+    "name": "angular-auth-oidc-client",
+    "version": "1.3.12",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "@angular/animations": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-4.1.0.tgz",
+            "integrity": "sha1-l7ZCruAbVAbgPsZeSZNCupHi3Tg=",
+            "dev": true
+        },
+        "@angular/common": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/common/-/common-4.1.0.tgz",
+            "integrity": "sha1-Q3D1aeUd3ZmWO39KpYwaXcxf6lI=",
+            "dev": true
+        },
+        "@angular/compiler": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-4.1.0.tgz",
+            "integrity": "sha1-vhreW2rsgfA8KdUry5WSWiiQDcs=",
+            "dev": true
+        },
+        "@angular/compiler-cli": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-4.1.0.tgz",
+            "integrity": "sha1-cnqq2ov9lChemBiZWSUEj3/fEgA=",
+            "dev": true
+        },
+        "@angular/core": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/core/-/core-4.1.0.tgz",
+            "integrity": "sha1-cuwXMxaHlXGIDJxIPtbfwMqrlLA=",
+            "dev": true
+        },
+        "@angular/http": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/http/-/http-4.1.0.tgz",
+            "integrity": "sha1-e6DE0ETe6WQCG3zxnLFGosMVd6U=",
+            "dev": true
+        },
+        "@angular/platform-browser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-4.1.0.tgz",
+            "integrity": "sha1-uYE4a+Gjbyr38GeUR/2XtyZ7Jd4=",
+            "dev": true
+        },
+        "@angular/platform-browser-dynamic": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/platform-browser-dynamic/-/platform-browser-dynamic-4.1.0.tgz",
+            "integrity": "sha1-AlDYLUq9Nr5guzH8dEisbigDZpA=",
+            "dev": true
+        },
+        "@angular/platform-server": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/platform-server/-/platform-server-4.1.0.tgz",
+            "integrity": "sha1-YQChL+PoVoyb9fwnr3nlKqpx/ts=",
+            "dev": true
+        },
+        "@angular/router": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/router/-/router-4.1.0.tgz",
+            "integrity": "sha1-3TVjZi+Vyjqj3Z/xPG7UvqHZCwY=",
+            "dev": true
+        },
+        "@angular/tsc-wrapped": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@angular/tsc-wrapped/-/tsc-wrapped-4.1.0.tgz",
+            "integrity": "sha1-B8vWHZGt3kwtr5pBYFFSlSuIMrM=",
+            "dev": true
+        },
+        "@compodoc/compodoc": {
+            "version": "1.0.0-beta.9",
+            "resolved": "https://registry.npmjs.org/@compodoc/compodoc/-/compodoc-1.0.0-beta.9.tgz",
+            "integrity": "sha1-sa6U1iY8b10ERCsGjJcOfCCUOpo=",
+            "dev": true,
+            "dependencies": {
+                "typescript": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.2.tgz",
+                    "integrity": "sha1-8PBF4Zb2mnLwayX9O9OdAcPOmYQ=",
+                    "dev": true
+                }
+            }
+        },
+        "@compodoc/ngd-core": {
+            "version": "2.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/@compodoc/ngd-core/-/ngd-core-2.0.0-alpha.3.tgz",
+            "integrity": "sha512-wZNC0HhZCu3KufvulriGfEayjmniEih25R3CvxIvEMVk4kCvVA6giLhYzKgIl0J9JC5KKYdXuu9SlVXr9Niyug==",
+            "dev": true,
+            "dependencies": {
+                "typescript": {
+                    "version": "2.5.2",
+                    "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+                    "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+                    "dev": true
+                }
+            }
+        },
+        "@compodoc/ngd-transformer": {
+            "version": "2.0.0-alpha.5",
+            "resolved": "https://registry.npmjs.org/@compodoc/ngd-transformer/-/ngd-transformer-2.0.0-alpha.5.tgz",
+            "integrity": "sha512-gA6AgVgPXvlL4MtzzgMWB4FzQsQHndXpRQGWZ9NzQFpl+Qcyko+CMVU+ssqSwp/JAidL/3l3fk/aDDlymhJJag==",
+            "dev": true,
+            "dependencies": {
+                "fs-extra": {
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.1.tgz",
+                    "integrity": "sha1-f8DGyJV/mD9X8waiTlud3Y0N2IA=",
+                    "dev": true
+                }
+            }
+        },
+        "@types/jasmine": {
+            "version": "2.5.48",
+            "resolved": "https://registry.npmjs.org/@types/jasmine/-/jasmine-2.5.48.tgz",
+            "integrity": "sha512-XelrQlM8WM8JqZSnjDC51ojku80PT/fMgqCxVFK1kg8ABg6WxDxZwr4R9ITfRC6CFwXElSbINj0ZUHf/7YzQkw==",
+            "dev": true
+        },
+        "@types/node": {
+            "version": "7.0.22",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.22.tgz",
+            "integrity": "sha1-RZP02Ci91hKSlHjqQMZ7T0A8olU=",
+            "dev": true
+        },
+        "accepts": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+            "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+            "dev": true
+        },
+        "acorn": {
+            "version": "4.0.13",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+            "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
+            "dev": true
+        },
+        "acorn-dynamic-import": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
+            "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
+            "dev": true
+        },
+        "after": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
+            "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8=",
+            "dev": true
+        },
+        "ajv": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "dev": true
+        },
+        "ajv-keywords": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+            "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "anymatch": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
+            "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
+            "dev": true
+        },
+        "apache-crypt": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/apache-crypt/-/apache-crypt-1.2.1.tgz",
+            "integrity": "sha1-1vxyqm0n2ZyVqU/RiNcx7v/6Zjw=",
+            "dev": true
+        },
+        "apache-md5": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.2.tgz",
+            "integrity": "sha1-7klza2ObTxCLbp5ibG2pkwa0FpI=",
+            "dev": true
+        },
+        "app-root-path": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+            "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+            "dev": true
+        },
+        "arr-diff": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+            "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
+            "dev": true
+        },
+        "arr-flatten": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+            "dev": true
+        },
+        "array-differ": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-1.0.0.tgz",
+            "integrity": "sha1-7/UuN1gknTO+QCuLuOVkuytdQDE=",
+            "dev": true
+        },
+        "array-slice": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/array-slice/-/array-slice-0.2.3.tgz",
+            "integrity": "sha1-3Tz7gO15c6dRF82sabC5nshhhvU=",
+            "dev": true
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "array-unique": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
+            "integrity": "sha1-odl8yvy8JiXMcPrc6zalDFiwGlM=",
+            "dev": true
+        },
+        "arraybuffer.slice": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.6.tgz",
+            "integrity": "sha1-8zshWfBTKj8xB6JywMz70a0peco=",
+            "dev": true
+        },
+        "asn1.js": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.9.1.tgz",
+            "integrity": "sha1-SLokC0WpKA6UdImQull9IWYX/UA=",
+            "dev": true
+        },
+        "assert": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
+            "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+            "dev": true
+        },
+        "async": {
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
+        },
+        "async-each": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
+            "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true
+        },
+        "backo2": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/backo2/-/backo2-1.0.2.tgz",
+            "integrity": "sha1-MasayLEpNjRj41s+u2n038+6eUc=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "base64-arraybuffer": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg=",
+            "dev": true
+        },
+        "base64-js": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz",
+            "integrity": "sha512-dwVUVIXsBZXwTuwnXI9RK8sBmgq09NDHzyR9SAph9eqk76gKK2JSQmZARC2zRC81JC2QTtxD0ARU5qTS25gIGw==",
+            "dev": true
+        },
+        "base64id": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
+            "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY=",
+            "dev": true
+        },
+        "basic-auth": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-1.1.0.tgz",
+            "integrity": "sha1-RSIe5Cn37h5QNb4/UVM/HN/SmIQ=",
+            "dev": true
+        },
+        "batch": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/batch/-/batch-0.6.1.tgz",
+            "integrity": "sha1-3DQxT05nkxgJP8dgJyUl+UvyXBY=",
+            "dev": true
+        },
+        "bcryptjs": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+            "integrity": "sha1-mrVie5PmBiH/fNrF2pczAn3x0Ms=",
+            "dev": true
+        },
+        "beeper": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/beeper/-/beeper-1.1.1.tgz",
+            "integrity": "sha1-5tXqjF2tABMEpwsiY4RH9pyy+Ak=",
+            "dev": true
+        },
+        "better-assert": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/better-assert/-/better-assert-1.0.2.tgz",
+            "integrity": "sha1-QIZrnhueC1W0gYlDEeaPr/rrxSI=",
+            "dev": true
+        },
+        "big.js": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz",
+            "integrity": "sha1-TK2iGTZS6zyp7I5VyQFWacmAaXg=",
+            "dev": true
+        },
+        "binary-extensions": {
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.10.0.tgz",
+            "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA=",
+            "dev": true
+        },
+        "blob": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.4.tgz",
+            "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE=",
+            "dev": true
+        },
+        "bluebird": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.0.tgz",
+            "integrity": "sha1-eRQg1/VR7qKJdFOop3ZT+WYG1nw=",
+            "dev": true
+        },
+        "bn.js": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+            "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+            "dev": true
+        },
+        "body-parser": {
+            "version": "1.17.2",
+            "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+            "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.7",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+                    "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha1-aN/1++YMUes3cl6p4+0xDcwed24=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+            "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+            "dev": true
+        },
+        "braces": {
+            "version": "1.8.5",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+            "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
+            "dev": true
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
+            "dev": true
+        },
+        "browser-resolve": {
+            "version": "1.11.2",
+            "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
+            "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
+            "dev": true,
+            "dependencies": {
+                "resolve": {
+                    "version": "1.1.7",
+                    "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
+                    "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
+                    "dev": true
+                }
+            }
+        },
+        "browserify-aes": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.0.6.tgz",
+            "integrity": "sha1-Xncl297x/Vkw1OurSFZ85FHEigo=",
+            "dev": true
+        },
+        "browserify-cipher": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
+            "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
+            "dev": true
+        },
+        "browserify-des": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
+            "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
+            "dev": true
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "dev": true
+        },
+        "browserify-sign": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
+            "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+            "dev": true
+        },
+        "browserify-zlib": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+            "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
+            "dev": true
+        },
+        "buffer": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=",
+            "dev": true
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
+            "dev": true
+        },
+        "bytes": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
+            "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
+            "dev": true
+        },
+        "callsite": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+            "integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true
+        },
+        "cheerio": {
+            "version": "0.22.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+            "integrity": "sha1-qbqoYKP5tZWmuBsahocxIe06Jp4=",
+            "dev": true
+        },
+        "chokidar": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+            "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
+            "dev": true
+        },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "dev": true
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true
+                }
+            }
+        },
+        "clone": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz",
+            "integrity": "sha1-Jgt6meux7f4kdTgXX3gyQ8sZ0Uk=",
+            "dev": true
+        },
+        "clone-stats": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
+            "integrity": "sha1-uI+UqCzzi4eR1YBG6kAprYjKmdE=",
+            "dev": true
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "codelyzer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/codelyzer/-/codelyzer-3.0.1.tgz",
+            "integrity": "sha1-uma3sqpWT+n0XWAEtAA60s8RaCg=",
+            "dev": true
+        },
+        "colors": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+            "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+            "dev": true
+        },
+        "combine-lists": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/combine-lists/-/combine-lists-1.0.1.tgz",
+            "integrity": "sha1-RYwH4J4NkA/Ci3Cj/sLazR0st/Y=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.11.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+            "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+            "dev": true
+        },
+        "component-bind": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
+            "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E=",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+            "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+            "dev": true
+        },
+        "component-inherit": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
+            "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "connect": {
+            "version": "3.5.1",
+            "resolved": "https://registry.npmjs.org/connect/-/connect-3.5.1.tgz",
+            "integrity": "sha1-bTDXpjx/FwhXprOqazY9lz3KWI4=",
+            "dev": true
+        },
+        "console-browserify": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+            "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
+            "dev": true
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
+            "dev": true
+        },
+        "content-type": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
+            "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0=",
+            "dev": true
+        },
+        "cookie": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+            "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+            "dev": true
+        },
+        "core-js": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
+            "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cors": {
+            "version": "2.8.4",
+            "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.4.tgz",
+            "integrity": "sha1-K9OB8usgECAQXNUOpZ2mMJBpRoY=",
+            "dev": true,
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "create-ecdh": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
+            "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
+            "dev": true
+        },
+        "create-hash": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
+            "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
+            "dev": true
+        },
+        "create-hmac": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
+            "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
+            "dependencies": {
+                "lru-cache": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+                    "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+                    "dev": true
+                }
+            }
+        },
+        "crypto-browserify": {
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.11.1.tgz",
+            "integrity": "sha512-Na7ZlwCOqoaW5RwUK1WpXws2kv8mNhWdTlzob0UXulk6G9BDbyiJaGTYBIX61Ozn9l1EPPJpICZb4DaOpT9NlQ==",
+            "dev": true
+        },
+        "css-select": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+            "integrity": "sha1-KzoRBTnFNV8c2NMUYj6HCxIeyFg=",
+            "dev": true
+        },
+        "css-selector-tokenizer": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+            "integrity": "sha1-5piEdK6MlTR3v15+/s/OzNnPTIY=",
+            "dev": true
+        },
+        "css-what": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+            "integrity": "sha1-lGfQMsOM+u+58teVASUwYvh/ob0=",
+            "dev": true
+        },
+        "cssauron": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/cssauron/-/cssauron-1.4.0.tgz",
+            "integrity": "sha1-pmAt/34EqDBtwNuaVR6S6LVmKtg=",
+            "dev": true
+        },
+        "cssesc": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
+            "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q=",
+            "dev": true
+        },
+        "custom-event": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/custom-event/-/custom-event-1.0.1.tgz",
+            "integrity": "sha1-XQKkaFCt8bSjF5RqOSj8y1v9BCU=",
+            "dev": true
+        },
+        "date-now": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz",
+            "integrity": "sha1-6vQ5/U1ISK105cx9vvIAZyueNFs=",
+            "dev": true
+        },
+        "dateformat": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
+            "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+            "dev": true
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true
+        },
+        "depd": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+            "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+            "dev": true
+        },
+        "des.js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
+            "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
+            "dev": true
+        },
+        "destroy": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+            "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+            "dev": true
+        },
+        "di": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/di/-/di-0.0.1.tgz",
+            "integrity": "sha1-gGZJMmzqp8qjMG112YXqJ0i6kTw=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.0.tgz",
+            "integrity": "sha512-w0XZubFWn0Adlsapj9EAWX0FqWdO4tz8kc3RiYdWLh4k/V8PTb6i0SMgXt0vRM3zyKnT8tKO7mUlieRQHIjMNg==",
+            "dev": true
+        },
+        "diffie-hellman": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
+            "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
+            "dev": true
+        },
+        "dom-serialize": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/dom-serialize/-/dom-serialize-2.2.1.tgz",
+            "integrity": "sha1-ViromZ9Evl6jB29UGdzVnrQ6yVs=",
+            "dev": true
+        },
+        "dom-serializer": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+            "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
+            "dev": true,
+            "dependencies": {
+                "domelementtype": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+                    "integrity": "sha1-vSh3PiZCiBrsUVRJJCmcXNgiGFs=",
+                    "dev": true
+                }
+            }
+        },
+        "domain-browser": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
+            "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
+            "dev": true
+        },
+        "domelementtype": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+            "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+            "dev": true
+        },
+        "domhandler": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+            "integrity": "sha1-iS5HAAqZvlW783dP/qBWHYh5wlk=",
+            "dev": true
+        },
+        "domutils": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+            "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
+            "dev": true
+        },
+        "dot": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/dot/-/dot-1.1.2.tgz",
+            "integrity": "sha1-xzdwGfxOVQeYkosrmv62ar+h8vk=",
+            "dev": true
+        },
+        "duplexer": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "dev": true
+        },
+        "duplexer2": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
+            "integrity": "sha1-xhTc9n4vsUmVqRcR5aYX6KYKMds=",
+            "dev": true
+        },
+        "ee-first": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+            "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+            "dev": true
+        },
+        "elliptic": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
+            "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
+            "dev": true
+        },
+        "emojis-list": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
+            "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+            "dev": true
+        },
+        "encodeurl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+            "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+            "dev": true
+        },
+        "engine.io": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-1.8.3.tgz",
+            "integrity": "sha1-jef5eJXSDTm4X4ju7nd7K9QrE9Q=",
+            "dev": true,
+            "dependencies": {
+                "accepts": {
+                    "version": "1.3.3",
+                    "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                    "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                    "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                    "dev": true
+                }
+            }
+        },
+        "engine.io-client": {
+            "version": "1.8.3",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-1.8.3.tgz",
+            "integrity": "sha1-F5jtk0USRkU9TG9jXXogH+lA1as=",
+            "dev": true,
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                    "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                    "dev": true
+                }
+            }
+        },
+        "engine.io-parser": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-1.3.2.tgz",
+            "integrity": "sha1-k3sHnwAH0Ik+xW1GyyILjLQ1Igo=",
+            "dev": true
+        },
+        "enhanced-resolve": {
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
+            "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
+            "dev": true,
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "ent": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ent/-/ent-2.2.0.tgz",
+            "integrity": "sha1-6WQhkyWiHQX0RGai9obtbOX13R0=",
+            "dev": true
+        },
+        "entities": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+            "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+            "dev": true
+        },
+        "errno": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+            "integrity": "sha1-uJbiOp5ei6M4cfyZar02NfyaHH0=",
+            "dev": true
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "dev": true
+        },
+        "es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+            "dev": true
+        },
+        "escape-html": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+            "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "estree-walker": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.3.1.tgz",
+            "integrity": "sha1-5rGlHPcpJSTnI3wxLl/mZgwc4ao=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "etag": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
+            "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE=",
+            "dev": true
+        },
+        "event-stream": {
+            "version": "3.3.4",
+            "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+            "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+            "dev": true
+        },
+        "eventemitter3": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz",
+            "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg=",
+            "dev": true
+        },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
+            "dev": true
+        },
+        "evp_bytestokey": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz",
+            "integrity": "sha512-ni0r0lrm7AOzsh2qC5mi9sj8S0gmj5fLNjfFpxN05FB4tAVZEKotbkjOtLPqTCX/CXT7NsUr6juZb4IFJeNNdA==",
+            "dev": true
+        },
+        "execa": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "dev": true
+        },
+        "expand-braces": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/expand-braces/-/expand-braces-0.1.2.tgz",
+            "integrity": "sha1-SIsdHSRRyz06axks/AMPRMWFX+o=",
+            "dev": true,
+            "dependencies": {
+                "braces": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-0.1.5.tgz",
+                    "integrity": "sha1-wIVxEIUpHYt1/ddOqw+FlygHEeY=",
+                    "dev": true
+                },
+                "expand-range": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-0.1.1.tgz",
+                    "integrity": "sha1-TLjtoJk8pW+k9B/ELzy7TMrf8EQ=",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "0.1.1",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-0.1.1.tgz",
+                    "integrity": "sha1-aaevEWlj1HIG7JvZtIoUIW8eOAY=",
+                    "dev": true
+                },
+                "repeat-string": {
+                    "version": "0.2.2",
+                    "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-0.2.2.tgz",
+                    "integrity": "sha1-x6jTI2BoNiBZp+RlH8aITosftK4=",
+                    "dev": true
+                }
+            }
+        },
+        "expand-brackets": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+            "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
+            "dev": true
+        },
+        "expand-range": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+            "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
+            "dev": true
+        },
+        "extend": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+            "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+            "dev": true
+        },
+        "extglob": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
+            "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
+            "dev": true
+        },
+        "fancy-log": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
+            "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+            "dev": true
+        },
+        "fastparse": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz",
+            "integrity": "sha1-0eJkOzipTXWDtHkGDmxK/8lAcfg=",
+            "dev": true
+        },
+        "faye-websocket": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+            "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
+            "dev": true
+        },
+        "filename-regex": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
+            "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY=",
+            "dev": true
+        },
+        "fill-range": {
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+            "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+            "dev": true
+        },
+        "finalhandler": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.5.1.tgz",
+            "integrity": "sha1-LEANjUUwk1vCMlScX6OF7Afeb80=",
+            "dev": true
+        },
+        "find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true
+        },
+        "for-in": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+            "dev": true
+        },
+        "for-own": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+            "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
+            "dev": true
+        },
+        "fresh": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
+            "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44=",
+            "dev": true
+        },
+        "from": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+            "integrity": "sha1-g8YK/Fi5xWmXAH7Rp2izqzA6RP4=",
+            "dev": true
+        },
+        "fs-access": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+            "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
+            "dev": true
+        },
+        "fs-extra": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-3.0.1.tgz",
+            "integrity": "sha1-N5TzeMWLNC6n27sjCVEJxLO2IpE=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "fsevents": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+            "integrity": "sha512-Sn44E5wQW4bTHXvQmvSHwqbuiXtduD6Rrjm2ZtUEGbyrig+nUH3t/QD4M4/ZXViY556TBpRgZkHLDx3JxPwxiw==",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "abbrev": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "aproba": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "asn1": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "assert-plus": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "asynckit": {
+                    "version": "0.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws-sign2": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "aws4": {
+                    "version": "1.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "balanced-match": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "bcrypt-pbkdf": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "block-stream": {
+                    "version": "0.0.9",
+                    "bundled": true,
+                    "dev": true
+                },
+                "boom": {
+                    "version": "2.10.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "brace-expansion": {
+                    "version": "1.1.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "buffer-shims": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "caseless": {
+                    "version": "0.12.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "co": {
+                    "version": "4.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "code-point-at": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "combined-stream": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true
+                },
+                "concat-map": {
+                    "version": "0.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "console-control-strings": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "core-util-is": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "cryptiles": {
+                    "version": "2.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "dashdash": {
+                    "version": "1.14.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "deep-extend": {
+                    "version": "0.4.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "delayed-stream": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "delegates": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "ecc-jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "extend": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "extsprintf": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "forever-agent": {
+                    "version": "0.6.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "form-data": {
+                    "version": "2.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "fs.realpath": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream": {
+                    "version": "1.0.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "fstream-ignore": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "getpass": {
+                    "version": "0.1.7",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "glob": {
+                    "version": "7.1.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "graceful-fs": {
+                    "version": "4.1.11",
+                    "bundled": true,
+                    "dev": true
+                },
+                "har-schema": {
+                    "version": "1.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "har-validator": {
+                    "version": "4.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "has-unicode": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "hawk": {
+                    "version": "3.1.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "hoek": {
+                    "version": "2.16.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "http-signature": {
+                    "version": "1.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "inflight": {
+                    "version": "1.0.6",
+                    "bundled": true,
+                    "dev": true
+                },
+                "inherits": {
+                    "version": "2.0.3",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ini": {
+                    "version": "1.3.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "is-typedarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "isstream": {
+                    "version": "0.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jodid25519": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsbn": {
+                    "version": "0.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-schema": {
+                    "version": "0.2.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-stable-stringify": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "json-stringify-safe": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsonify": {
+                    "version": "0.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "jsprim": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "mime-db": {
+                    "version": "1.27.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mime-types": {
+                    "version": "2.1.15",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimatch": {
+                    "version": "3.0.4",
+                    "bundled": true,
+                    "dev": true
+                },
+                "minimist": {
+                    "version": "0.0.8",
+                    "bundled": true,
+                    "dev": true
+                },
+                "mkdirp": {
+                    "version": "0.5.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "node-pre-gyp": {
+                    "version": "0.6.36",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "nopt": {
+                    "version": "4.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npmlog": {
+                    "version": "4.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "number-is-nan": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "oauth-sign": {
+                    "version": "0.8.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "once": {
+                    "version": "1.4.0",
+                    "bundled": true,
+                    "dev": true
+                },
+                "os-homedir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "os-tmpdir": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "osenv": {
+                    "version": "0.1.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "path-is-absolute": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "performance-now": {
+                    "version": "0.2.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "process-nextick-args": {
+                    "version": "1.0.7",
+                    "bundled": true,
+                    "dev": true
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "qs": {
+                    "version": "6.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rc": {
+                    "version": "1.2.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "dependencies": {
+                        "minimist": {
+                            "version": "1.2.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.2.9",
+                    "bundled": true,
+                    "dev": true
+                },
+                "request": {
+                    "version": "2.81.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "rimraf": {
+                    "version": "2.6.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "safe-buffer": {
+                    "version": "5.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "semver": {
+                    "version": "5.3.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "set-blocking": {
+                    "version": "2.0.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "signal-exit": {
+                    "version": "3.0.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sntp": {
+                    "version": "1.0.9",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sshpk": {
+                    "version": "1.13.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "dependencies": {
+                        "assert-plus": {
+                            "version": "1.0.0",
+                            "bundled": true,
+                            "dev": true,
+                            "optional": true
+                        }
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "stringstream": {
+                    "version": "0.0.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "strip-json-comments": {
+                    "version": "2.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tar": {
+                    "version": "2.2.1",
+                    "bundled": true,
+                    "dev": true
+                },
+                "tar-pack": {
+                    "version": "3.4.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tough-cookie": {
+                    "version": "2.3.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tunnel-agent": {
+                    "version": "0.6.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "tweetnacl": {
+                    "version": "0.14.5",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "uid-number": {
+                    "version": "0.0.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "util-deprecate": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "verror": {
+                    "version": "1.3.6",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wide-align": {
+                    "version": "1.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "wrappy": {
+                    "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                }
+            }
+        },
+        "get-caller-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
+            "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U=",
+            "dev": true
+        },
+        "get-stream": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true
+        },
+        "glob-base": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+            "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
+            "dev": true
+        },
+        "glob-parent": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
+            "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
+            "dev": true
+        },
+        "glogg": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/glogg/-/glogg-1.0.0.tgz",
+            "integrity": "sha1-f+DxmfV6yQbPUS/urY+Q7kooT8U=",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "gulp-util": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-3.0.8.tgz",
+            "integrity": "sha1-AFTh50RQLifATBh8PsxQXdVLu08=",
+            "dev": true
+        },
+        "gulplog": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/gulplog/-/gulplog-1.0.0.tgz",
+            "integrity": "sha1-4oxNRdBey77YGDY86PnFkmIp/+U=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+            "dev": true,
+            "dependencies": {
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true
+                }
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true
+        },
+        "has-binary": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/has-binary/-/has-binary-0.1.7.tgz",
+            "integrity": "sha1-aOYesWIQyVRaClzOBqhzkS/h5ow=",
+            "dev": true
+        },
+        "has-cors": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/has-cors/-/has-cors-1.1.0.tgz",
+            "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk=",
+            "dev": true
+        },
+        "has-flag": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
+            "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=",
+            "dev": true
+        },
+        "has-gulplog": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/has-gulplog/-/has-gulplog-0.1.0.tgz",
+            "integrity": "sha1-ZBTIKRNpfaUVkDl9r7EvIpZ4Ec4=",
+            "dev": true
+        },
+        "hash-base": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
+            "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
+            "dev": true
+        },
+        "hash.js": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+            "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+            "dev": true
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dev": true
+        },
+        "hosted-git-info": {
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+            "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+            "dev": true
+        },
+        "html-entities": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-1.2.1.tgz",
+            "integrity": "sha1-DfKTUfByEWNRXfueVUPl9u7VFi8=",
+            "dev": true
+        },
+        "htmlparser2": {
+            "version": "3.9.2",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+            "integrity": "sha1-G9+HrMoPP55T+k/M6w9LTLsAszg=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true
+                }
+            }
+        },
+        "http-auth": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/http-auth/-/http-auth-3.1.3.tgz",
+            "integrity": "sha1-lFz63WZSHq+PfISRPTd9exXyTjE=",
+            "dev": true
+        },
+        "http-errors": {
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+            "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+            "dev": true
+        },
+        "http-proxy": {
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+            "integrity": "sha1-Bt/ykpUr9k2+hHH6nfcwZtTzd0I=",
+            "dev": true
+        },
+        "https-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz",
+            "integrity": "sha1-P5E2XKvmC3ftDruiS0VOPgnZWoI=",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
+            "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es=",
+            "dev": true
+        },
+        "ieee754": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
+            "dev": true
+        },
+        "indexof": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "interpret": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+            "dev": true
+        },
+        "invert-kv": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "dev": true
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-binary-path": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+            "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+            "dev": true
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true
+        },
+        "is-dotfile": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
+            "integrity": "sha1-pqLzL/0t+wT1yiXs0Pa4PPeYoeE=",
+            "dev": true
+        },
+        "is-equal-shallow": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
+            "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
+            "dev": true
+        },
+        "is-extendable": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+            "dev": true
+        },
+        "is-extglob": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+            "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true
+        },
+        "is-glob": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+            "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+            "dev": true
+        },
+        "is-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+            "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+            "dev": true
+        },
+        "is-number": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
+            "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
+            "dev": true
+        },
+        "is-posix-bracket": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
+            "integrity": "sha1-MzTceXdDaOkvAW5vvAqI9c1ua8Q=",
+            "dev": true
+        },
+        "is-primitive": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
+            "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
+            "dev": true
+        },
+        "is-stream": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+            "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+            "dev": true
+        },
+        "is-utf8": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+            "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=",
+            "dev": true
+        },
+        "is-wsl": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+            "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "isbinaryfile": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-3.0.2.tgz",
+            "integrity": "sha1-Sj6XTsDLqQBNP8bN5yCeppNopiE=",
+            "dev": true
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "isobject": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+            "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "jasmine-core": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-2.6.2.tgz",
+            "integrity": "sha1-dOoffPQoaRryARB9YxI0AnoJ2qs=",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "jsesc": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
+            "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=",
+            "dev": true
+        },
+        "json-loader": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/json-loader/-/json-loader-0.5.7.tgz",
+            "integrity": "sha512-QLPs8Dj7lnf3e3QYS1zkCo+4ZwqOiF9d/nZnYozTISxXWCfNs9yuky5rJw4/W34s7POaNlbZmQGaB5NiXCbP4w==",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true
+        },
+        "json3": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.2.tgz",
+            "integrity": "sha1-PAQ0dD35Pi9cQq7nsZvLSDV19OE=",
+            "dev": true
+        },
+        "json5": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+            "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+            "dev": true
+        },
+        "jsonfile": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-3.0.1.tgz",
+            "integrity": "sha1-pezG9l9T9mLEQVx2daAzHQmS7GY=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsrsasign": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/jsrsasign/-/jsrsasign-8.0.3.tgz",
+            "integrity": "sha1-BAF7FFL19+9s//BT/t5NOXr8iRA="
+        },
+        "karma": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/karma/-/karma-1.7.0.tgz",
+            "integrity": "sha1-b3oaQGRG+i4YfslTmGmPTO5HYmk=",
+            "dev": true,
+            "dependencies": {
+                "connect": {
+                    "version": "3.6.3",
+                    "resolved": "https://registry.npmjs.org/connect/-/connect-3.6.3.tgz",
+                    "integrity": "sha512-GLSZqgjVxPvGYVD/2vz//gS201MEXk4b7t3nHV6OVnTdDNWi/Gm7Rpxs/ybvljPWvULys/wrzIV3jB3YvEc3nQ==",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "dev": true
+                },
+                "finalhandler": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
+                    "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "karma-chrome-launcher": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/karma-chrome-launcher/-/karma-chrome-launcher-2.1.1.tgz",
+            "integrity": "sha1-IWh5xorATY1RQOmWGboEtZr9Rs8=",
+            "dev": true
+        },
+        "karma-jasmine": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/karma-jasmine/-/karma-jasmine-1.1.0.tgz",
+            "integrity": "sha1-IuTAa/mhguUpTR9wXjczgRuBCs8=",
+            "dev": true
+        },
+        "karma-sourcemap-loader": {
+            "version": "0.3.7",
+            "resolved": "https://registry.npmjs.org/karma-sourcemap-loader/-/karma-sourcemap-loader-0.3.7.tgz",
+            "integrity": "sha1-kTIsd/jxPUb+0GKwQuEAnUxFBdg=",
+            "dev": true
+        },
+        "karma-spec-reporter": {
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/karma-spec-reporter/-/karma-spec-reporter-0.0.31.tgz",
+            "integrity": "sha1-SDDccUihVcfXoYbmMjOaDYD63sM=",
+            "dev": true
+        },
+        "karma-webpack": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/karma-webpack/-/karma-webpack-2.0.3.tgz",
+            "integrity": "sha1-Oc6/XKJYATmyf5rmm3iBa5yC+uY=",
+            "dev": true,
+            "dependencies": {
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "dev": true
+                },
+                "lodash": {
+                    "version": "3.10.1",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+                    "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.1.43",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+                    "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+                    "dev": true
+                }
+            }
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true
+        },
+        "lcid": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "dev": true
+        },
+        "live-server": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/live-server/-/live-server-1.2.0.tgz",
+            "integrity": "sha1-RJhkS7+Bpm8Y3Y3/3vYcTBw3TKM=",
+            "dev": true,
+            "dependencies": {
+                "colors": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
+                    "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM=",
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "load-json-file": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+            "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+            "dev": true
+        },
+        "loader-runner": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.3.0.tgz",
+            "integrity": "sha1-9IKuqC1UPgeSFwDVpG7yb9rGuKI=",
+            "dev": true
+        },
+        "loader-utils": {
+            "version": "0.2.17",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+            "integrity": "sha1-+G5jdNQyBabmxg6RlvF8Apm/s0g=",
+            "dev": true,
+            "dependencies": {
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+                    "dev": true
+                }
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
+        },
+        "lodash._basecopy": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz",
+            "integrity": "sha1-jaDmqHbPNEwK2KVIghEd08XHyjY=",
+            "dev": true
+        },
+        "lodash._basetostring": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._basetostring/-/lodash._basetostring-3.0.1.tgz",
+            "integrity": "sha1-0YYdh3+CSlL2aYMtyvPuFVZqB9U=",
+            "dev": true
+        },
+        "lodash._basevalues": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._basevalues/-/lodash._basevalues-3.0.0.tgz",
+            "integrity": "sha1-W3dXYoAr3j0yl1A+JjAIIP32Ybc=",
+            "dev": true
+        },
+        "lodash._getnative": {
+            "version": "3.9.1",
+            "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz",
+            "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=",
+            "dev": true
+        },
+        "lodash._isiterateecall": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz",
+            "integrity": "sha1-UgOte6Ql+uhCRg5pbbnPPmqsBXw=",
+            "dev": true
+        },
+        "lodash._reescape": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reescape/-/lodash._reescape-3.0.0.tgz",
+            "integrity": "sha1-Kx1vXf4HyKNVdT5fJ/rH8c3hYWo=",
+            "dev": true
+        },
+        "lodash._reevaluate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reevaluate/-/lodash._reevaluate-3.0.0.tgz",
+            "integrity": "sha1-WLx0xAZklTrgsSTYBpltrKQx4u0=",
+            "dev": true
+        },
+        "lodash._reinterpolate": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
+            "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0=",
+            "dev": true
+        },
+        "lodash._root": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz",
+            "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI=",
+            "dev": true
+        },
+        "lodash.assignin": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+            "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI=",
+            "dev": true
+        },
+        "lodash.bind": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+            "integrity": "sha1-euMBfpOWIqwxt9fX3LGzTbFpDTU=",
+            "dev": true
+        },
+        "lodash.defaults": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+            "integrity": "sha1-0JF4cW/+pN3p5ft7N/bwgCJ0WAw=",
+            "dev": true
+        },
+        "lodash.escape": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-3.2.0.tgz",
+            "integrity": "sha1-mV7g3BjBtIzJLv+ucaEKq1tIdpg=",
+            "dev": true
+        },
+        "lodash.filter": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+            "integrity": "sha1-ZosdSYFgOuHMWm+nYBQ+SAtMSs4=",
+            "dev": true
+        },
+        "lodash.flatten": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+            "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+            "dev": true
+        },
+        "lodash.foreach": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+            "integrity": "sha1-Gmo16s5AEoDH8G3d7DUWWrJ+PlM=",
+            "dev": true
+        },
+        "lodash.isarguments": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
+            "integrity": "sha1-L1c9hcaiQon/AGY7SRwdM4/zRYo=",
+            "dev": true
+        },
+        "lodash.isarray": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz",
+            "integrity": "sha1-eeTriMNqgSKvhvhEqpvNhRtfu1U=",
+            "dev": true
+        },
+        "lodash.keys": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+            "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+            "dev": true
+        },
+        "lodash.map": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+            "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+            "dev": true
+        },
+        "lodash.merge": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+            "integrity": "sha1-aYhLoUSsM/5plzemCG3v+t0PicU=",
+            "dev": true
+        },
+        "lodash.pick": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+            "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+            "dev": true
+        },
+        "lodash.reduce": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+            "integrity": "sha1-8atrg5KZrUj3hKu/R2WW8DuRTTs=",
+            "dev": true
+        },
+        "lodash.reject": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+            "integrity": "sha1-gNZJLcFHCGS79YNTO2UfQqn1JBU=",
+            "dev": true
+        },
+        "lodash.restparam": {
+            "version": "3.6.1",
+            "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
+            "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=",
+            "dev": true
+        },
+        "lodash.some": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+            "integrity": "sha1-G7nzFO9ri63tE7VJFpsqlF62jk0=",
+            "dev": true
+        },
+        "lodash.template": {
+            "version": "3.6.2",
+            "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-3.6.2.tgz",
+            "integrity": "sha1-+M3sxhaaJVvpCYrosMU9N4kx0U8=",
+            "dev": true
+        },
+        "lodash.templatesettings": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-3.1.1.tgz",
+            "integrity": "sha1-+zB4RHU7Zrnxr6VOJix0UwfbqOU=",
+            "dev": true
+        },
+        "log4js": {
+            "version": "0.6.38",
+            "resolved": "https://registry.npmjs.org/log4js/-/log4js-0.6.38.tgz",
+            "integrity": "sha1-LElBFmldb7JUgJQ9P8hy5mKlIv0=",
+            "dev": true,
+            "dependencies": {
+                "readable-stream": {
+                    "version": "1.0.34",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+                    "dev": true
+                },
+                "semver": {
+                    "version": "4.3.6",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
+                    "integrity": "sha1-MAvG4OhjdPe6YQaLWx7NV/xlMto=",
+                    "dev": true
+                }
+            }
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+            "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
+            "dev": true
+        },
+        "lunr": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/lunr/-/lunr-1.0.0.tgz",
+            "integrity": "sha1-XJJ2ySyRrDWpJBtQGNRnI9kuL18=",
+            "dev": true
+        },
+        "macos-release": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-1.1.0.tgz",
+            "integrity": "sha512-mmLbumEYMi5nXReB9js3WGsB8UE6cDBWyIO62Z4DNx6GbRhDxHNjA1MlzSpJ2S2KM1wyiPRA0d19uHWYYvMHjA==",
+            "dev": true
+        },
+        "magic-string": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.19.1.tgz",
+            "integrity": "sha1-FNdoATyvLsj96hakmvgvw3fnUgE=",
+            "dev": true
+        },
+        "map-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
+            "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+            "dev": true
+        },
+        "marked": {
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
+            "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc=",
+            "dev": true
+        },
+        "md5.js": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
+            "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
+            "dev": true,
+            "dependencies": {
+                "hash-base": {
+                    "version": "3.0.4",
+                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
+                    "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+                    "dev": true
+                }
+            }
+        },
+        "media-typer": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+            "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+            "dev": true
+        },
+        "mem": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
+            "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+            "dev": true
+        },
+        "memory-fs": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+            "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true
+                }
+            }
+        },
+        "micromatch": {
+            "version": "2.3.11",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+            "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
+            "dev": true
+        },
+        "miller-rabin": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.0.tgz",
+            "integrity": "sha1-SmL7HUKTPAVYOYL0xxb2+55sbT0=",
+            "dev": true
+        },
+        "mime": {
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+            "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM=",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+            "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
+            "dev": true
+        },
+        "mime-types": {
+            "version": "2.1.16",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+            "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+            "dev": true
+        },
+        "mimic-fn": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
+            "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+            "dev": true
+        },
+        "minimalistic-assert": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz",
+            "integrity": "sha1-cCvi3aazf0g2vLP121ZkG2Sh09M=",
+            "dev": true
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true
+        },
+        "minimist": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+            "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.8",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                    "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+                    "dev": true
+                }
+            }
+        },
+        "morgan": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.8.2.tgz",
+            "integrity": "sha1-eErHc05KRTqcbm6GgKkyknXItoc=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "ms": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+            "dev": true
+        },
+        "multipipe": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
+            "integrity": "sha1-Ko8t33Du1WTf8tV/HhoTfZ8FB4s=",
+            "dev": true
+        },
+        "nan": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+            "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
+            "dev": true,
+            "optional": true
+        },
+        "negotiator": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+            "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+            "dev": true
+        },
+        "node-libs-browser": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.0.0.tgz",
+            "integrity": "sha1-o6WeyXAkmFtG6Vg3lkb5bEthZkY=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true,
+                    "dependencies": {
+                        "string_decoder": {
+                            "version": "1.0.3",
+                            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                            "dev": true
+                        }
+                    }
+                }
+            }
+        },
+        "normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "dev": true
+        },
+        "normalize-path": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+            "dev": true
+        },
+        "npm-run-path": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+            "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+            "dev": true
+        },
+        "nth-check": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+            "integrity": "sha1-mSms32KPwsQQmN6rgqxYDPFJquQ=",
+            "dev": true
+        },
+        "null-check": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/null-check/-/null-check-1.0.0.tgz",
+            "integrity": "sha1-l33/1xdgErnsMNKjnbXPcqBDnt0=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+            "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+            "dev": true
+        },
+        "object-component": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/object-component/-/object-component-0.0.3.tgz",
+            "integrity": "sha1-8MaapQ78lbhmwYb0AKM3acsvEpE=",
+            "dev": true
+        },
+        "object.omit": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+            "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
+            "dev": true
+        },
+        "on-finished": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+            "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+            "dev": true
+        },
+        "on-headers": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+            "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true
+        },
+        "opn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/opn/-/opn-5.1.0.tgz",
+            "integrity": "sha512-iPNl7SyM8L30Rm1sjGdLLheyHVw5YXVfi3SKWJzBI7efxRwHojfRFjwE/OLM6qp9xJYMgab8WicTU1cPoY+Hpg==",
+            "dev": true
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "dependencies": {
+                "minimist": {
+                    "version": "0.0.10",
+                    "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+                    "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+                    "dev": true
+                }
+            }
+        },
+        "options": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/options/-/options-0.0.6.tgz",
+            "integrity": "sha1-7CLTEoBrtT5zF3Pnza788cZDEo8=",
+            "dev": true
+        },
+        "os-browserify": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz",
+            "integrity": "sha1-Y/xMzuXS13Y9Jrv4YBB45sLgBE8=",
+            "dev": true
+        },
+        "os-locale": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "dev": true
+        },
+        "os-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/os-name/-/os-name-2.0.1.tgz",
+            "integrity": "sha1-uaOGNhwXrjohc27wWZQFyajF3F4=",
+            "dev": true
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
+            "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw=",
+            "dev": true
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true
+        },
+        "pako": {
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-0.2.9.tgz",
+            "integrity": "sha1-8/dSL073gjSNqBYbrZ7P1Rv4OnU=",
+            "dev": true
+        },
+        "parse-asn1": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
+            "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
+            "dev": true
+        },
+        "parse-glob": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+            "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
+            "dev": true
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true
+        },
+        "parse5": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.2.tgz",
+            "integrity": "sha1-Be/1fw70V3+xRKefi5qWemzERRA=",
+            "dev": true,
+            "dependencies": {
+                "@types/node": {
+                    "version": "6.0.88",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-6.0.88.tgz",
+                    "integrity": "sha512-bYDPZTX0/s1aihdjLuAgogUAT5M+TpoWChEMea2p0yOcfn5bu3k6cJb9cp6nw268XeSNIGGr+4+/8V5K6BGzLQ==",
+                    "dev": true
+                }
+            }
+        },
+        "parsejson": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/parsejson/-/parsejson-0.0.3.tgz",
+            "integrity": "sha1-q343WfIJ7OmUN5c/fQ8fZK4OZKs=",
+            "dev": true
+        },
+        "parseqs": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.5.tgz",
+            "integrity": "sha1-1SCKNzjkZ2bikbouoXNoSSGouJ0=",
+            "dev": true
+        },
+        "parseuri": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.5.tgz",
+            "integrity": "sha1-gCBKUNTbt3m/3G6+J3jZDkvOMgo=",
+            "dev": true
+        },
+        "parseurl": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
+            "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY=",
+            "dev": true
+        },
+        "path-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
+            "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+            "dev": true
+        },
+        "path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-key": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+            "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+            "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+            "dev": true
+        },
+        "pause-stream": {
+            "version": "0.0.11",
+            "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+            "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
+            "dev": true
+        },
+        "pbkdf2": {
+            "version": "3.0.13",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.13.tgz",
+            "integrity": "sha512-+dCHxDH+djNtjgWmvVC/my3SYBAKpKNqKSjLkp+GtWWYe4XPE+e/PSD2aCanlEZZnqPk2uekTKNC/ccbwd2X2Q==",
+            "dev": true
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true
+        },
+        "preserve": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
+            "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
+            "dev": true
+        },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "proxy-middleware": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/proxy-middleware/-/proxy-middleware-0.15.0.tgz",
+            "integrity": "sha1-o/3xvvtzD5UZZYcqwvYHTGFHelY=",
+            "dev": true
+        },
+        "prr": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-0.0.0.tgz",
+            "integrity": "sha1-GoS4WQgyVQFBGFPQCB7j+obikmo=",
+            "dev": true
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "public-encrypt": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
+            "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+            "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+            "dev": true
+        },
+        "qjobs": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/qjobs/-/qjobs-1.1.5.tgz",
+            "integrity": "sha1-ZZ3p8s+NzCehSBJ28gU3cnI4LnM=",
+            "dev": true
+        },
+        "qs": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+            "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
+            "dev": true
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+            "dev": true
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM=",
+            "dev": true
+        },
+        "randomatic": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+            "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+            "dev": true,
+            "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true
+                        }
+                    }
+                },
+                "kind-of": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                    "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
+                    "dev": true
+                }
+            }
+        },
+        "randombytes": {
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.5.tgz",
+            "integrity": "sha512-8T7Zn1AhMsQ/HI1SjcCfT/t4ii3eAqco3yOcSzS4mozsOz69lHLsoMXmF9nZgnFanYscnSlUSgs8uZyKzpE6kg==",
+            "dev": true
+        },
+        "range-parser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+            "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+            "dev": true
+        },
+        "raw-body": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+            "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+            "dev": true
+        },
+        "read-pkg": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+            "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+            "dev": true
+        },
+        "read-pkg-up": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+            "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+            "dev": true
+        },
+        "readable-stream": {
+            "version": "1.1.14",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+            "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+            "dev": true
+        },
+        "readdirp": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+            "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true
+                }
+            }
+        },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true
+        },
+        "reflect-metadata": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.10.tgz",
+            "integrity": "sha1-tPg3BEFqytiZiMmxVjXUfgO5NEo=",
+            "dev": true
+        },
+        "regenerate": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
+            "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA=",
+            "dev": true
+        },
+        "regex-cache": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+            "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+            "dev": true
+        },
+        "regexpu-core": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+            "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
+            "dev": true
+        },
+        "regjsgen": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
+            "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc=",
+            "dev": true
+        },
+        "regjsparser": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+            "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
+            "dev": true
+        },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "dev": true
+        },
+        "repeat-element": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
+            "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "replace-ext": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
+            "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ=",
+            "dev": true
+        },
+        "require-directory": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
+            "dev": true
+        },
+        "require-main-filename": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
+            "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE=",
+            "dev": true
+        },
+        "requires-port": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+            "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+            "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true
+        },
+        "rimraf": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+            "dev": true
+        },
+        "ripemd160": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
+            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "dev": true
+        },
+        "rollup": {
+            "version": "0.41.6",
+            "resolved": "https://registry.npmjs.org/rollup/-/rollup-0.41.6.tgz",
+            "integrity": "sha1-4NBUl4d6OYwQTYFtJzOnGKepTio=",
+            "dev": true
+        },
+        "rollup-plugin-commonjs": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-commonjs/-/rollup-plugin-commonjs-8.0.2.tgz",
+            "integrity": "sha1-mLFYm/4ypsD2d5C2DAtJmXKv7Yk=",
+            "dev": true
+        },
+        "rollup-plugin-node-resolve": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-3.0.0.tgz",
+            "integrity": "sha1-i4l8TDAw1QASd7BRSyXSygloPuA=",
+            "dev": true
+        },
+        "rollup-pluginutils": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.0.1.tgz",
+            "integrity": "sha1-fslbNXP2VDpGpkYb2afFRFJdD8A=",
+            "dev": true
+        },
+        "rxjs": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.4.0.tgz",
+            "integrity": "sha1-p9sUqxV/nXqsalbmVeejhg05vyY=",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "dev": true
+        },
+        "sander": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+            "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+            "dev": true
+        },
+        "semver": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+            "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+            "dev": true
+        },
+        "semver-dsl": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/semver-dsl/-/semver-dsl-1.0.1.tgz",
+            "integrity": "sha1-02eN5VVeimH2Ke7QJTZq5fJzQKA=",
+            "dev": true
+        },
+        "send": {
+            "version": "0.15.4",
+            "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
+            "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "serve-index": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
+            "integrity": "sha1-0rKA/FYNYW7oG0i/D6gqvtJIXOc=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.8",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                    "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+                    "dev": true
+                }
+            }
+        },
+        "set-blocking": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "set-immediate-shim": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
+            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
+            "dev": true
+        },
+        "setimmediate": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+            "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=",
+            "dev": true
+        },
+        "setprototypeof": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+            "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.8",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.8.tgz",
+            "integrity": "sha1-NwaMLEdra69ALRSknGf1l5IfY08=",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "shelljs": {
+            "version": "0.7.7",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.7.tgz",
+            "integrity": "sha1-svXHfvlxSPS09uImguELuoZnz/E=",
+            "dev": true
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "socket.io": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-1.7.3.tgz",
+            "integrity": "sha1-uK+cq6AJSeVo42nxMn6pvp6iRhs=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                    "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                    "dev": true
+                },
+                "object-assign": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                    "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A=",
+                    "dev": true
+                }
+            }
+        },
+        "socket.io-adapter": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-0.5.0.tgz",
+            "integrity": "sha1-y21LuL7IHhB4uZZ3+c7QBGBmu4s=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                    "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                    "dev": true
+                }
+            }
+        },
+        "socket.io-client": {
+            "version": "1.7.3",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-1.7.3.tgz",
+            "integrity": "sha1-sw6GqhDV7zVGYBwJzeR2Xjgdo3c=",
+            "dev": true,
+            "dependencies": {
+                "component-emitter": {
+                    "version": "1.2.1",
+                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
+                    "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY=",
+                    "dev": true
+                },
+                "debug": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.3.3.tgz",
+                    "integrity": "sha1-QMRT5n5uE8kB3ewxeviYbNqe/4w=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.7.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+                    "integrity": "sha1-riXPJRKziFodldfwN4aNhDESR2U=",
+                    "dev": true
+                }
+            }
+        },
+        "socket.io-parser": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-2.3.1.tgz",
+            "integrity": "sha1-3VMgJRA85Clpcya+/WQAX8/ltKA=",
+            "dev": true
+        },
+        "sorcery": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+            "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+            "dev": true
+        },
+        "source-list-map": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-1.1.2.tgz",
+            "integrity": "sha1-mIkBnRAkzOVc3AaUmDN+9hhqEaE=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.7",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.4.16",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz",
+            "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
+            "dev": true
+        },
+        "sourcemap-codec": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.3.1.tgz",
+            "integrity": "sha1-mtb5vb1pGTEBbjCTnbyGhnMyMUY=",
+            "dev": true
+        },
+        "sparkles": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/sparkles/-/sparkles-1.0.0.tgz",
+            "integrity": "sha1-Gsu/tZJDbRC76PeFt8xvgoFQEsM=",
+            "dev": true
+        },
+        "spdx-correct": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+            "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+            "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+            "dev": true
+        },
+        "spdx-license-ids": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+            "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+            "dev": true
+        },
+        "split": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
+            "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.1.tgz",
+            "integrity": "sha1-Nr54Mgr+WAH2zqPueLblqrlA6gw=",
+            "dev": true
+        },
+        "statuses": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+            "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4=",
+            "dev": true
+        },
+        "stream-browserify": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+            "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true
+                }
+            }
+        },
+        "stream-combiner": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
+            "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+            "dev": true
+        },
+        "stream-http": {
+            "version": "2.7.2",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+            "integrity": "sha512-c0yTD2rbQzXtSsFSVhtpvY/vS6u066PcXOX9kBB3mSO76RiUQzL340uJkGBWnlBg4/HZzqiUXtaVA7wcRcJgEw==",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true
+                }
+            }
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true
+        },
+        "strip-bom": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+            "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+            "dev": true
+        },
+        "strip-eof": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+            "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+            "dev": true
+        },
+        "supports-color": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+            "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+            "dev": true
+        },
+        "symbol-observable": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
+            "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
+            "dev": true
+        },
+        "tapable": {
+            "version": "0.2.8",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-0.2.8.tgz",
+            "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "through2": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+            "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.3.3",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                    "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.3",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                    "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+                    "dev": true
+                }
+            }
+        },
+        "time-stamp": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-1.1.0.tgz",
+            "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
+            "dev": true
+        },
+        "timers-browserify": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.4.tgz",
+            "integrity": "sha512-uZYhyU3EX8O7HQP+J9fTVYwsq90Vr68xPEFo7yrVImIxYvHgukBEgOB/SgGoorWVTzGM/3Z+wUNnboA4M8jWrg==",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.31",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
+            "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
+            "dev": true
+        },
+        "to-array": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
+            "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA=",
+            "dev": true
+        },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
+            "dev": true
+        },
+        "ts-loader": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-2.1.0.tgz",
+            "integrity": "sha1-Wo78xccsBvxJ1putachWF8YZT3c=",
+            "dev": true,
+            "dependencies": {
+                "loader-utils": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+                    "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+                    "dev": true
+                }
+            }
+        },
+        "tsickle": {
+            "version": "0.21.6",
+            "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.21.6.tgz",
+            "integrity": "sha1-U7Abl5xcE/2xOvs/uVgXflmRWI0=",
+            "dev": true
+        },
+        "tslib": {
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.7.1.tgz",
+            "integrity": "sha1-vIAEFkaRkjp5/oN4u+s9ogF1OOw=",
+            "dev": true
+        },
+        "tslint": {
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.4.0.tgz",
+            "integrity": "sha1-5eJlJMo5/pUKUUFkVsLylsy2k0g=",
+            "dev": true
+        },
+        "tsutils": {
+            "version": "2.8.2",
+            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.8.2.tgz",
+            "integrity": "sha1-LBSGukMSYIRbCsb5Aq/Z1wio6mo=",
+            "dev": true
+        },
+        "tty-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=",
+            "dev": true
+        },
+        "type-is": {
+            "version": "1.6.15",
+            "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+            "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+            "dev": true
+        },
+        "typescript": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.3.4.tgz",
+            "integrity": "sha1-PTgyGCgjHkNPKHUUlZw3qCtin0I=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "2.8.29",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+            "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+            "dev": true,
+            "dependencies": {
+                "yargs": {
+                    "version": "3.10.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+                    "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+                    "dev": true
+                }
+            }
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "ultron": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
+            "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
+            "dev": true
+        },
+        "universalify": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
+            "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+            "dev": true
+        },
+        "unix-crypt-td-js": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unix-crypt-td-js/-/unix-crypt-td-js-1.0.0.tgz",
+            "integrity": "sha1-HAgkFQSBvHoB1J6Y8exmjYJBLzs=",
+            "dev": true
+        },
+        "unpipe": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+            "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+            "dev": true
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "dev": true,
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
+                    "dev": true
+                }
+            }
+        },
+        "useragent": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
+            "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
+            "dev": true
+        },
+        "util": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "dev": true,
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                }
+            }
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "utils-merge": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+            "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg=",
+            "dev": true
+        },
+        "uuid": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+            "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+            "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+            "dev": true
+        },
+        "vary": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
+            "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc=",
+            "dev": true
+        },
+        "vinyl": {
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.5.3.tgz",
+            "integrity": "sha1-sEVbOPxeDPMNQyUTLkYZcMIJHN4=",
+            "dev": true
+        },
+        "viz.js": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-1.8.0.tgz",
+            "integrity": "sha1-4Mta0kE2jjWxpulgaR66RUwklR8=",
+            "dev": true
+        },
+        "vlq": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.2.tgz",
+            "integrity": "sha1-4xbVJXtAuGu0PLjV/qXX9U1rDKE=",
+            "dev": true
+        },
+        "vm-browserify": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+            "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
+            "dev": true
+        },
+        "void-elements": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
+            "integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w=",
+            "dev": true
+        },
+        "watchpack": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
+            "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
+            "dev": true,
+            "dependencies": {
+                "async": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+                    "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+                    "dev": true
+                }
+            }
+        },
+        "webpack": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-2.6.1.tgz",
+            "integrity": "sha1-LgRX8KuxrF3zqxBsacZy8jZ4Xwc=",
+            "dev": true,
+            "dependencies": {
+                "acorn": {
+                    "version": "5.1.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+                    "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw==",
+                    "dev": true
+                },
+                "async": {
+                    "version": "2.5.0",
+                    "resolved": "https://registry.npmjs.org/async/-/async-2.5.0.tgz",
+                    "integrity": "sha512-e+lJAJeNWuPCNyxZKOBdaJGyLGHugXVQtrAwtuAe2vhxTYxFTKE73p8JuTmdH0qdQZtDvI4dhJwjZc5zsfIsYw==",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "dev": true
+                },
+                "supports-color": {
+                    "version": "3.2.3",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+                    "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
+                    "dev": true
+                },
+                "yargs": {
+                    "version": "6.6.0",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-6.6.0.tgz",
+                    "integrity": "sha1-eC7CHvQDNF+DCoCMo9UTr1YGUgg=",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-dev-middleware": {
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.12.0.tgz",
+            "integrity": "sha1-007++y7dp+HTtdvgcolRMhllFwk=",
+            "dev": true,
+            "dependencies": {
+                "time-stamp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/time-stamp/-/time-stamp-2.0.0.tgz",
+                    "integrity": "sha1-lcakRTDhW6jW9KPsuMOj+sRto1c=",
+                    "dev": true
+                }
+            }
+        },
+        "webpack-sources": {
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-0.2.3.tgz",
+            "integrity": "sha1-F8Yr+vE8cH+dAsR54Nzd6DgGl/s=",
+            "dev": true
+        },
+        "websocket-driver": {
+            "version": "0.6.5",
+            "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+            "integrity": "sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=",
+            "dev": true
+        },
+        "websocket-extensions": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz",
+            "integrity": "sha1-domUmcGEtu91Q3fC27DNbLVdKec=",
+            "dev": true
+        },
+        "which": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "dev": true
+        },
+        "which-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz",
+            "integrity": "sha1-u6Y8qGGUiZT/MHc2CJ47lgJsKk8=",
+            "dev": true
+        },
+        "win-release": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/win-release/-/win-release-1.1.1.tgz",
+            "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
+            "dev": true
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true
+        },
+        "wordwrap": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+            "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+            "dev": true
+        },
+        "wrap-ansi": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "ws": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-1.1.2.tgz",
+            "integrity": "sha1-iiRPoFJAHgjJiGz0SoUYnh/UBn8=",
+            "dev": true
+        },
+        "wtf-8": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wtf-8/-/wtf-8-1.0.0.tgz",
+            "integrity": "sha1-OS2LotDxw00e4tYw8V0O+2jhBIo=",
+            "dev": true
+        },
+        "xhr2": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.1.4.tgz",
+            "integrity": "sha1-f4dliEdxbbUCYyOBL4GMras4el8=",
+            "dev": true
+        },
+        "xmlhttprequest-ssl": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.5.3.tgz",
+            "integrity": "sha1-GFqIjATspGw+QHDZn3tJ3jUomS0=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "y18n": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+            "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+            "dev": true
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
+            "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao=",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                },
+                "camelcase": {
+                    "version": "4.1.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+                    "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+                    "dev": true
+                },
+                "cliui": {
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+                    "dev": true,
+                    "dependencies": {
+                        "string-width": {
+                            "version": "1.0.2",
+                            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+                            "dev": true
+                        }
+                    }
+                },
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true
+                },
+                "load-json-file": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+                    "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+                    "dev": true
+                },
+                "os-locale": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+                    "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+                    "dev": true
+                },
+                "path-type": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+                    "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+                    "dev": true
+                },
+                "read-pkg": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+                    "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+                    "dev": true
+                },
+                "read-pkg-up": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+                    "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+                    "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
+                    "dependencies": {
+                        "is-fullwidth-code-point": {
+                            "version": "2.0.0",
+                            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                            "dev": true
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "dev": true
+                        }
+                    }
+                },
+                "strip-bom": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+                    "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+                    "dev": true
+                },
+                "which-module": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
+                    "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
+                    "dev": true
+                },
+                "yargs-parser": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+                    "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+                    "dev": true
+                }
+            }
+        },
+        "yargs-parser": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-4.2.1.tgz",
+            "integrity": "sha1-KczqwNxPA8bIe0qfIX3RjJ90hxw=",
+            "dev": true,
+            "dependencies": {
+                "camelcase": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
+                    "integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo=",
+                    "dev": true
+                }
+            }
+        },
+        "yeast": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
+            "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
+            "dev": true
+        },
+        "zone.js": {
+            "version": "0.8.11",
+            "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.8.11.tgz",
+            "integrity": "sha1-dCvvsX+8SaVxcSuMfYfljKJv2IY=",
+            "dev": true
+        }
+    }
+}

--- a/public_api.ts
+++ b/public_api.ts
@@ -7,3 +7,4 @@
  */
 
 export * from './src/angular-auth-oidc-client';
+export * from './src/services/authorization-result.enum';

--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -19,7 +19,8 @@ export class DefaultConfiguration {
     // HTTP 401
     unauthorized_route = '/unauthorized';
     auto_userinfo = true;
-    auto_clean_state_after_authentication: true;
+	auto_clean_state_after_authentication: true;
+	trigger_authorization_result_event: false;
     log_console_warning_active = true;
     log_console_debug_active = false;
 
@@ -48,7 +49,8 @@ export class OpenIDImplicitFlowConfiguration {
     forbidden_route: string;
     unauthorized_route: string;
     auto_userinfo: boolean;
-    auto_clean_state_after_authentication: boolean;
+	auto_clean_state_after_authentication: boolean;
+	trigger_authorization_result_event: boolean;
     log_console_warning_active: boolean;
     log_console_debug_active: boolean;
     max_id_token_iat_offset_allowed_in_seconds: number;
@@ -115,6 +117,10 @@ export class AuthConfiguration {
 
     get auto_clean_state_after_authentication(): boolean {
         return this.openIDImplicitFlowConfiguration.auto_clean_state_after_authentication !== undefined ? this.openIDImplicitFlowConfiguration.auto_clean_state_after_authentication : this.defaultConfig.auto_clean_state_after_authentication;
+	}
+
+	get trigger_authorization_result_event(): boolean {
+        return this.openIDImplicitFlowConfiguration.trigger_authorization_result_event !== undefined ? this.openIDImplicitFlowConfiguration.trigger_authorization_result_event : this.defaultConfig.trigger_authorization_result_event;
     }
 
     get log_console_warning_active(): boolean {

--- a/src/services/authorization-result.enum.ts
+++ b/src/services/authorization-result.enum.ts
@@ -1,0 +1,5 @@
+export enum AuthorizationResult {
+	authorized = 1,
+	forbidden = 2,
+	unauthorized = 3
+}


### PR DESCRIPTION
Instead of forcing the application consuming this library to automatically redirect to one of the 3 hard-configured routes (start, unauthorized, forbidden), this modification will add an extra configuration option to override such behavior and trigger an event that will allow to subscribe to it and let the application perform other actions.
This would be useful to allow the application to save an initial return url so that the user is redirected to it after a successful login on the STS (ie: saving the return url previously on sessionStorage and then retrieving it during the triggering of the event).