### PR TITLE
Handle callback params that contain equals char

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -270,7 +270,7 @@ export class OidcSecurityService {
 
         const result: any = hash.split('&').reduce(function(resultData: any, item: string) {
             const parts = item.split('=');
-            resultData[parts[0]] = parts[1];
+            resultData[<string>parts.shift()] = parts.join('=');
             return resultData;
         }, {});
 


### PR DESCRIPTION
We've had logins randomly fail validation (particularly with Microsoft's Azure AD v2.0 endpoint) on `at_hash` validation and I traced that back to the way the hash is parsed. Replaced with flexible shift + join combo.

![image](https://user-images.githubusercontent.com/3198469/45500219-d6ad9180-b786-11e8-876d-d6013acfe5fa.png)

I initially thought tokens like this [MS example](https://docs.microsoft.com/en-us/onedrive/developer/rest-api/getting-started/msa-oauth#response-2) showing token ending with `==` padding (presumably base64) must be sidetracked from the protocol based on [oauth.com](https://www.oauth.com/oauth2-servers/access-tokens/access-token-response/). Turns out the [access token spec](https://tools.ietf.org/html/rfc6749#appendix-A.12) actually accepts `VSCHAR` or hex 20-7E which is pretty much everything [pritable](https://en.wikipedia.org/wiki/ASCII#Printable_characters), including the `=` char.
