### PR TITLE
Added renew process denotation to AuthorizationResult

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -492,7 +492,8 @@ Subscribe to the event:
         tap((authorizationResult: AuthorizationResult) => {
             console.log('Auth result received AuthorizationState:'
                 + authorizationResult.authorizationState
-                + ' validationResult:' + authorizationResult.validationResult);
+                + ' validationResult:' + authorizationResult.validationResult
+                + ' isRenewProcess:' + authorizationResult.isRenewProcess);
         }),
         map((authorizationResult: AuthorizationResult) => authorizationResult.authorizationState),
         filter((authorizationState: AuthorizationState) => authorizationState === AuthorizationState.unauthorized)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-auth-oidc-client",
-    "version": "10.0.7",
+    "version": "10.0.10",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/projects/angular-auth-oidc-client/src/lib/models/authorization-result.ts
+++ b/projects/angular-auth-oidc-client/src/lib/models/authorization-result.ts
@@ -4,6 +4,7 @@ import { ValidationResult } from './validation-result.enum';
 export class AuthorizationResult {
     constructor(
         public authorizationState: AuthorizationState,
-        public validationResult: ValidationResult
+        public validationResult: ValidationResult,
+        public isRenewProcess: boolean = false
     ) {}
 }


### PR DESCRIPTION
When subscribing to `onAuthorizationResult`, there is no convenient way to determine if the AuthorizationResult is the result of the auto-renewal process or if it comes from an explicit login event. Most of the various handlers in the `OidcSecurityService` already had some knowledge as to whether the source of the event was from the auto-renewal process. So I added a new boolean field, `isRenewProcess`, to AuthorizationResult and updated the subject updates to include the new field.
