### PR TITLE
fixed possible memory leak in silent renew

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/services/existing-iframe.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/existing-iframe.service.ts
@@ -5,17 +5,19 @@ import { LoggerService } from './oidc.logger.service';
 export class IFrameService {
     constructor(private loggerService: LoggerService) {}
 
-    getExistingIFrame(identifier: string) {
+    getExistingIFrame(identifier: string): HTMLIFrameElement | null {
         const iFrameOnParent = this.getIFrameFromParentWindow(identifier);
-
-        if (iFrameOnParent) {
+        if (this.isIFrameElement(iFrameOnParent)) {
             return iFrameOnParent;
         }
-
-        return this.getIFrameFromWindow(identifier);
+        const iFrameOnSelf = this.getIFrameFromWindow(identifier);
+        if (this.isIFrameElement(iFrameOnSelf)) {
+            return iFrameOnSelf;
+        }
+        return null;
     }
 
-    addIFrameToWindowBody(identifier: string) {
+    addIFrameToWindowBody(identifier: string): HTMLIFrameElement {
         const sessionIframe = window.document.createElement('iframe');
         sessionIframe.id = identifier;
         this.loggerService.logDebug(sessionIframe);
@@ -24,15 +26,27 @@ export class IFrameService {
         return sessionIframe;
     }
 
-    private getIFrameFromParentWindow(identifier: string) {
+    private getIFrameFromParentWindow(identifier: string): HTMLIFrameElement | null {
         try {
-            return window.parent.document.getElementById(identifier);
+            const iFrameElement = window.parent.document.getElementById(identifier);
+            if (this.isIFrameElement(iFrameElement)) {
+                return iFrameElement;
+            }
+            return null;
         } catch (e) {
             return null;
         }
     }
 
-    private getIFrameFromWindow(identifier: string) {
-        return window.document.getElementById(identifier);
+    private getIFrameFromWindow(identifier: string): HTMLIFrameElement | null {
+        const iFrameElement = window.document.getElementById(identifier);
+        if (this.isIFrameElement(iFrameElement)) {
+            return iFrameElement;
+        }
+        return null;
+    }
+
+    private isIFrameElement(element: HTMLElement | null): element is HTMLIFrameElement {
+        return !!element && element instanceof HTMLIFrameElement;
     }
 }

--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
@@ -114,7 +114,7 @@ export class OidcSecurityService {
                 if (this.oidcSecurityCommon.authNonce === '' || this.oidcSecurityCommon.authNonce === undefined) {
                     // login not running, or a second silent renew, user must login first before this will work.
                     this.loggerService.logDebug('Silent Renew or login not running, try to refresh the session');
-                    this.refreshSession();
+                    this.refreshSession().subscribe();
                 }
 
                 return race$;
@@ -675,9 +675,9 @@ export class OidcSecurityService {
         }
     }
 
-    refreshSession(): Observable<any> {
+    refreshSession(): Observable<boolean> {
         if (!this.configurationProvider.openIDConfiguration.silent_renew) {
-            return from([false]);
+            return of(false);
         }
 
         this.loggerService.logDebug('BEGIN refresh session Authorize');
@@ -744,7 +744,7 @@ export class OidcSecurityService {
         }
 
         this.oidcSecurityCommon.silentRenewRunning = 'running';
-        return this.oidcSecuritySilentRenew.startRenew(url);
+        return this.oidcSecuritySilentRenew.startRenew(url).pipe(map(() => true));
     }
 
     handleError(error: any) {

--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.silent-renew.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.silent-renew.ts
@@ -1,5 +1,5 @@
 ﻿import { Injectable } from '@angular/core';
-import { Observable, Observer } from 'rxjs';
+import { Observable } from 'rxjs';
 import { IFrameService } from './existing-iframe.service';
 import { LoggerService } from './oidc.logger.service';
 
@@ -7,35 +7,29 @@ const IFRAME_FOR_SILENT_RENEW_IDENTIFIER = 'myiFrameForSilentRenew';
 
 @Injectable()
 export class OidcSecuritySilentRenew {
-    private sessionIframe: any;
-    private isRenewInitialized = false;
-
     constructor(private loggerService: LoggerService, private iFrameService: IFrameService) {}
 
-    initRenew() {
+    initRenew(): HTMLIFrameElement {
         const existingIFrame = this.iFrameService.getExistingIFrame(IFRAME_FOR_SILENT_RENEW_IDENTIFIER);
-
         if (!existingIFrame) {
-            this.iFrameService.addIFrameToWindowBody(IFRAME_FOR_SILENT_RENEW_IDENTIFIER);
+            return this.iFrameService.addIFrameToWindowBody(IFRAME_FOR_SILENT_RENEW_IDENTIFIER);
         }
-
-        this.isRenewInitialized = true;
+        return existingIFrame;
     }
 
-    startRenew(url: string): Observable<any> {
-        if (!this.isRenewInitialized) {
-            this.initRenew();
-        }
-
-        this.sessionIframe = this.iFrameService.getExistingIFrame(IFRAME_FOR_SILENT_RENEW_IDENTIFIER);
-
+    startRenew(url: string): Observable<void> {
+        const sessionIframe = this.initRenew();
         this.loggerService.logDebug('startRenew for URL:' + url);
-        this.sessionIframe.contentWindow.location.replace(url);
-
-        return Observable.create((observer: Observer<any>) => {
-            this.sessionIframe.onload = () => {
-                observer.next(this);
+        return new Observable<void>(observer => {
+            const onLoadHandler = () => {
+                sessionIframe.removeEventListener('load', onLoadHandler);
+                observer.next(undefined);
                 observer.complete();
+            };
+            sessionIframe.addEventListener('load', onLoadHandler);
+            sessionIframe.src = url;
+            return () => {
+                sessionIframe.removeEventListener('load', onLoadHandler);
             };
         });
     }


### PR DESCRIPTION
- IFrameService
  - only return typesafe HTMLIFrameElement
---
- OidcSecuritySilentRenew
  - made service stateless   
  - fix: sessionIframe.contentWindow could sometimes be null (if DOM has yet to finish loading iframe element), replaced be setting sessionIframe.src attribute
  - fix: removed possible memory leak in sessionIframe.onload (never removed listener)
---
- OidcSecurityService
  - fix: not all usage of refreshSession subscribed
  - line 176; this.oidcSecuritySilentRenew.initRenew(); seems kind of obsolete now?

