### PR TITLE
A blank `session_state` in the check session heartbeat should emit a …

### DIFF
--- a/src/services/oidc.security.check-session.ts
+++ b/src/services/oidc.security.check-session.ts
@@ -92,6 +92,11 @@ export class OidcSecurityCheckSession {
                         clientId + ' ' + session_state,
                         this.authConfiguration.stsServer
                     );
+                } else {
+                    this.loggerService.logWarning(
+                        'OidcSecurityCheckSession pollServerSession session_state is blank'
+                    );
+                    this.onCheckSessionChanged.emit();
                 }
             } else {
                 this.loggerService.logWarning(


### PR DESCRIPTION
…change event.

Fix for #303