### PR TITLE
Update app.module.ts

### DIFF
--- a/projects/sample-code-flow/src/app/app.module.ts
+++ b/projects/sample-code-flow/src/app/app.module.ts
@@ -12,7 +12,7 @@ import {
 import { AppComponent } from './app.component';
 
 export function loadConfig(oidcConfigService: OidcConfigService) {
-    return () => oidcConfigService.loadUsingStsServer('https://offeringsolutions-sts.azurewebsites.net');
+    return () => oidcConfigService.load_using_stsServer('https://offeringsolutions-sts.azurewebsites.net');
 }
 
 @NgModule({


### PR DESCRIPTION
Changed to method load_using_stsServer().

Also who is owner of https://offeringsolutions-sts.azurewebsites.net pls add http://localhost:4200 in allowed callbacks, as with this sample auth server rejects auth request with message:
>Sign in
>Sorry, but we’re having trouble signing you in.

>AADSTS50011: The reply url specified in the request does not match the reply urls configured for the application: '99eb0b9d-ca40-476e-b5ac-6f4c32bfb530'.