### PR TITLE
AuthConfiguration object will now always return false for `start_chec…

### DIFF
--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
 import { Observable, Subject } from 'rxjs';
 
 export class OpenIDImplicitFlowConfiguration {
@@ -107,6 +108,10 @@ export class AuthConfiguration {
     }
 
     get start_checksession(): boolean {
+        if (!isPlatformBrowser(this.platformId)) {
+            return false;
+        }
+
         if (this.openIDImplicitFlowConfiguration) {
             return this.openIDImplicitFlowConfiguration.start_checksession;
         }
@@ -115,6 +120,10 @@ export class AuthConfiguration {
     }
 
     get silent_renew(): boolean {
+        if (!isPlatformBrowser(this.platformId)) {
+            return false;
+        }
+
         if (this.openIDImplicitFlowConfiguration) {
             return this.openIDImplicitFlowConfiguration.silent_renew;
         }
@@ -210,7 +219,7 @@ export class AuthConfiguration {
         return this.defaultConfig.storage;
     }
 
-    constructor() {
+    constructor(@Inject(PLATFORM_ID) private platformId: Object) {
         this.defaultConfig = new OpenIDImplicitFlowConfiguration();
     }
 

--- a/tests/modules/auth.configuration.spec.ts
+++ b/tests/modules/auth.configuration.spec.ts
@@ -1,0 +1,69 @@
+import { PLATFORM_ID } from '@angular/core'
+import { TestBed } from '@angular/core/testing';
+import {
+    OpenIDImplicitFlowConfiguration,
+    AuthModule,
+} from '../../src/angular-auth-oidc-client';
+import { AuthConfiguration } from '../../src/modules/auth.configuration';
+import { LoggerService } from '../../src/services/oidc.logger.service';
+import { TestLogging } from '../common/test-logging.service';
+
+describe('AuthConfiguration', () => {
+    let authConfiguration: AuthConfiguration;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            imports: [
+                AuthModule.forRoot(),
+            ],
+            providers: [
+                {
+                    provide: LoggerService,
+                    useClass: TestLogging,
+                }
+            ],
+        });
+    });
+
+    describe('browser', () => {
+        beforeEach( () => {
+            TestBed.configureTestingModule({
+                providers: [ { provide: PLATFORM_ID, useValue: 'browser'} ]
+            });
+
+            authConfiguration = TestBed.get(AuthConfiguration);
+        });
+
+        it('silent_renew and start_checksession can be set to true when using the browser platform', () => {
+            let openIDImplicitFlowConfiguration = new OpenIDImplicitFlowConfiguration();
+            openIDImplicitFlowConfiguration.silent_renew = true;
+            openIDImplicitFlowConfiguration.start_checksession = true;
+
+            authConfiguration.init(openIDImplicitFlowConfiguration);
+        
+            expect(authConfiguration.silent_renew).toEqual(true);
+            expect(authConfiguration.start_checksession).toEqual(true);
+        });
+    });
+    
+    describe('server', () => {
+        beforeEach( () => {
+            TestBed.configureTestingModule({
+                providers: [ { provide: PLATFORM_ID, useValue: 'server'} ]
+            });
+
+            authConfiguration = TestBed.get(AuthConfiguration);
+        });
+
+        it('silent_renew and start_checksession are always false when not using the browser platform', () => {
+            let openIDImplicitFlowConfiguration = new OpenIDImplicitFlowConfiguration();
+            openIDImplicitFlowConfiguration.silent_renew = true;
+            openIDImplicitFlowConfiguration.start_checksession = true;
+
+            authConfiguration.init(openIDImplicitFlowConfiguration);
+        
+            expect(authConfiguration.silent_renew).toEqual(false);
+            expect(authConfiguration.start_checksession).toEqual(false);
+        });
+    });
+});

--- a/tests/services/oidc-security-validation.spec.ts
+++ b/tests/services/oidc-security-validation.spec.ts
@@ -16,6 +16,7 @@ import { TestStorage } from '../common/test-storage.service';
 
 describe('OidcSecurityValidation', () => {
     let oidcSecurityValidation: OidcSecurityValidation;
+    let authConfiguration: AuthConfiguration;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -26,6 +27,7 @@ describe('OidcSecurityValidation', () => {
                 AuthModule.forRoot(),
             ],
             providers: [
+                AuthConfiguration,
                 EqualityHelperService,
                 OidcSecurityValidation,
                 {
@@ -42,11 +44,10 @@ describe('OidcSecurityValidation', () => {
 
     beforeEach(() => {
         oidcSecurityValidation = TestBed.get(OidcSecurityValidation);
+        authConfiguration = TestBed.get(AuthConfiguration);
     });
 
     it('validate aud string', () => {
-        const authConfiguration = new AuthConfiguration();
-
         let openIDImplicitFlowConfiguration = new OpenIDImplicitFlowConfiguration();
         openIDImplicitFlowConfiguration.stsServer = 'https://localhost:5001';
         openIDImplicitFlowConfiguration.redirect_url =
@@ -84,8 +85,6 @@ describe('OidcSecurityValidation', () => {
     });
 
     it('validate aud array', () => {
-        const authConfiguration = new AuthConfiguration();
-
         let openIDImplicitFlowConfiguration = new OpenIDImplicitFlowConfiguration();
         openIDImplicitFlowConfiguration.stsServer = 'https://localhost:5001';
         openIDImplicitFlowConfiguration.redirect_url =


### PR DESCRIPTION
…ksession` and `silent_renew` properties when not running on a browser platform.

Fixes #337