### PR TITLE
Fix for bug #235: silent-renew problems when using webpack hot module…

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -117,8 +117,23 @@ export class OidcSecurityService {
                 this.oidcSecuritySilentRenew.initRenew();
 
                 // Support authorization via DOM events.
+                // Deregister if OidcSecurityService.setupModule is called again by any instance.
+                //      We only ever want the latest setup service to be reacting to this event.
                 this.boundSilentRenewEvent =  this.silentRenewEventHandler.bind(this);
+                
+                let instanceId = Math.random();
+
+                let boundSilentRenewInitEvent = ((e: CustomEvent) => {
+                    if (e.detail !== instanceId) {
+                        window.removeEventListener('oidc-silent-renew-message', this.boundSilentRenewEvent);
+                        window.removeEventListener('oidc-silent-renew-init', boundSilentRenewInitEvent);
+                    }
+                }).bind(this);
+
+                window.addEventListener('oidc-silent-renew-init', boundSilentRenewInitEvent, false);
                 window.addEventListener('oidc-silent-renew-message', this.boundSilentRenewEvent, false);
+                 
+                window.dispatchEvent(new CustomEvent('oidc-silent-renew-init', { detail: instanceId }));
             }
 
             if (


### PR DESCRIPTION
… replacement 

This fix deregisters other listeners of `oidc-silent-renew-message` any time a new one is added. It doesn't make sense to respond to this event from multiple instances.