### PR TITLE
Allow multiple auth states and auth nonces to exist.

### DIFF
--- a/src/services/oidc-security-state-validation.service.ts
+++ b/src/services/oidc-security-state-validation.service.ts
@@ -27,8 +27,7 @@ export class StateValidationService {
         const toReturn = new ValidateStateResult('', '', false, {});
         if (
             !this.oidcSecurityValidation.validateStateFromHashCallback(
-                result.state,
-                this.oidcSecurityCommon.authStateControl
+                result.state
             )
         ) {
             this.loggerService.logWarning('authorizedCallback incorrect state');
@@ -59,8 +58,7 @@ export class StateValidationService {
 
         if (
             !this.oidcSecurityValidation.validate_id_token_nonce(
-                toReturn.decoded_id_token,
-                this.oidcSecurityCommon.authNonce
+                toReturn.decoded_id_token
             )
         ) {
             this.loggerService.logWarning('authorizedCallback incorrect nonce');
@@ -132,7 +130,7 @@ export class StateValidationService {
         // flow id_token token
         if (this.authConfiguration.response_type !== 'id_token token') {
             toReturn.authResponseIsValid = true;
-            this.handleSuccessfulValidation();
+            this.handleSuccessfulValidation(result.state);
             return toReturn;
         }
 
@@ -150,15 +148,13 @@ export class StateValidationService {
         }
 
         toReturn.authResponseIsValid = true;
-        this.handleSuccessfulValidation();
+        this.handleSuccessfulValidation(result.state);
         return toReturn;
     }
 
-    private handleSuccessfulValidation() {
-        this.oidcSecurityCommon.authNonce = '';
-
+    private handleSuccessfulValidation(state: string) {
         if (this.authConfiguration.auto_clean_state_after_authentication) {
-            this.oidcSecurityCommon.authStateControl = '';
+            this.oidcSecurityCommon.removeAuthState(state);
         }
         this.loggerService.logDebug(
             'AuthorizedCallback token(s) validated, continue'

--- a/src/services/oidc.security.common.ts
+++ b/src/services/oidc.security.common.ts
@@ -62,7 +62,11 @@ export class OidcSecurityCommon {
             (_createDate, _value) => _value === nonce,
             (_createDate) => (_createDate + (3600000)) < Date.now()); //1 hour expiration
 
-        return nonces.find((n) => n === nonce) !== undefined;
+        const isValid = nonces.find((n) => n === nonce) !== undefined;
+
+        if(isValid) this.removeValueFromSerializedCacheDictionary(this.storage_auth_nonce, nonce);
+
+        return isValid;
     }
 
     public addAuthNonce(value: string) {
@@ -82,9 +86,7 @@ export class OidcSecurityCommon {
     }
 
     public removeAuthState(state: string) {
-        this.getValuesFromSerializedCacheDictionary(this.storage_auth_state_control,
-            () => false,
-            (_createDate, _value) => _value === state);
+        this.removeValueFromSerializedCacheDictionary(this.storage_auth_state_control, state);
     }
 
     private storage_session_state = 'session_state';
@@ -131,6 +133,12 @@ export class OidcSecurityCommon {
         currentValue[Date.now()] = value;
 
         this.store(storageKey, JSON.stringify(currentValue));
+    }
+
+    private removeValueFromSerializedCacheDictionary(storageKey: string, value: string) {
+        this.getValuesFromSerializedCacheDictionary(storageKey,
+            () => false,
+            (_createDate, _value) => _value === value);
     }
 
     private getValuesFromSerializedCacheDictionary(storageKey: string,

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -236,11 +236,7 @@ export class OidcSecurityService {
     }
 
     setState(state: string): void {
-        this.oidcSecurityCommon.authStateControl = state;
-    }
-
-    getState(): string {
-        return this.oidcSecurityCommon.authStateControl;
+        this.oidcSecurityCommon.addAuthState(state);
     }
 
     setCustomRequestParameters(params: { [key: string]: string | number | boolean }) {
@@ -272,16 +268,13 @@ export class OidcSecurityService {
 
         this.loggerService.logDebug('BEGIN Authorize, no auth data');
 
-        let state = this.oidcSecurityCommon.authStateControl;
-        if (!state) {
-            state = Date.now() + '' + Math.random();
-            this.oidcSecurityCommon.authStateControl = state;
-        }
+        const state = Date.now() + '' + Math.random();
+        this.oidcSecurityCommon.addAuthState(state);
 
         const nonce = 'N' + Math.random() + '' + Date.now();
-        this.oidcSecurityCommon.authNonce = nonce;
+        this.oidcSecurityCommon.addAuthNonce(nonce);
         this.loggerService.logDebug(
-            'AuthorizedController created. local state: ' + this.oidcSecurityCommon.authStateControl
+            'AuthorizedController created. local state: ' + state
         );
 
         if (this.authWellKnownEndpoints) {
@@ -524,17 +517,13 @@ export class OidcSecurityService {
     refreshSession(): Observable<any> {
         this.loggerService.logDebug('BEGIN refresh session Authorize');
 
-        let state = this.oidcSecurityCommon.authStateControl;
-        if (state === '' || state === null) {
-            state = Date.now() + '' + Math.random();
-            this.oidcSecurityCommon.authStateControl = state;
-        }
+        const state = Date.now() + '' + Math.random();
+        this.oidcSecurityCommon.addAuthState(state);
 
         const nonce = 'N' + Math.random() + '' + Date.now();
-        this.oidcSecurityCommon.authNonce = nonce;
+        this.oidcSecurityCommon.addAuthNonce(nonce);
         this.loggerService.logDebug(
-            'RefreshSession created. adding myautostate: ' +
-                this.oidcSecurityCommon.authStateControl
+            `RefreshSession created. adding myautostate: ${state}`
         );
 
         let url = '';


### PR DESCRIPTION
This is a fundamental change to how auth staes and nonces work.

Multiple auth states and nonces will now be stored. This will allow multiple auth processes to work simultaneously (multiple tabs, auth and refresh, etc.).

Auth states and nonces are valid for 1 hour. Nonces are valid only for one retrieval from storage and are immediately deleted.