### PR TITLE
If the authority server goes down, the oidc.security.check-session se…

### DIFF
--- a/src/services/oidc.security.check-session.ts
+++ b/src/services/oidc.security.check-session.ts
@@ -1,5 +1,6 @@
 import { EventEmitter, Injectable, NgZone, Output } from '@angular/core';
-import { Observable, Observer } from 'rxjs';
+import { Observable, Observer, from } from 'rxjs';
+import { take } from 'rxjs/operators';
 import { AuthWellKnownEndpoints } from '../models/auth.well-known-endpoints';
 import { AuthConfiguration } from '../modules/auth.configuration';
 import { IFrameService } from './existing-iframe.service';
@@ -16,6 +17,10 @@ export class OidcSecurityCheckSession {
     private iframeMessageEvent: any;
     private authWellKnownEndpoints: AuthWellKnownEndpoints | undefined;
     private scheduledHeartBeat: any;
+    private lastIFrameRefresh: number = 0;
+    private lastMessageResponseReceived: number = 0;
+    private heartBeatInterval: number = 3000;
+    private iframeRefreshInterval: number = 60000;
 
     @Output()
     onCheckSessionChanged: EventEmitter<any> = new EventEmitter<any>(true);
@@ -44,7 +49,16 @@ export class OidcSecurityCheckSession {
     }
 
     init() {
-        this.sessionIframe = this.iFrameService.addIFrameToWindowBody(IFRAME_FOR_CHECK_SESSION_IDENTIFIER);
+        if ((this.lastIFrameRefresh + this.iframeRefreshInterval) > Date.now()) {
+            return from([this]);
+        }
+
+        if (!this.doesSessionExist()) {
+            this.sessionIframe = this.iFrameService.addIFrameToWindowBody(IFRAME_FOR_CHECK_SESSION_IDENTIFIER);
+            this.iframeMessageEvent = this.messageHandler.bind(this);
+            window.addEventListener('message', this.iframeMessageEvent, false);
+            this.lastMessageResponseReceived = Date.now();
+        }
 
         if (this.authWellKnownEndpoints) {
             this.sessionIframe.src = this.authWellKnownEndpoints.check_session_iframe;
@@ -52,11 +66,9 @@ export class OidcSecurityCheckSession {
             this.loggerService.logWarning('init check session: authWellKnownEndpoints is undefined');
         }
 
-        this.iframeMessageEvent = this.messageHandler.bind(this);
-        window.addEventListener('message', this.iframeMessageEvent, false);
-
         return Observable.create((observer: Observer<OidcSecurityCheckSession>) => {
             this.sessionIframe.onload = () => {
+                this.lastIFrameRefresh = Date.now();
                 observer.next(this);
                 observer.complete();
             };
@@ -80,26 +92,40 @@ export class OidcSecurityCheckSession {
 
     pollServerSession(clientId: string) {
         const _pollServerSessionRecur = () => {
-            if (this.sessionIframe && clientId) {
-                this.loggerService.logDebug(this.sessionIframe);
-                const session_state = this.oidcSecurityCommon.sessionState;
-                if (session_state) {
-                    this.sessionIframe.contentWindow.postMessage(clientId + ' ' + session_state, this.authConfiguration.stsServer);
+
+            this.init().pipe(take(1)).subscribe(() => {
+                if (this.sessionIframe && clientId) {
+                    this.loggerService.logDebug(this.sessionIframe);
+                    const session_state = this.oidcSecurityCommon.sessionState;
+                    if (session_state) {
+                        this.sessionIframe.contentWindow.postMessage(clientId + ' ' + session_state,
+                            this.authConfiguration.stsServer);
+                    } else {
+                        this.loggerService.logDebug(
+                            'OidcSecurityCheckSession pollServerSession session_state is blank');
+                        this.onCheckSessionChanged.emit();
+                    }
                 } else {
-                    this.loggerService.logDebug('OidcSecurityCheckSession pollServerSession session_state is blank');
+                    this.loggerService.logWarning(
+                        'OidcSecurityCheckSession pollServerSession sessionIframe does not exist');
+                    this.loggerService.logDebug(clientId);
+                    this.loggerService.logDebug(this.sessionIframe);
+                    // this.init();
+                }
+
+                // after sending three messages with no response, fail.
+                if ((this.lastMessageResponseReceived + (this.heartBeatInterval * 3)) < Date.now()) {
+                    this.loggerService.logError(
+                        'OidcSecurityCheckSession not receiving check session response messages. Server unreachable?');
                     this.onCheckSessionChanged.emit();
                 }
-            } else {
-                this.loggerService.logWarning('OidcSecurityCheckSession pollServerSession sessionIframe does not exist');
-                this.loggerService.logDebug(clientId);
-                this.loggerService.logDebug(this.sessionIframe);
-                // this.init();
-            }
-            this.scheduledHeartBeat = setTimeout(_pollServerSessionRecur, 3000);
+
+                this.scheduledHeartBeat = setTimeout(_pollServerSessionRecur, this.heartBeatInterval);
+            });
         };
 
         this.zone.runOutsideAngular(() => {
-            this.scheduledHeartBeat = setTimeout(_pollServerSessionRecur, 3000);
+            this.scheduledHeartBeat = setTimeout(_pollServerSessionRecur, this.heartBeatInterval);
         });
     }
     private clearScheduledHeartBeat() {
@@ -108,6 +134,7 @@ export class OidcSecurityCheckSession {
     }
 
     private messageHandler(e: any) {
+        this.lastMessageResponseReceived = Date.now();
         if (this.sessionIframe && e.origin === this.authConfiguration.stsServer && e.source === this.sessionIframe.contentWindow) {
             if (e.data === 'error') {
                 this.loggerService.logWarning('error from checksession messageHandler');


### PR DESCRIPTION
…rvice will now emit an onCheckSessionChanged event.

The server will be checked every sixty seconds.
If a message isn't received from the check session iframe within 3 "beats" of the check session heart beat. An event will be emitted.

The iframe will only stop emitting events after the server is checked. So the event will be emitted at a minimum of 3 beats (9 seconds) and  maximum of sixty seconds + 3 beats (69 seconds).

Fixes #310