### PR TITLE
use !! to display getIdToken() and _userData.value in silentRenewHear…

### DIFF
--- a/src/services/oidc.security.service.ts
+++ b/src/services/oidc.security.service.ts
@@ -839,8 +839,8 @@ export class OidcSecurityService {
             this.loggerService.logDebug(
                 'silentRenewHeartBeatCheck\r\n' +
                     `\tsilentRenewRunning: ${this.oidcSecurityCommon.silentRenewRunning === 'running'}\r\n` +
-                    `\tidToken: ${this.getIdToken() != null}\r\n` +
-                    `\t_userData.value: ${this._userData.value != null}`
+                    `\tidToken: ${!!this.getIdToken()}\r\n` +
+                    `\t_userData.value: ${!!this._userData.value}`
             );
             if (this._userData.value && this.oidcSecurityCommon.silentRenewRunning !== 'running' && this.getIdToken()) {
                 if (


### PR DESCRIPTION
…tBeatCheck()

These properties are string-based and eventually both stored in the localStorage/sessionStorage. When they are cleared in the other parts of the library, an empty string is set instead, which later leads to an incorrect debug logging in the console if it's being compared against `null` (as of now):

```
> window.localStorage.setItem('someKey', '')
> window.localStorage.getItem('someKey') != null
true
> !!window.localStorage.getItem('someKey')
false
```

