### PR TITLE
Adding support for Code flow with PKCE

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -62,6 +62,33 @@ Example of a silent_renew.html callback html file.
 
 Note: The CustomEvent does not work for older versions of IE. Add a javascript function instead of this, if required.
 
+### Code Flow with PKCE
+```html
+<!doctype html>
+<html>
+<head>
+    <base href="./">
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>silent-renew</title>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8" />
+</head>
+<body>
+
+    <script>
+        window.onload = function () {
+            /* The parent window hosts the Angular application */
+            var parent = window.parent;
+            /* Send the id_token information to the oidc message handler */
+            var event = new CustomEvent('oidc-silent-renew-message', { detail: window.location });
+            parent.dispatchEvent(event);
+        };
+    </script>
+</body>
+</html>
+
+```
+### Implicit Flow
 ```html
 <!doctype html>
 <html>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 ### 2019-01-08 version 9.0.0
 * Support for OpenID Connect Code Flow with PKCE
 
-Breaking changes:
+### Breaking changes:
+
 Implicit flow callback renamed from authorizedCallback() to authorizedImplicitFlowCallback()
 
 <a name="2018-11-16"></a>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## angular-auth-oidc-client Changelog
 
+<a name="2019-01-08"></a>
+### 2019-01-08 version 9.0.0
+* Support for OpenID Connect Code Flow with PKCE
+
+Breaking changes:
+Implicit flow callback renamed from authorizedCallback() to authorizedImplicitFlowCallback()
+
 <a name="2018-11-16"></a>
 ### 2018-11-16 version 8.0.3
 * Changed iframe to avoid changing history state for repeated silent token renewals

--- a/README.md
+++ b/README.md
@@ -184,18 +184,8 @@ export class AppComponent implements OnInit, OnDestroy {
 
     private doCallbackLogicIfRequired() {
         console.log(window.location);
-
-        const urlParts = window.location.toString().split('?');
-        const params = new HttpParams({
-            fromString: urlParts[1]
-        });
-        const code = params.get('code');
-        const state = params.get('state');
-        const session_state = params.get('session_state');
-
-        if (code && state && session_state) {
-            this.oidcSecurityService.requestTokensWithCode(code, state, session_state);
-        }
+        // Will do a callback, if the url has a code and state parameter.
+        this.oidcSecurityService.authorizedCallbackWithCode(window.location.toString());
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -148,99 +148,37 @@ Create the login, logout component and use the oidcSecurityService
 
 ```typescript
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Subscription } from 'rxjs';
-import { Router } from '@angular/router';
-import { OidcSecurityService } from './auth/services/oidc.security.service';
-import { LocaleService, TranslationService, Language } from 'angular-l10n';
-import './app.component.css';
-import { AuthorizationResult } from './auth/models/authorization-result';
-import { AuthorizationState } from './auth/models/authorization-state.enum';
-import { HttpParams } from '@angular/common/http';
-// import { ValidationResult } from './auth/models/validation-result.enum';
+import { Subscription } from 'rxjs/Subscription';
+import { OidcSecurityService } from 'angular-auth-oidc-client';
 
 @Component({
-    selector: 'app-component',
+    selector: 'my-app',
     templateUrl: 'app.component.html',
 })
-
 export class AppComponent implements OnInit, OnDestroy {
-
-    @Language() lang = '';
-
-    title = '';
-
-    isAuthorizedSubscription: Subscription | undefined;
-    isAuthorized = false;
-
-    onChecksessionChanged: Subscription | undefined;
-    checksession = false;
-
-    constructor(
-        public oidcSecurityService: OidcSecurityService,
-        public locale: LocaleService,
-        private router: Router,
-        public translation: TranslationService
-    ) {
-        console.log('AppComponent STARTING');
-
-        if (this.oidcSecurityService.moduleSetup) {
-            this.doCallbackLogicIfRequired();
-        } else {
-            this.oidcSecurityService.onModuleSetup.subscribe(() => {
-                this.doCallbackLogicIfRequired();
-            });
-        }
-
-        this.oidcSecurityService.onCheckSessionChanged.subscribe(
-            (checksession: boolean) => {
-                console.log('...recieved a check session event');
-                this.checksession = checksession;
-            });
-
-        this.oidcSecurityService.onAuthorizationResult.subscribe(
-            (authorizationResult: AuthorizationResult) => {
-                this.onAuthorizationResultComplete(authorizationResult);
-            });
+    constructor(public oidcSecurityService: OidcSecurityService) {
+	this.oidcSecurityService.getIsModuleSetup().pipe(
+	    filter((isModuleSetup: boolean) => isModuleSetup),
+	    take(1)
+	).subscribe((isModuleSetup: boolean) => {
+	    this.doCallbackLogicIfRequired();
+	});
     }
 
-    ngOnInit() {
-        this.isAuthorizedSubscription = this.oidcSecurityService.getIsAuthorized().subscribe(
-            (isAuthorized: boolean) => {
-                this.isAuthorized = isAuthorized;
-            });
-    }
+    ngOnInit() {}
 
-    changeCulture(language: string, country: string) {
-        this.locale.setDefaultLocale(language, country);
-        console.log('set language: ' + language);
-    }
-
-    ngOnDestroy(): void {
-        if (this.isAuthorizedSubscription) {
-            this.isAuthorizedSubscription.unsubscribe();
-        }
-    }
+    ngOnDestroy(): void {}
 
     login() {
-        console.log('start login');
-
-        let culture = 'de-CH';
-        if (this.locale.getCurrentCountry()) {
-            culture = this.locale.getCurrentLanguage() + '-' + this.locale.getCurrentCountry();
-        }
-
-        this.oidcSecurityService.setCustomRequestParameters({ 'ui_locales': culture});
-
-        this.oidcSecurityService.authorize();
-    }
-
-    refreshSession() {
-        console.log('start refreshSession');
+  
+        // if you need to add extra parameters to the login
+        // let culture = 'de-CH';
+        // this.oidcSecurityService.setCustomRequestParameters({ 'ui_locales': culture });
+	
         this.oidcSecurityService.authorize();
     }
 
     logout() {
-        console.log('start logoff');
         this.oidcSecurityService.logoff();
     }
 
@@ -257,22 +195,6 @@ export class AppComponent implements OnInit, OnDestroy {
 
         if (code && state && session_state) {
             this.oidcSecurityService.requestTokensWithCode(code, state, session_state);
-        }
-    }
-
-    private onAuthorizationResultComplete(authorizationResult: AuthorizationResult) {
-
-        console.log('Auth result received AuthorizationState:'
-            + authorizationResult.authorizationState
-            + ' validationResult:' + authorizationResult.validationResult);
-
-        if (authorizationResult.authorizationState === AuthorizationState.unauthorized) {
-            if (window.parent) {
-                // sent from the child iframe, for example the silent renew
-                this.router.navigate(['/unauthorized']);
-            } else {
-                window.location.href = '/unauthorized';
-            }
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -502,6 +502,20 @@ The event handler will send this token to the authorization callback and complet
 
 Point the `silent_renew_url` property to an HTML file which contains the following script element to enable authorization.
 
+Code Flow with PKCE
+```
+<script>
+	window.onload = function () {
+		/* The parent window hosts the Angular application */
+		var parent = window.parent;
+		/* Send the id_token information to the oidc message handler */
+		var event = new CustomEvent('oidc-silent-renew-message', { detail: window.location });
+		parent.dispatchEvent(event);
+	};
+</script>
+```
+
+Implicit Flow
 ```
 <script>
     window.onload = function () {
@@ -513,6 +527,7 @@ Point the `silent_renew_url` property to an HTML file which contains the followi
 };
 </script>
 ```
+
 When silent renew is enabled, `getIsAuthorized()` will attempt to perform a renew before returning the authorization state. This allows the application to authorize a user, that is already authenticated, without redirects.
 
 ## X-Frame-Options / CSP ancestor / different domains

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ export class AppModule {
         // The Client MUST validate that the aud (audience) Claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience.
         // The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
         openIDImplicitFlowConfiguration.client_id = 'singleapp';
-        openIDImplicitFlowConfiguration.response_type = 'id_token token';
+        openIDImplicitFlowConfiguration.response_type = 'code'; // 'id_token token' Implicit Flow
         openIDImplicitFlowConfiguration.scope = 'dataEventRecords openid';
         openIDImplicitFlowConfiguration.post_logout_redirect_uri =
             'https://localhost:44363/Unauthorized';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "angular-auth-oidc-client",
     "private": true,
     "version": "9.0.0",
-    "description": "An OpenID Connect Implicit Flow client for Angular",
+    "description": "An OpenID Connect Code Flow with PKCE,Implicit Flow client for Angular",
     "main": "./bundles/angular-auth-oidc-client.umd.js",
     "module": "./fesm5/angular-auth-oidc-client.js",
     "es2015": "./fesm2015/angular-auth-oidc-client.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "angular-auth-oidc-client",
     "private": true,
-    "version": "8.0.3",
+    "version": "9.0.0",
     "description": "An OpenID Connect Implicit Flow client for Angular",
     "main": "./bundles/angular-auth-oidc-client.umd.js",
     "module": "./fesm5/angular-auth-oidc-client.js",

--- a/src/services/oidc-security-state-validation.service.ts
+++ b/src/services/oidc-security-state-validation.service.ts
@@ -32,9 +32,10 @@ export class StateValidationService {
             return toReturn;
         }
 
-        if (this.authConfiguration.response_type === 'id_token token') {
+        if (this.authConfiguration.response_type === 'id_token token' || this.authConfiguration.response_type === 'code') {
             toReturn.access_token = result.access_token;
         }
+
         toReturn.id_token = result.id_token;
 
         toReturn.decoded_id_token = this.tokenHelperService.getPayloadFromToken(toReturn.id_token, false);
@@ -96,7 +97,7 @@ export class StateValidationService {
         }
 
         // flow id_token token
-        if (this.authConfiguration.response_type !== 'id_token token') {
+        if (this.authConfiguration.response_type !== 'id_token token' && this.authConfiguration.response_type !== 'code') {
             toReturn.authResponseIsValid = true;
             toReturn.state = ValidationResult.Ok;
             this.handleSuccessfulValidation();

--- a/src/services/oidc.security.common.ts
+++ b/src/services/oidc.security.common.ts
@@ -65,6 +65,16 @@ export class OidcSecurityCommon {
         this.store(this.storage_auth_nonce, value);
     }
 
+    private storage_code_verifier = 'code_verifier';
+
+    public get code_verifier(): string {
+        return this.retrieve(this.storage_code_verifier) || '';
+    }
+
+    public set code_verifier(value: string) {
+        this.store(this.storage_code_verifier, value);
+    }
+
     private storage_auth_state_control = 'authStateControl';
 
     public get authStateControl(): string {
@@ -126,6 +136,7 @@ export class OidcSecurityCommon {
             this.store(this.storage_access_token, '');
             this.store(this.storage_id_token, '');
             this.store(this.storage_user_data, '');
+            this.store(this.storage_code_verifier, '');
         }
     }
 

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -349,12 +349,10 @@ export class OidcSecurityService {
                     obj.session_state = session_state;
 
                     this.authorizedCodeFlowCallbackProcedure(obj);
-                    // this._onConfigurationLoaded.next(true);
                 }),
             catchError(error => {
-                    console.error(error);
-                    console.error(`OidcService code request ${this.authConfiguration.stsServer}`, error);
-                    // this._onConfigurationLoaded.next(false);
+                    this.loggerService.logError(error);
+                    this.loggerService.logError(`OidcService code request ${this.authConfiguration.stsServer}`);
                     return of(false);
                 })
             )

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -309,7 +309,7 @@ export class OidcSecurityService {
     }
 
     // Code Flow
-    requestTokensWithCode(code: string, state: string, session_state: string) {
+    requestTokensWithCode(code: string, state: string, session_state: string | null) {
         this._isModuleSetup
             .pipe(
                 filter((isModuleSetup: boolean) => isModuleSetup),
@@ -321,7 +321,7 @@ export class OidcSecurityService {
     }
 
     // Code Flow with PCKE
-    requestTokensWithCodeProcedure(code: string, state: string, session_state: string) {
+    requestTokensWithCodeProcedure(code: string, state: string, session_state: string | null) {
         let tokenRequestUrl = '';
         if (this.authWellKnownEndpoints && this.authWellKnownEndpoints.token_endpoint) {
             tokenRequestUrl = `${this.authWellKnownEndpoints.token_endpoint}`;

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -322,7 +322,10 @@ export class OidcSecurityService {
 
     // Code Flow with PCKE
     requestTokensWithCodeProcedure(code: string, state: string, session_state: string) {
-        const tokenRequestUrl = `${this.authWellKnownEndpoints.token_endpoint}`;
+        let tokenRequestUrl = '';
+        if (this.authWellKnownEndpoints && this.authWellKnownEndpoints.token_endpoint) {
+            tokenRequestUrl = `${this.authWellKnownEndpoints.token_endpoint}`;
+        }
 
         // TODO validate state early instead of waiting for the callback with the tokens
 
@@ -947,7 +950,7 @@ export class OidcSecurityService {
             const state = params.get('state');
             const session_state = params.get('session_state');
             const error = params.get('error');
-            if (code) {
+            if (code && state && session_state) {
                 this.requestTokensWithCodeProcedure(code, state, session_state);
             }
             if (error) {

--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -309,6 +309,21 @@ export class OidcSecurityService {
     }
 
     // Code Flow
+    authorizedCallbackWithCode(urlToCheck: string) {
+        const urlParts = urlToCheck.split('?');
+        const params = new HttpParams({
+            fromString: urlParts[1]
+        });
+        const code = params.get('code');
+        const state = params.get('state');
+        const session_state = params.get('session_state');
+
+        if (code && state && session_state) {
+            this.requestTokensWithCode(code, state, session_state);
+        }
+    }
+
+    // Code Flow
     requestTokensWithCode(code: string, state: string, session_state: string | null) {
         this._isModuleSetup
             .pipe(

--- a/src/services/oidc.security.validation.ts
+++ b/src/services/oidc.security.validation.ts
@@ -305,6 +305,10 @@ export class OidcSecurityValidation {
             return true;
         }
 
+        if (response_type === 'code') {
+            return true;
+        }
+
         this.loggerService.logWarning('module configure incorrect, invalid response_type:' + response_type);
         return false;
     }
@@ -350,6 +354,13 @@ export class OidcSecurityValidation {
         const hash = KJUR.crypto.Util.hashString(access_token, 'sha256');
         const first128bits = hash.substr(0, hash.length / 2);
         const testdata = hextob64u(first128bits);
+
+        return testdata;
+    }
+
+    generate_code_verifier(code_challenge: any): string {
+        const hash = KJUR.crypto.Util.hashString(code_challenge, 'sha256');
+        const testdata = hextob64u(hash);
 
         return testdata;
     }

--- a/tests/services/oidc.security.service.spec.ts
+++ b/tests/services/oidc.security.service.spec.ts
@@ -270,7 +270,7 @@ describe('OidcSecurityService', () => {
         expect(value).toEqual(expectValue);
     });
 
-    it('authorizedCallback should correctly parse hash params', () => {
+    it('authorizedImplicitFlowCallback should correctly parse hash params', () => {
         spyOn(oidcSecurityService, 'getSigningKeys').and.returnValue(empty());
 
         const resultSetter = spyOnProperty(
@@ -286,7 +286,7 @@ describe('OidcSecurityService', () => {
             state: 'testState',
         };
 
-        (oidcSecurityService as OidcSecurityService).authorizedCallback(hash);
+        (oidcSecurityService as OidcSecurityService).authorizedImplicitFlowCallback(hash);
 
         expect(resultSetter).not.toHaveBeenCalled();
 
@@ -299,7 +299,7 @@ describe('OidcSecurityService', () => {
         expectedResult['access_token'] = 'ACCESS-TOKEN==';
         expectedResult['state'] = 'test=State';
 
-        (oidcSecurityService as OidcSecurityService).authorizedCallback(hash);
+        (oidcSecurityService as OidcSecurityService).authorizedImplicitFlowCallback(hash);
         expect(resultSetter).toHaveBeenCalledWith(expectedResult);
     });
 

--- a/tests/services/oidc.security.service.spec.ts
+++ b/tests/services/oidc.security.service.spec.ts
@@ -77,6 +77,7 @@ describe('OidcSecurityService', () => {
         oidcSecurityService.setupModule(openIDImplicitFlowConfiguration);
 
         let value = oidcSecurityService.createAuthorizeUrl(
+		    false, '', // Implicit Flow
             openIDImplicitFlowConfiguration.redirect_url,
             'nonce',
             'state',
@@ -113,6 +114,7 @@ describe('OidcSecurityService', () => {
         oidcSecurityService.authConfiguration.init(openIDImplicitFlowConfiguration);
 
         let value = oidcSecurityService.createAuthorizeUrl(
+		    false, '', // Implicit Flow
             openIDImplicitFlowConfiguration.redirect_url,
             'nonce',
             'state',
@@ -184,6 +186,7 @@ describe('OidcSecurityService', () => {
         });
 
         let value = oidcSecurityService.createAuthorizeUrl(
+		    false, '', // Implicit Flow
             openIDImplicitFlowConfiguration.redirect_url,
             'nonce',
             'state',
@@ -225,6 +228,7 @@ describe('OidcSecurityService', () => {
         });
 
         let value = oidcSecurityService.createAuthorizeUrl(
+		    false, '', // Implicit Flow
             openIDImplicitFlowConfiguration.redirect_url,
             'nonce',
             'state',


### PR DESCRIPTION
## Details planned released 9.0.0

- OIDC Code Flow with PKCE
- Uses silent renew to get new access tokens
- no support for refresh tokens
- still support for OIDC Implicit Flow

## Breaking changes

Implicit flow callback renamed from authorizedCallback() to authorizedImplicitFlowCallback()

## Docs 
Added to the readme, API docs

## Usage diffs to Implicit Flow

-  response_type :"code"
-  handle callback:

```javascript
private doCallbackLogicIfRequired() {
        console.log(window.location);
        // Will do a callback, if the url has a code and state parameter.
        this.oidcSecurityService.authorizedCallbackWithCode(window.location.toString());
}
```
- silent renew:
```javascript
window.onload = function () {
            /* The parent window hosts the Angular application */
            var parent = window.parent;
            /* Send the id_token information to the oidc message handler */
            var event = new CustomEvent('oidc-silent-renew-message', { detail: window.location });
            parent.dispatchEvent(event);
        };
```