### PR TITLE
Ability to change the amount of seconds for the IsAuthorizedRace to do a Timeout

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -166,6 +166,10 @@ If this is active, the history is not cleaned up at an authorize callback. This 
 
 default value : 3
 
+### isauthorizedrace_timeout_in_seconds
+
+default value : 5
+
 ### disable_iat_offset_validation
 
 default value : false

--- a/projects/angular-auth-oidc-client/src/lib/models/auth.configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/models/auth.configuration.ts
@@ -22,6 +22,7 @@ export interface OpenIdConfiguration {
   iss_validation_off?: boolean;
   history_cleanup_off?: boolean;
   max_id_token_iat_offset_allowed_in_seconds?: number;
+  isauthorizedrace_timeout_in_seconds?: number;
   disable_iat_offset_validation?: boolean;
   storage?: any;
 }
@@ -50,6 +51,7 @@ export interface OpenIdInternalConfiguration {
   iss_validation_off: boolean;
   history_cleanup_off: boolean;
   max_id_token_iat_offset_allowed_in_seconds: number;
+  isauthorizedrace_timeout_in_seconds: number;
   disable_iat_offset_validation: boolean;
   storage: any;
 }

--- a/projects/angular-auth-oidc-client/src/lib/services/auth-configuration.provider.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/auth-configuration.provider.ts
@@ -30,6 +30,7 @@ export class ConfigurationProvider {
         iss_validation_off: false,
         history_cleanup_off: false,
         max_id_token_iat_offset_allowed_in_seconds: 3,
+        isauthorizedrace_timeout_in_seconds: 5,
         disable_iat_offset_validation: false,
         storage: typeof Storage !== 'undefined' ? sessionStorage : null,
     };

--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
@@ -98,8 +98,8 @@ export class OidcSecurityService {
                             tap(() => this.loggerService.logDebug('IsAuthorizedRace: Silent Renew Refresh Session Complete')),
                             map(() => true)
                         ),
-                        timer(5000).pipe(
-                            // backup, if nothing happens after 5 seconds stop waiting and emit
+                        timer(this.configurationProvider.openIDConfiguration.isauthorizedrace_timeout_in_seconds * 1000).pipe(
+                            // backup, if nothing happens after X seconds stop waiting and emit (5s Default)
                             tap(() => {
                                 this.resetAuthorizationData(false);
                                 this.oidcSecurityCommon.authNonce = '';

--- a/projects/angular-auth-oidc-client/src/tests/services/config.provider.spec.ts
+++ b/projects/angular-auth-oidc-client/src/tests/services/config.provider.spec.ts
@@ -73,6 +73,7 @@ describe('ConfigurationProviderTests', () => {
             iss_validation_off: false,
             history_cleanup_off: false,
             max_id_token_iat_offset_allowed_in_seconds: 3,
+            isauthorizedrace_timeout_in_seconds: 5,
             disable_iat_offset_validation: false,
             storage: sessionStorage,
         };
@@ -111,6 +112,7 @@ describe('ConfigurationProviderTests', () => {
             iss_validation_off: false,
             history_cleanup_off: false,
             max_id_token_iat_offset_allowed_in_seconds: 3,
+            isauthorizedrace_timeout_in_seconds: 5,
             disable_iat_offset_validation: false,
             storage: sessionStorage,
         };
@@ -151,6 +153,7 @@ describe('ConfigurationProviderTests', () => {
             iss_validation_off: false,
             history_cleanup_off: false,
             max_id_token_iat_offset_allowed_in_seconds: 3,
+            isauthorizedrace_timeout_in_seconds: 5,
             disable_iat_offset_validation: false,
             storage: sessionStorage,
         };


### PR DESCRIPTION
I've been having an issue that if I run the STS server locally or through a very slow connection (I have no other option) the request sometimes takes longer than 5 seconds (I know it isn't normal). Then, if the value for “IsAuthorizedRace” Timeout is hard-coded I do not have the ability to change it, so that my "slower" request can retrieve the Token and Log In to my applications. Adding a configurable parameters maintain the default value of 5 seconds, would help for people with those extreme cases.

Thanks.