### PR TITLE
Refactoring getIsAuthorized()

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -3,7 +3,7 @@ import { HttpParams } from '@angular/common/http';
 import { EventEmitter, Inject, Injectable, NgZone, Output, PLATFORM_ID } from '@angular/core';
 import { Router } from '@angular/router';
 import { BehaviorSubject, Observable, throwError as observableThrowError } from 'rxjs';
-import { catchError, filter, shareReplay, switchMap, switchMapTo, take, tap, race } from 'rxjs/operators';
+import { catchError, filter, map, shareReplay, switchMap, switchMapTo, take, tap, race } from 'rxjs/operators';
 import { OidcDataService } from '../data-services/oidc-data.service';
 import { AuthWellKnownEndpoints } from '../models/auth.well-known-endpoints';
 import { AuthorizationResult } from '../models/authorization-result.enum';
@@ -81,7 +81,8 @@ export class OidcSecurityService {
                     tap(() => this.loggerService.logDebug("IsAuthorizedRace: Existing token is still authorized.")),
                     race(this.onAuthorizationResult.asObservable().pipe(
                             take(1),
-                            tap(() => this.loggerService.logDebug("IsAuthorizedRace: Silent Renew Refresh Session Complete"))
+                            tap(() => this.loggerService.logDebug("IsAuthorizedRace: Silent Renew Refresh Session Complete")),
+                            map(() => true)
                         )
                 ));
 

--- a/src/services/oidc.security.silent-renew.ts
+++ b/src/services/oidc.security.silent-renew.ts
@@ -5,6 +5,7 @@ import { LoggerService } from './oidc.logger.service';
 @Injectable()
 export class OidcSecuritySilentRenew {
     private sessionIframe: any;
+    private isRenewInitialized : boolean = false;
 
     constructor(private loggerService: LoggerService) {}
 
@@ -35,9 +36,15 @@ export class OidcSecuritySilentRenew {
 
             window.document.body.appendChild(this.sessionIframe);
         }
+
+        this.isRenewInitialized = true;
     }
 
     startRenew(url: string): Observable<any> {
+        if (!this.isRenewInitialized) {
+            this.initRenew();
+        }
+
         let existsparent = undefined;
         try {
             const parentdoc = window.parent.document;


### PR DESCRIPTION
Refactoring `getIsAuthorized()` to wait until setup and refresh is complete before emitting.

### Previously:
`getIsAuthorized()` would emit its default value of `false` even before setup of the module had been completed. This lead to some very strange race conditions and numerous bug reports.

### With this change:
`getIsAuthorized()` will now:

1.  Wait for setup to complete
2.  Then:
     1. If silent renew _is not_ enabled:
          1. Return the result of authenticating any local tokens either successfully or unsuccessfully. 
     2. If silent renew _is_ enabled then SIMULTANEOUSLY:
          1. Authenticate locally stored tokens and return the result _ONLY_ if authentication is successful. _This action will never return if the locally stored tokens aren't successfully authenticated._
          2. Try and authenticate with the authority and return true or false based on outcome.
3. As soon as one of the above actions complete, the observable will emit and you'll have the authentication result.
4. This result is replayed to any late subscribers.

**While I think the impact will be minimal, this does create a fundamental change to an external facing API so care should be taken when upgrading.**

This issue has come up multiple times:
#257 
#291
#299 
