### PR TITLE
Changed iframe to avoid changing history state for repeated silent token renewals

### DIFF
--- a/src/services/oidc.security.check-session.ts
+++ b/src/services/oidc.security.check-session.ts
@@ -62,7 +62,7 @@ export class OidcSecurityCheckSession {
         }
 
         if (this.authWellKnownEndpoints) {
-            this.sessionIframe.src = this.authWellKnownEndpoints.check_session_iframe;
+            this.sessionIframe.contentWindow.location.replace(this.authWellKnownEndpoints.check_session_iframe);
         } else {
             this.loggerService.logWarning('init check session: authWellKnownEndpoints is undefined');
         }

--- a/src/services/oidc.security.silent-renew.ts
+++ b/src/services/oidc.security.silent-renew.ts
@@ -30,7 +30,7 @@ export class OidcSecuritySilentRenew {
         this.sessionIframe = this.iFrameService.getExistingIFrame(IFRAME_FOR_SILENT_RENEW_IDENTIFIER);
 
         this.loggerService.logDebug('startRenew for URL:' + url);
-        this.sessionIframe.src = url;
+        this.sessionIframe.contentWindow.location.replace(url);
 
         return Observable.create((observer: Observer<any>) => {
             this.sessionIframe.onload = () => {


### PR DESCRIPTION
This pull request should avoid the problem described in #279 by not changing the src but updating the location of the iFrame in another way

Fixes #279