### PR TITLE
When `logOff()` is called storage should be cleared before emitting a…

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -567,9 +567,10 @@ export class OidcSecurityService {
                 // Clear user data. Fixes #97.
                 this.setUserData('');
             }
-            this.setIsAuthorized(false);
+            
             this.oidcSecurityCommon.resetStorageData(isRenewProcess);
             this.checkSessionChanged = false;
+            this.setIsAuthorized(false);
         }
     }
 


### PR DESCRIPTION
…n authorization event.

If users are redirecting/reloading from within the isAuthorized subscription, storage may not be cleared. This pull request simply changes the order of operations to have storage cleared first, and then emit. 

Unit test added to prevent regression.

Fixes #339