### PR TITLE
PCKE proper access token request.

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.service.ts
@@ -413,17 +413,12 @@ export class OidcSecurityService {
             return throwError(new Error('incorrect state'));
         }
 
-        let headers: HttpHeaders = new HttpHeaders();
-        headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
+        const headers: HttpHeaders = new HttpHeaders()
+          .set('Content-Type', 'application/x-www-form-urlencoded');
 
-        let data =
+        const data =
             `grant_type=authorization_code&client_id=${this.configurationProvider.openIDConfiguration.client_id}` +
             `&code_verifier=${this.oidcSecurityCommon.code_verifier}&code=${code}&redirect_uri=${this.configurationProvider.openIDConfiguration.redirect_url}`;
-        if (this.oidcSecurityCommon.silentRenewRunning === 'running') {
-            data =
-                `grant_type=authorization_code&client_id=${this.configurationProvider.openIDConfiguration.client_id}` +
-                `&code_verifier=${this.oidcSecurityCommon.code_verifier}&code=${code}&redirect_uri=${this.configurationProvider.openIDConfiguration.silent_renew_url}`;
-        }
 
         return this.httpClient.post(tokenRequestUrl, data, { headers: headers }).pipe(
             map(response => {


### PR DESCRIPTION
According to RFC 7636 (4.5) and RFC 6749 (4.1.3): "if the "redirect_uri" parameter was included in the authorization request as described in Section 4.1.1, and their values MUST be identical."

redirect_uri should be the same for authorization request and for the access token request!

RFC 7636 (4.5): https://tools.ietf.org/html/rfc7636#section-4.5
RFC 6749 (4.1.3): https://tools.ietf.org/html/rfc6749#section-4.1.3

Should fix the next bug: https://github.com/damienbod/angular-auth-oidc-client/issues/498
And looks like should fix: https://github.com/damienbod/angular-auth-oidc-client/issues/519 and https://github.com/damienbod/angular-auth-oidc-client/issues/476