### PR TITLE
Throw error when userinfo_endpoint is not defined (Azure AD)

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -311,6 +311,11 @@ export class OidcSecurityService {
                                 ]);
                             }
                         }
+                    }, (err) => {
+                        /* Something went wrong while getting signing key */
+                        this.loggerService.logWarning(
+                            'Failed to retreive user info with error: ' + JSON.stringify(err)
+                        );
                     });
                 } else {
                     if (!isRenewProcess) {

--- a/src/services/oidc.security.user-service.ts
+++ b/src/services/oidc.security.user-service.ts
@@ -43,10 +43,15 @@ export class OidcSecurityUserService {
         const token = this.oidcSecurityCommon.getAccessToken();
 
         if (this.authWellKnownEndpoints) {
-            return this.oidcDataService.getIdentityUserData(
-                this.authWellKnownEndpoints.userinfo_endpoint,
-                token
-            );
+            if (this.authWellKnownEndpoints.userinfo_endpoint) {
+                return this.oidcDataService.getIdentityUserData(
+                    this.authWellKnownEndpoints.userinfo_endpoint,
+                    token
+                );
+            } else {
+                this.loggerService.logError('init check session: authWellKnownEndpoints.userinfo_endpoint is undefined; set auto_userinfo = false in config');
+                throw Error('authWellKnownEndpoints.userinfo_endpoint is undefined');
+            }
         } else {
             this.loggerService.logWarning('init check session: authWellKnownEndpoints is undefined');
         }


### PR DESCRIPTION
Log error, and recommend setting auto_userinfo to false in config.

Ideally, the error would be trapped, and the proper `AuthorizationResult` would be returned to the user. This should be enough to notify the user of the problem, and point them to how to solve it.