### PR TITLE
Optional url handler for logoff function

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -458,7 +458,7 @@ export class OidcSecurityService {
         });
     }
 
-    logoff() {
+    logoff(urlHandler?: (url: string) => any) {
         // /connect/endsession?id_token_hint=...&post_logout_redirect_uri=https://myapp.com
         this.loggerService.logDebug('BEGIN Authorize, no auth data');
 
@@ -472,6 +472,8 @@ export class OidcSecurityService {
 
                 if (this.authConfiguration.start_checksession && this.checkSessionChanged) {
                     this.loggerService.logDebug('only local login cleaned up, server session has changed');
+                } else if(urlHandler) {
+                    urlHandler(url);  
                 } else {
                     window.location.href = url;
                 }

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -284,7 +284,7 @@ export class OidcSecurityService {
             if (urlHandler) {
                 urlHandler(url);
             } else {
-                window.location.href = url;
+                this.redirectTo(url);
             }
         } else {
             this.loggerService.logError('authWellKnownEndpoints is undefined');
@@ -300,6 +300,10 @@ export class OidcSecurityService {
             .subscribe(() => {
                 this.authorizedCallbackProcedure(hash);
             });
+    }
+
+    private redirectTo(url: string) {
+        window.location.href = url;
     }
 
     private authorizedCallbackProcedure(hash?: string) {
@@ -475,7 +479,7 @@ export class OidcSecurityService {
                 } else if(urlHandler) {
                     urlHandler(url);  
                 } else {
-                    window.location.href = url;
+                    this.redirectTo(url);
                 }
             } else {
                 this.resetAuthorizationData(false);

--- a/tests/services/oidc.security.service.spec.ts
+++ b/tests/services/oidc.security.service.spec.ts
@@ -297,4 +297,36 @@ describe('OidcSecurityService', () => {
         (oidcSecurityService as OidcSecurityService).authorizedCallback(hash);
         expect(resultSetter).toHaveBeenCalledWith(expectedResult);
     });
+
+    it('logoff should call urlHandler', () => {
+        oidcSecurityService.authWellKnownEndpoints = { end_session_endpoint: 'some_endpoint' };
+
+        const logoffUrl = 'http://some_logoff_url';
+
+        spyOn(oidcSecurityService, 'createEndSessionUrl').and.returnValue(logoffUrl);
+        const redirectToSpy = spyOn(oidcSecurityService, 'redirectTo');
+
+        let hasBeenCalled = false;
+
+        (oidcSecurityService as OidcSecurityService).logoff((url: string) => {
+            expect(url).toEqual(logoffUrl);
+            hasBeenCalled = true;
+        });
+
+        expect(hasBeenCalled).toEqual(true);
+        expect(redirectToSpy).not.toHaveBeenCalled();
+    });
+
+    it('logoff should redirect', () => {
+        oidcSecurityService.authWellKnownEndpoints = { end_session_endpoint: 'some_endpoint' };
+
+        const logoffUrl = 'http://some_logoff_url';
+
+        spyOn(oidcSecurityService, 'createEndSessionUrl').and.returnValue(logoffUrl);
+        const redirectToSpy = spyOn(oidcSecurityService, 'redirectTo');
+
+        (oidcSecurityService as OidcSecurityService).logoff();
+
+        expect(redirectToSpy).toHaveBeenCalledWith(logoffUrl);
+    });
 });


### PR DESCRIPTION
Authorization function has the option to pass a function that hanlde the url instead of redirect to it. I propose that logoff function works the same way and allow the user to pass a function that handle the url as it want or redirect if there is not handler in parameters.