### PR TITLE
Removing unnecessary gating of `runTokenValidation()`.

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -709,7 +709,7 @@ export class OidcSecurityService {
         const silentRenewHeartBeatCheck = () => {
             this.loggerService.logDebug(
                 'silentRenewHeartBeatCheck\r\n' + 
-                `\tsilentRenewRunning: ${(this.oidcSecurityCommon.silentRenewRunning !== 'running')}\r\n` +
+                `\tsilentRenewRunning: ${(this.oidcSecurityCommon.silentRenewRunning === 'running')}\r\n` +
                 `\tidToken: ${(this.getIdToken() != null)}\r\n` +
                 `\t_userData.value: ${(this._userData.value != null)}`
             );

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -97,8 +97,8 @@ export class OidcSecurityService {
             } else {
                 this.loggerService.logDebug('IsAuthorized setup module; id_token is valid');
                 this.setIsAuthorized(isAuthorized);
-                this.runTokenValidation();
             }
+            this.runTokenValidation();
         }
 
         this.loggerService.logDebug('STS server: ' + this.authConfiguration.stsServer);
@@ -338,8 +338,9 @@ export class OidcSecurityService {
                                 validationResult.decoded_id_token
                             );
                             this.setUserData(this.oidcSecurityUserService.getUserData());
-                            this.runTokenValidation();
                         }
+
+                        this.runTokenValidation();
 
                         this.onAuthorizationResult.emit(AuthorizationResult.authorized);
                         if (
@@ -441,9 +442,7 @@ export class OidcSecurityService {
 
                 this.oidcSecurityCommon.sessionState = result.session_state;
 
-                if (!isRenewProcess) {
-                    this.runTokenValidation();
-                }
+                this.runTokenValidation();
 
                 observer.next(true);
                 observer.complete();
@@ -700,12 +699,20 @@ export class OidcSecurityService {
             return;
         }
         this.runTokenValidationRunning = true;
+	
+        this.loggerService.logDebug('runTokenValidation silent-renew running');
 
         /**
             First time: delay 10 seconds to call silentRenewHeartBeatCheck
             Afterwards: Run this check in a 5 second interval only AFTER the previous operation ends.
          */
         const silentRenewHeartBeatCheck = () => {
+            this.loggerService.logDebug(
+                'silentRenewHeartBeatCheck\r\n' + 
+                `\tsilentRenewRunning: ${(this.oidcSecurityCommon.silentRenewRunning !== 'running')}\r\n` +
+                `\tidToken: ${(this.getIdToken() != null)}\r\n` +
+                `\t_userData.value: ${(this._userData.value != null)}`
+            );
             if (
                 this._userData.value &&
                 this.oidcSecurityCommon.silentRenewRunning !== 'running' &&

--- a/src/services/oidc.security.validation.ts
+++ b/src/services/oidc.security.validation.ts
@@ -76,11 +76,14 @@ export class OidcSecurityValidation {
             return false;
         }
 
+        const tokenExpirationValue = tokenExpirationDate.valueOf();
+        const nowWithOffset = new Date().valueOf() + offsetSeconds * 1000;
+	const tokenNotExpired = ( tokenExpirationValue > nowWithOffset );
+
+        this.loggerService.logDebug(`Token not expired?: ${tokenExpirationValue} > ${nowWithOffset}  (${tokenNotExpired})`)
+
         // Token not expired?
-        return (
-            tokenExpirationDate.valueOf() >
-            new Date().valueOf() + offsetSeconds * 1000
-        );
+        return tokenNotExpired;
     }
 
     // iss

--- a/src/services/oidc.security.validation.ts
+++ b/src/services/oidc.security.validation.ts
@@ -78,7 +78,7 @@ export class OidcSecurityValidation {
 
         const tokenExpirationValue = tokenExpirationDate.valueOf();
         const nowWithOffset = new Date().valueOf() + offsetSeconds * 1000;
-	const tokenNotExpired = ( tokenExpirationValue > nowWithOffset );
+        const tokenNotExpired = ( tokenExpirationValue > nowWithOffset );
 
         this.loggerService.logDebug(`Token not expired?: ${tokenExpirationValue} > ${nowWithOffset}  (${tokenNotExpired})`)
 


### PR DESCRIPTION
`runTokenValidation()` has it own internal gating. The unnecessary gating can lead to situations where silent_renew heartbeat is never started.

Fix for #297