### PR TITLE
Adding an `onConfigurationChange` Observable to `OidcSecurityService`

### DIFF
--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { Observable, Subject } from 'rxjs';
 
 export class OpenIDImplicitFlowConfiguration {
     stsServer = 'https://localhost:44318';
@@ -215,5 +216,11 @@ export class AuthConfiguration {
 
     init(openIDImplicitFlowConfiguration: OpenIDImplicitFlowConfiguration) {
         this.openIDImplicitFlowConfiguration = openIDImplicitFlowConfiguration;
+        this._onConfigurationChange.next(openIDImplicitFlowConfiguration);
+    }
+
+    private _onConfigurationChange = new Subject<OpenIDImplicitFlowConfiguration>();
+    get onConfigurationChange(): Observable<OpenIDImplicitFlowConfiguration> {
+        return this._onConfigurationChange.asObservable();
     }
 }

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -40,6 +40,10 @@ export class OidcSecurityService {
         return this._onCheckSessionChanged.asObservable();
     }
 
+    public get onConfigurationChange(): Observable<OpenIDImplicitFlowConfiguration> {
+        return this.authConfiguration.onConfigurationChange;
+    }
+
     checkSessionChanged = false;
     moduleSetup = false;
 


### PR DESCRIPTION
Adding an `onConfigurationChange` Observable to `OidcSecurityService`

This will allow users to listen for configuration changes. This could be useful when needed to modify things like custom request parameters before setup is completed.

Fixes #333