### PR TITLE
generic OidcSecurityService.getUserData

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -424,12 +424,12 @@ import { OidcSecurityService } from 'angular-auth-oidc-client';
 })
 export class ExampleComponent implements OnInit, OnDestroy {
     userDataSubscription: Subscription;
-    userData: boolean;
+    userData: { name: string };
 
     constructor(public oidcSecurityService: OidcSecurityService) {}
 
     ngOnInit() {
-        this.userDataSubscription = this.oidcSecurityService.getUserData().subscribe((userData: any) => {
+        this.userDataSubscription = this.oidcSecurityService.getUserData<{ name: string }>().subscribe(userData => {
             this.userData = userData;
         });
     }

--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
@@ -200,7 +200,7 @@ export class OidcSecurityService {
         }
     }
 
-    getUserData(): Observable<any> {
+    getUserData<T = any>(): Observable<T> {
         return this._userData.asObservable();
     }
 


### PR DESCRIPTION
A more generic way for OidcSecurityService.getUserData

Therefore result of getUserData must not be casted.