### PR TITLE
Do not check idToken nonce when using refreshToken

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
@@ -696,6 +696,8 @@ export class OidcSecurityService {
                 const refresh_token = this.oidcSecurityCommon.getRefreshToken();
                 if (refresh_token) {
                     this.loggerService.logDebug('found refresh code, obtaining new credentials with refresh code');
+                    // Nonce is not used with refresh tokens
+                    this.oidcSecurityCommon.authNonce = OidcSecurityValidation.RefreshTokenNoncePlaceholder;
                     return this.refreshTokensWithCodeProcedure(refresh_token, state);
                 } else {
                     this.loggerService.logDebug('no refresh token found, using silent renew');

--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.validation.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.validation.ts
@@ -48,6 +48,9 @@ import { LoggerService } from './oidc.logger.service';
 
 @Injectable()
 export class OidcSecurityValidation {
+
+    static RefreshTokenNoncePlaceholder = '--RefreshToken--';
+
     constructor(
         private arrayHelperService: EqualityHelperService,
         private tokenHelperService: TokenHelperService,
@@ -138,8 +141,8 @@ export class OidcSecurityValidation {
     // id_token C8: The iat Claim can be used to reject tokens that were issued too far away from the current time,
     // limiting the amount of time that nonces need to be stored to prevent attacks.The acceptable range is Client specific.
     validate_id_token_iat_max_offset(dataIdToken: any,
-        max_offset_allowed_in_seconds: number,
-        disable_iat_offset_validation: boolean): boolean {
+                                     max_offset_allowed_in_seconds: number,
+                                     disable_iat_offset_validation: boolean): boolean {
 
         if (disable_iat_offset_validation) {
             return true;
@@ -171,7 +174,8 @@ export class OidcSecurityValidation {
     // that was sent in the Authentication Request.The Client SHOULD check the nonce value for replay attacks.
     // The precise method for detecting replay attacks is Client specific.
     validate_id_token_nonce(dataIdToken: any, local_nonce: any): boolean {
-        if (dataIdToken.nonce !== local_nonce) {
+        const isFromRefreshToken = dataIdToken.nonce === undefined && local_nonce === OidcSecurityValidation.RefreshTokenNoncePlaceholder;
+        if (!isFromRefreshToken && dataIdToken.nonce !== local_nonce) {
             this.loggerService.logDebug('Validate_id_token_nonce failed, dataIdToken.nonce: ' + dataIdToken.nonce + ' local_nonce:' + local_nonce);
             return false;
         }


### PR DESCRIPTION
Should fix #491 (and maybe #479)

This PR disables the nonce check when receiving an authorization code response after requesting a token with a refresh token as these do not contain a nonce.