### PR TITLE
Readme and API_Documentation update

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -164,7 +164,7 @@ Optional hd parameter for Google Auth with particular G Suite domain, see https:
 
 Can be used to check if the setup logic is already completed, before your component loads.
 
-*Note: See also: [getIsModuleSetup()](###getismodulesetup-observable)*
+*Note: See also: [getIsModuleSetup()](#getismodulesetup-observable)*
 
 ```typescript
 constructor(public oidcSecurityService: OidcSecurityService) {
@@ -180,7 +180,7 @@ constructor(public oidcSecurityService: OidcSecurityService) {
 
 ### @Output() onModuleSetup: EventEmitter<any> = new EventEmitter<any>(true);
 
-*Note: This will only emit once and late subscribers will never be notified. If you want a more reliable notification see: [getIsModuleSetup()](###getismodulesetup-observable)*
+*Note: This will only emit once and late subscribers will never be notified. If you want a more reliable notification see: [getIsModuleSetup()](#getismodulesetup-observable)*
 
 Example using:
 

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -164,6 +164,8 @@ Optional hd parameter for Google Auth with particular G Suite domain, see https:
 
 Can be used to check if the setup logic is already completed, before your component loads.
 
+*Note: See also: [getIsModuleSetup()](###getismodulesetup-observable)*
+
 ```typescript
 constructor(public oidcSecurityService: OidcSecurityService) {
 	if (this.oidcSecurityService.moduleSetup) {
@@ -178,8 +180,9 @@ constructor(public oidcSecurityService: OidcSecurityService) {
 
 ### @Output() onModuleSetup: EventEmitter<any> = new EventEmitter<any>(true);
 
-Example using:
+*Note: This will only emit once and late subscribers will never be notified. If you want a more reliable notification see: [getIsModuleSetup()](###getismodulesetup-observable)*
 
+Example using:
 
 App.module: get your json settings:
 
@@ -310,7 +313,7 @@ This boolean is set to true when the OpenID session management receives a messag
 
 ### getIsAuthorized(): Observable<boolean>
 
-Set to true if the client and user are authenticated.
+This method will return an observable that will not emit until after module setup is completed. The emitted value will be set to `true` if the client and user are authenticated, `false` otherwise. If silent renew is configured, a silent renew will be attempted before emitting `false`.
 
 Example using:
 
@@ -347,6 +350,20 @@ export class ExampleComponent implements OnInit, OnDestroy   {
     }
 
 }
+```
+
+### getIsModuleSetup(): Observable<boolean>
+
+This method will return an observable that will emit right away with a value set to `true` if the module has completed setup, `false` otherwise. It will continue to emit its last value to all late subscribers.
+
+Example using: 
+
+```typescript
+this.oidcSecurityService.getIsModuleSetup().pipe(
+    filter((isModuleSetup: boolean) => isModuleSetup)
+).subscribe((isModuleSetup: boolean) => {
+    // Do something when module setup is completed.
+});
 ```
 
 ### getIdToken()

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -361,7 +361,7 @@ Example using:
 ```typescript
 this.oidcSecurityService.getIsModuleSetup().pipe(
     filter((isModuleSetup: boolean) => isModuleSetup),
-	take(1)
+    take(1)
 ).subscribe((isModuleSetup: boolean) => {
     // Do something when module setup is completed.
 });

--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -360,7 +360,8 @@ Example using:
 
 ```typescript
 this.oidcSecurityService.getIsModuleSetup().pipe(
-    filter((isModuleSetup: boolean) => isModuleSetup)
+    filter((isModuleSetup: boolean) => isModuleSetup),
+	take(1)
 ).subscribe((isModuleSetup: boolean) => {
     // Do something when module setup is completed.
 });

--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ export function loadConfig(oidcConfigService: OidcConfigService) {
 import { Injectable } from '@angular/core';
 import { Router, CanActivate, CanLoad, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
-import { map } from 'rxjs/operators';
+import { tap } from 'rxjs/operators';
 
 import { OidcSecurityService } from './auth/services/oidc.security.service';
 
@@ -341,17 +341,13 @@ export class AuthorizationGuard implements CanActivate, CanLoad {
         console.log('AuthorizationGuard, canActivate');
 
         return this.oidcSecurityService.getIsAuthorized().pipe(
-            map((isAuthorized: boolean) => {
+            tap((isAuthorized: boolean) => {
                 console.log('AuthorizationGuard, canActivate isAuthorized: ' + isAuthorized);
-
-                if (isAuthorized) {
-                    return true;
-                }
-
-                this.router.navigate(['/unauthorized']);
-                return false;
-            }),
-            take(1)
+                
+		if(!isAuthorized) {
+		    this.router.navigate(['/unauthorized']);
+	        }
+            })
         );
     }
 }
@@ -458,7 +454,7 @@ Point the `silent_renew_url` property to an HTML file which contains the followi
 };
 </script>
 ```
-
+When silent renew is enabled, `getIsAuthorized()` will attempt to perform a renew before returning the authorization state. This allows the application to authorize a user, that is already authenticated, without redirects.
 
 ## X-Frame-Options / CSP ancestor / different domains
 


### PR DESCRIPTION
`take(1)` isn't necessary for guards.

Adding note about `getIsAuthorized()`

Adding documentation for `getIsModuleSetup()`

Adding note about `getIsModuleSetup()`
