### PR TITLE
Server side rendering [SSR] Compatibility

### DIFF
--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -59,7 +59,7 @@ export class OpenIDImplicitFlowConfiguration {
     log_console_warning_active = true;
     log_console_debug_active = false;
     max_id_token_iat_offset_allowed_in_seconds = 3;
-    storage: any = sessionStorage;
+    storage = typeof Storage !== 'undefined' ? sessionStorage : null;
 }
 
 @Injectable()

--- a/src/services/oidc-token-helper.service.ts
+++ b/src/services/oidc-token-helper.service.ts
@@ -69,6 +69,6 @@ export class TokenHelperService {
                 throw Error('Illegal base64url string!');
         }
 
-        return window.atob(output);
+        return new Buffer(output, 'base64').toString('binary');
     }
 }


### PR DESCRIPTION
Server side rendering mode compatibility:

window not exists, atob() function is replace by 
```js
new Buffer(output, 'base64').toString('binary')
```
sessionStorage not exists, in OpenIDImplicitFlowConfiguration if Storage is Undefined use null.
```js
storage = typeof Storage !== 'undefined' ? sessionStorage : null;
```
