### PR TITLE
Added a try catch to handle the CORS error that is thrown if the pare…

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/services/existing-iframe.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/existing-iframe.service.ts
@@ -25,7 +25,11 @@ export class IFrameService {
     }
 
     private getIFrameFromParentWindow(identifier: string) {
-        return window.parent.document.getElementById(identifier);
+        try {
+            return window.parent.document.getElementById(identifier);
+        } catch (e) {
+            return null;
+        }
     }
 
     private getIFrameFromWindow(identifier: string) {


### PR DESCRIPTION
PR to fix the CORS error thrown when the parent window is a different origin. Added a try catch around the call to get the iframe from the parent, returns null in the catch. Tested on Chrome v75.0.3770.100 &    Safari v11.0.1.