### PR TITLE
Fix default storage value for ssr

### DIFF
--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -59,7 +59,7 @@ export class OpenIDImplicitFlowConfiguration {
     log_console_warning_active = true;
     log_console_debug_active = false;
     max_id_token_iat_offset_allowed_in_seconds = 3;
-    storage: any = sessionStorage;
+    storage: any = typeof window !== 'undefined' ? sessionStorage : null;
 }
 
 @Injectable()


### PR DESCRIPTION
SSR fix: check if it is browser before setting sessionStorage  as default value to fix error "sessionStorage is not defined".
`storage: any = typeof window !== 'undefined' ? sessionStorage : null;`
