### PR TITLE
allow custom URL handlers in authorize()

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -180,7 +180,7 @@ export class OidcSecurityService {
         this.oidcSecurityCommon.customRequestParams = params;
     }
 
-    authorize() {
+    authorize(urlHandler?: (url: string) => any) {
         if (this.authWellKnownEndpoints) {
             this.authWellKnownEndpointsLoaded = true;
         }
@@ -223,7 +223,11 @@ export class OidcSecurityService {
             state,
             this.authWellKnownEndpoints.authorization_endpoint
         );
-        window.location.href = url;
+        if (urlHandler) {
+            urlHandler(url);
+        } else {
+            window.location.href = url;
+        }
     }
 
     authorizedCallback(hash?: string) {


### PR DESCRIPTION
In `OidcSecurityService`, the `authorize()` method builds an authorization URL and then immediately sets the `window`'s `location.href` to that URL, navigating the user away from the Angular app context onto the OpenID Provider's authorization endpoint. This commit modifies that method so that it accepts an optional handler function as an argument. If a handler is provided, the authorization URL will be passed to it instead of triggering a window navigation.

Use case:
An implementing app wants to initiate the authorization process in a popup or a silent iframe. Currently, the only way to achieve that is to load a page in the popup/iframe which would call the `authorize()` method internally, which requires loading and bootstrapping a whole additional instance of Angular. Instead, the app should be able to load the authorization URL directly in the popup/iframe.