### PR TITLE
Fix a couple of issues relating to silentRenew

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -5,8 +5,7 @@ import { EventEmitter, Injectable, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { Observable } from 'rxjs/Observable';
-import { timer } from 'rxjs/observable/timer';
-import { catchError, pluck, take, timeInterval } from 'rxjs/operators';
+import { catchError } from 'rxjs/operators';
 
 import { AuthorizationResult } from '../models/authorization-result.enum';
 import { JwtKeys } from '../models/jwtkeys';
@@ -46,7 +45,7 @@ export class OidcSecurityService {
 
     private runTokenValidationRunning: boolean;
 
-    private _scheduledHeartBeat;
+    private _scheduledHeartBeat: any;
 
     constructor(
         @Inject(PLATFORM_ID) private platformId: Object,

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -320,6 +320,12 @@ export class OidcSecurityService {
                     ]);
                 }
             }
+        }, (err) => {
+            /* Something went wrong while getting signing key */
+            this.loggerService.logWarning(
+                'Failed to retreive siging key with error: ' + JSON.stringify(err)
+            );
+            this.oidcSecurityCommon.silentRenewRunning = '';
         });
     }
 

--- a/src/services/oidc.security.silent-renew.ts
+++ b/src/services/oidc.security.silent-renew.ts
@@ -39,7 +39,7 @@ export class OidcSecuritySilentRenew {
     }
 
     // TODO The return type of this method is never used. Is it needed?
-    startRenew(url: string) {
+    startRenew(url: string): Observable<any> {
         let existsparent = undefined;
         try {
             const parentdoc = window.parent.document;


### PR DESCRIPTION
1. Replace the timer observable with a recursive setTimeout in order to prevent firing another event when the previous tokenRenew process has not yet finished.
2. Encapsulate the silentRenew heartbeat check into ngZone.runOutsideAngular to avoid triggering change detection.