### PR TITLE
fix decoding for browser

### DIFF
--- a/src/services/oidc-token-helper.service.ts
+++ b/src/services/oidc-token-helper.service.ts
@@ -69,6 +69,6 @@ export class TokenHelperService {
                 throw Error('Illegal base64url string!');
         }
 
-        return new Buffer(output, 'base64').toString('binary');
+        return typeof window !== 'undefined' ? window.atob(output) : new Buffer(output, 'base64').toString('binary');
     }
 }


### PR DESCRIPTION
Buffer does not exist in browser. So decode using window.atob in browser.