### PR TITLE
Add unique ending to key to prevent storage crossover

### DIFF
--- a/src/services/oidc.security.storage.ts
+++ b/src/services/oidc.security.storage.ts
@@ -31,7 +31,7 @@ export class BrowserStorage implements OidcSecurityStorage {
 
     public read(key: string): any {
         if (this.hasStorage) {
-            return JSON.parse(this.authConfiguration.storage.getItem(key));
+            return JSON.parse(this.authConfiguration.storage.getItem(key + '_' + this.authConfiguration.client_id));
         }
 
         return;
@@ -40,7 +40,7 @@ export class BrowserStorage implements OidcSecurityStorage {
     public write(key: string, value: any): void {
         if (this.hasStorage) {
             value = value === undefined ? null : value;
-            this.authConfiguration.storage.setItem(key, JSON.stringify(value));
+            this.authConfiguration.storage.setItem(key + '_' + this.authConfiguration.client_id, JSON.stringify(value));
         }
     }
 }


### PR DESCRIPTION
Add unique ending to key to prevent storage crossover when on same tab switching between websites.