### PR TITLE
silent_renew is now off by default (false).

### DIFF
--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 
-export class DefaultConfiguration {
+export class OpenIDImplicitFlowConfiguration {
     stsServer = 'https://localhost:44318';
     redirect_url = 'https://localhost:44311';
     // The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified
@@ -14,7 +14,7 @@ export class DefaultConfiguration {
     hd_param = '';
     post_logout_redirect_uri = 'https://localhost:44311/unauthorized';
     start_checksession = false;
-    silent_renew = true;
+    silent_renew = false;
     silent_renew_url = 'https://localhost:44311';
     silent_renew_offset_in_seconds = 0;
     silent_redirect_url = 'https://localhost:44311';
@@ -36,35 +36,10 @@ export class DefaultConfiguration {
     storage = typeof Storage !== 'undefined' ? sessionStorage : null;
 }
 
-export class OpenIDImplicitFlowConfiguration {
-    stsServer = 'https://localhost:44318';
-    redirect_url = 'https://localhost:44311';
-    client_id = 'angularclient';
-    response_type = 'id_token token';
-    resource = '';
-    scope = 'openid email profile';
-    hd_param = '';
-    post_logout_redirect_uri = 'https://localhost:44311/unauthorized';
-    start_checksession = false;
-    silent_renew = true;
-    silent_renew_url = 'https://localhost:44311';
-    silent_renew_offset_in_seconds = 0;
-    silent_redirect_url = 'https://localhost:44311';
-    post_login_route = '/';
-    forbidden_route = '/forbidden';
-    unauthorized_route = '/unauthorized';
-    auto_userinfo = true;
-    auto_clean_state_after_authentication = true;
-    trigger_authorization_result_event = false;
-    log_console_warning_active = true;
-    log_console_debug_active = false;
-    max_id_token_iat_offset_allowed_in_seconds = 3;
-    storage: any = typeof window !== 'undefined' ? sessionStorage : null;
-}
-
 @Injectable()
 export class AuthConfiguration {
     private openIDImplicitFlowConfiguration: OpenIDImplicitFlowConfiguration | undefined;
+    private defaultConfig: OpenIDImplicitFlowConfiguration;
 
     get stsServer(): string {
         if (this.openIDImplicitFlowConfiguration) {
@@ -234,7 +209,9 @@ export class AuthConfiguration {
         return this.defaultConfig.storage;
     }
 
-    constructor(private defaultConfig: DefaultConfiguration) {}
+    constructor() {
+        this.defaultConfig = new OpenIDImplicitFlowConfiguration();
+    }
 
     init(openIDImplicitFlowConfiguration: OpenIDImplicitFlowConfiguration) {
         this.openIDImplicitFlowConfiguration = openIDImplicitFlowConfiguration;

--- a/src/modules/auth.module.ts
+++ b/src/modules/auth.module.ts
@@ -14,7 +14,7 @@ import { OidcSecuritySilentRenew } from '../services/oidc.security.silent-renew'
 import { BrowserStorage, OidcSecurityStorage } from '../services/oidc.security.storage';
 import { OidcSecurityUserService } from '../services/oidc.security.user-service';
 import { OidcSecurityValidation } from '../services/oidc.security.validation';
-import { AuthConfiguration, DefaultConfiguration } from './auth.configuration';
+import { AuthConfiguration } from './auth.configuration';
 
 @NgModule()
 export class AuthModule {
@@ -33,7 +33,6 @@ export class AuthModule {
                 TokenHelperService,
                 LoggerService,
                 IFrameService,
-                DefaultConfiguration,
                 EqualityHelperService,
                 AuthWellKnownEndpoints,
                 OidcDataService,

--- a/tests/services/oidc-security-validation.spec.ts
+++ b/tests/services/oidc-security-validation.spec.ts
@@ -7,10 +7,7 @@ import {
     OpenIDImplicitFlowConfiguration,
     AuthModule,
 } from '../../src/angular-auth-oidc-client';
-import {
-    AuthConfiguration,
-    DefaultConfiguration,
-} from '../../src/modules/auth.configuration';
+import { AuthConfiguration } from '../../src/modules/auth.configuration';
 import { EqualityHelperService } from '../../src/services/oidc-equality-helper.service';
 import { LoggerService } from '../../src/services/oidc.logger.service';
 import { OidcSecurityValidation } from '../../src/services/oidc.security.validation';
@@ -48,9 +45,7 @@ describe('OidcSecurityValidation', () => {
     });
 
     it('validate aud string', () => {
-        const authConfiguration = new AuthConfiguration(
-            new DefaultConfiguration()
-        );
+        const authConfiguration = new AuthConfiguration();
 
         let openIDImplicitFlowConfiguration = new OpenIDImplicitFlowConfiguration();
         openIDImplicitFlowConfiguration.stsServer = 'https://localhost:5001';
@@ -89,9 +84,7 @@ describe('OidcSecurityValidation', () => {
     });
 
     it('validate aud array', () => {
-        const authConfiguration = new AuthConfiguration(
-            new DefaultConfiguration()
-        );
+        const authConfiguration = new AuthConfiguration();
 
         let openIDImplicitFlowConfiguration = new OpenIDImplicitFlowConfiguration();
         openIDImplicitFlowConfiguration.stsServer = 'https://localhost:5001';

--- a/tests/services/oidc-token-helper.service.spec.ts
+++ b/tests/services/oidc-token-helper.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { AuthConfiguration, DefaultConfiguration } from '../../src/angular-auth-oidc-client';
+import { AuthConfiguration } from '../../src/angular-auth-oidc-client';
 import { TokenHelperService } from '../../src/services/oidc-token-helper.service';
 import { LoggerService } from '../../src/services/oidc.logger.service';
 import { TestLogging } from '../common/test-logging.service';
@@ -12,8 +12,7 @@ describe('TokenHelperService', () => {
             providers: [
                 TokenHelperService,
                 { provide: LoggerService, useClass: TestLogging },
-                AuthConfiguration,
-                DefaultConfiguration,
+                AuthConfiguration
             ],
         });
     });

--- a/tests/services/oidc.security-check-session.spec.ts
+++ b/tests/services/oidc.security-check-session.spec.ts
@@ -2,9 +2,8 @@ import { TestBed } from '@angular/core/testing';
 import {
     AuthConfiguration,
     AuthWellKnownEndpoints,
-    DefaultConfiguration,
     OidcSecurityService,
-    OidcSecurityStorage,
+    OidcSecurityStorage
 } from '../../src/angular-auth-oidc-client';
 import { IFrameService } from '../../src/services/existing-iframe.service';
 import { LoggerService } from '../../src/services/oidc.logger.service';
@@ -22,7 +21,6 @@ describe('EqualityHelperServiceTests', () => {
                 AuthConfiguration,
                 OidcSecurityCommon,
                 LoggerService,
-                DefaultConfiguration,
                 OidcSecurityService,
                 { provide: OidcSecurityStorage, useClass: TestStorage },
                 IFrameService,


### PR DESCRIPTION
Removed `DefaultConfiguration` class as its simply an unmodified instance of the `OpenIDImplicitFlowConfiguration` class.

`AuthConfiguration` no longer is instantiated with an instance of `DefaultConfiguration` instead it instantiates its own instance of `OpenIDImplicitFlowConfiguration` to use for default values.

Fixes #329