### PR TITLE
Update documentation

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -317,7 +317,7 @@ Handle the authorize callback using the event:
 ```typescript
  private onModuleSetup() {
         if (window.location.hash) {
-            this.oidcSecurityService.authorizedCallback();
+            this.oidcSecurityService.authorizedImplicitFlowCallback();
         }
     }
 ```


### PR DESCRIPTION
In release 9 the authorizedCallback () method was changed to authorizedImplicitFlowCallback (), this was updated in README but not in the documentation.