### PR TITLE
UserData should be any instead of string

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -126,7 +126,7 @@ export class OidcSecurityService {
         }
     }
 
-    getUserData(): Observable<string> {
+    getUserData(): Observable<any> {
         return this._userData.asObservable();
     }
 

--- a/src/services/oidc.security.user-service.ts
+++ b/src/services/oidc.security.user-service.ts
@@ -7,13 +7,13 @@ import { OidcDataService } from './oidc-data.service';
 
 @Injectable()
 export class OidcSecurityUserService {
-    private userData = '';
+    private userData: any = '';
 
     constructor(
         private oidcDataService: OidcDataService,
         private oidcSecurityCommon: OidcSecurityCommon,
         private authWellKnownEndpoints: AuthWellKnownEndpoints
-    ) {}
+    ) { }
 
     initUserData() {
         return this.getIdentityUserData().pipe(
@@ -21,7 +21,7 @@ export class OidcSecurityUserService {
         );
     }
 
-    getUserData(): string {
+    getUserData(): any {
         if (!this.userData) {
             throw Error('UserData is not set!');
         }
@@ -29,7 +29,7 @@ export class OidcSecurityUserService {
         return this.userData;
     }
 
-    setUserData(value: string): void {
+    setUserData(value: any): void {
         this.userData = value;
     }
 


### PR DESCRIPTION
I just upgraded to the newest version an realized the top level API changed a bit. The getUserData() should be any in my opinion instead of string. At least in my project it's definitely an object in the form of {sub: "", email: "", roles: Array(2)}.