### PR TITLE
ISS validation per config

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -105,6 +105,13 @@ default value : '/Unauthorized'
 
 Route, if the server returns a 401. This is an Angular route. HTTP 401
 
+### iss_validation_off
+
+Make it possible to turn the iss validation off per configuration. You should not turn this off!
+
+default value : 'false'
+
+
 ### auto_userinfo
 
 default value : 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## angular-auth-oidc-client Changelog
 
+<a name="2018-11-16"></a>
+### 2018-11-16 version 8.0.3
+* Changed iframe to avoid changing history state for repeated silent token renewals
+
 <a name="2018-11-07"></a>
 ### 2018-11-07 version 8.0.2
 * When `logOff()` is called storage should be cleared before emitting an authorization event.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 <a name="2018-11-16"></a>
 ### 2018-11-16 version 8.0.3
 * Changed iframe to avoid changing history state for repeated silent token renewals
+* make it possible to turn the iss validation off per configuration
 
 <a name="2018-11-07"></a>
 ### 2018-11-07 version 8.0.2

--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -30,6 +30,7 @@ export class OpenIDImplicitFlowConfiguration {
     trigger_authorization_result_event = false;
     log_console_warning_active = true;
     log_console_debug_active = false;
+    iss_validation_off = false;
 
     // id_token C8: The iat Claim can be used to reject tokens that were issued too far away from the current time,
     // limiting the amount of time that nonces need to be stored to prevent attacks.The acceptable range is Client specific.
@@ -202,6 +203,16 @@ export class AuthConfiguration {
 
         return this.defaultConfig.log_console_debug_active;
     }
+
+    get iss_validation_off(): boolean {
+        if (this.openIDImplicitFlowConfiguration) {
+            return this.openIDImplicitFlowConfiguration.iss_validation_off;
+        }
+
+        return this.defaultConfig.iss_validation_off;
+    }
+
+    
 
     get max_id_token_iat_offset_allowed_in_seconds(): number {
         if (this.openIDImplicitFlowConfiguration) {

--- a/src/modules/auth.configuration.ts
+++ b/src/modules/auth.configuration.ts
@@ -212,8 +212,6 @@ export class AuthConfiguration {
         return this.defaultConfig.iss_validation_off;
     }
 
-    
-
     get max_id_token_iat_offset_allowed_in_seconds(): number {
         if (this.openIDImplicitFlowConfiguration) {
             return this.openIDImplicitFlowConfiguration.max_id_token_iat_offset_allowed_in_seconds;

--- a/src/services/oidc-security-state-validation.service.ts
+++ b/src/services/oidc-security-state-validation.service.ts
@@ -71,9 +71,7 @@ export class StateValidationService {
         if (this.authWellKnownEndpoints) {
             if (this.authConfiguration.iss_validation_off) {
                 this.loggerService.logDebug('iss validation is turned off, this is not recommended!');
-            }
-            
-            if (!this.authConfiguration.iss_validation_off &&
+            } else if (!this.authConfiguration.iss_validation_off &&
                 !this.oidcSecurityValidation.validate_id_token_iss(toReturn.decoded_id_token, this.authWellKnownEndpoints.issuer)) {
                 this.loggerService.logWarning('authorizedCallback incorrect iss does not match authWellKnownEndpoints issuer');
                 toReturn.state = ValidationResult.IssDoesNotMatchIssuer;

--- a/src/services/oidc-security-state-validation.service.ts
+++ b/src/services/oidc-security-state-validation.service.ts
@@ -69,7 +69,12 @@ export class StateValidationService {
         }
 
         if (this.authWellKnownEndpoints) {
-            if (!this.oidcSecurityValidation.validate_id_token_iss(toReturn.decoded_id_token, this.authWellKnownEndpoints.issuer)) {
+            if (this.authConfiguration.iss_validation_off) {
+                this.loggerService.logDebug('iss validation is turned off, this is not recommended!');
+            }
+            
+            if (!this.authConfiguration.iss_validation_off &&
+                !this.oidcSecurityValidation.validate_id_token_iss(toReturn.decoded_id_token, this.authWellKnownEndpoints.issuer)) {
                 this.loggerService.logWarning('authorizedCallback incorrect iss does not match authWellKnownEndpoints issuer');
                 toReturn.state = ValidationResult.IssDoesNotMatchIssuer;
                 return toReturn;


### PR DESCRIPTION
Make it possible to turn the iss validation off per configuration

default = false. Should NOT be turned off unless required.

enhancement for https://github.com/damienbod/angular-auth-oidc-client/issues/347