### PR TITLE
adding a property to the OpenIdConfiguration model to allow for a cus…

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/models/auth.configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/models/auth.configuration.ts
@@ -25,6 +25,7 @@ export interface OpenIdConfiguration {
   isauthorizedrace_timeout_in_seconds?: number;
   disable_iat_offset_validation?: boolean;
   storage?: any;
+  custom_discovery_url?: string;
 }
 
 export interface OpenIdInternalConfiguration {

--- a/projects/angular-auth-oidc-client/src/lib/services/oidc.security.config.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/services/oidc.security.config.service.ts
@@ -5,81 +5,80 @@ import { catchError, switchMap } from 'rxjs/operators';
 import { LoggerService } from './oidc.logger.service';
 
 export interface ConfigResult {
-    authWellknownEndpoints: any;
-    customConfig: any;
+  authWellknownEndpoints: any;
+  customConfig: any;
 }
 
 @Injectable()
 export class OidcConfigService {
-    private configurationLoadedInternal = new ReplaySubject<ConfigResult>(1);
+  private configurationLoadedInternal = new ReplaySubject<ConfigResult>(1);
 
-    public get onConfigurationLoaded(): Observable<ConfigResult> {
-        return this.configurationLoadedInternal.asObservable();
+  public get onConfigurationLoaded(): Observable<ConfigResult> {
+    return this.configurationLoadedInternal.asObservable();
+  }
+
+  constructor(private readonly loggerService: LoggerService, private readonly httpClient: HttpClient) { }
+
+  load(configUrl: string) {
+    return this.httpClient
+      .get(configUrl)
+      .pipe(
+        switchMap(clientConfiguration => {
+          return this.loadUsingConfiguration(clientConfiguration);
+        }),
+        catchError(error => {
+          this.loggerService.logError(`OidcConfigService 'load' threw an error on calling ${configUrl}`, error);
+          this.configurationLoadedInternal.next(undefined);
+          return of(false);
+        })
+      )
+      .toPromise();
+  }
+
+  load_using_stsServer(stsServer: string) {
+    return this.loadUsingConfiguration({ stsServer }).toPromise();
+  }
+
+  load_using_custom_stsServer(url: string) {
+    return this.httpClient
+      .get(url)
+      .pipe(
+        switchMap(wellKnownEndpoints => {
+          this.configurationLoadedInternal.next({
+            authWellknownEndpoints: wellKnownEndpoints,
+            customConfig: { stsServer: url },
+          });
+          return of(true);
+        }),
+        catchError(error => {
+          this.loggerService.logError(`OidcConfigService 'load_using_custom_stsServer' threw an error on calling ${url}`, error);
+          this.configurationLoadedInternal.next(undefined);
+          return of(false);
+        })
+      )
+      .toPromise();
+  }
+
+  private loadUsingConfiguration(clientConfig: any) {
+    if (!clientConfig.stsServer) {
+      this.loggerService.logError(`Property 'stsServer' is not present of passed config ${JSON.stringify(clientConfig)}`, clientConfig);
+      throw new Error(`Property 'stsServer' is not present of passed config ${JSON.stringify(clientConfig)}`);
     }
 
-    constructor(private readonly loggerService: LoggerService, private readonly httpClient: HttpClient) { }
-
-    load(configUrl: string) {
-        return this.httpClient
-            .get(configUrl)
-            .pipe(
-                switchMap(clientConfiguration => {
-                    return this.loadUsingConfiguration(clientConfiguration);
-                }),
-                catchError(error => {
-                    this.loggerService.logError(`OidcConfigService 'load' threw an error on calling ${configUrl}`, error);
-                    this.configurationLoadedInternal.next(undefined);
-                    return of(false);
-                })
-            )
-            .toPromise();
-    }
-
-    load_using_stsServer(stsServer: string) {
-        return this.loadUsingConfiguration({ stsServer }).toPromise();
-    }
-
-    load_using_custom_stsServer(url: string) {
-        return this.httpClient
-            .get(url)
-            .pipe(
-                switchMap(wellKnownEndpoints => {
-                    this.configurationLoadedInternal.next({
-                        authWellknownEndpoints: wellKnownEndpoints,
-                        customConfig: { stsServer: url },
-                    });
-                    return of(true);
-                }),
-                catchError(error => {
-                    this.loggerService.logError(`OidcConfigService 'load_using_custom_stsServer' threw an error on calling ${url}`, error);
-                    this.configurationLoadedInternal.next(undefined);
-                    return of(false);
-                })
-            )
-            .toPromise();
-    }
-
-    private loadUsingConfiguration(clientConfig: any) {
-        if (!clientConfig.stsServer) {
-            this.loggerService.logError(`Property 'stsServer' is not present of passed config ${JSON.stringify(clientConfig)}`, clientConfig);
-            throw new Error(`Property 'stsServer' is not present of passed config ${JSON.stringify(clientConfig)}`);
-        }
-
-        const url = `${clientConfig.stsServer}/.well-known/openid-configuration`;
-
-        return this.httpClient.get(url).pipe(
-            switchMap(wellKnownEndpoints => {
-                this.configurationLoadedInternal.next({
-                    authWellknownEndpoints: wellKnownEndpoints,
-                    customConfig: clientConfig,
-                });
-                return of(true);
-            }),
-            catchError(error => {
-                this.loggerService.logError(`OidcConfigService 'load_using_stsServer' threw an error on calling ${url}`, error);
-                this.configurationLoadedInternal.next(undefined);
-                return of(false);
-            })
-        );
-    }
+    const url = `${clientConfig.stsServer}${clientConfig.custom_discovery_url ? clientConfig.custom_discovery_url : "/.well-known/openid-configuration"}`;
+    return this.httpClient.get(url).pipe(
+      switchMap(wellKnownEndpoints => {
+        this.configurationLoadedInternal.next({
+          authWellknownEndpoints: wellKnownEndpoints,
+          customConfig: clientConfig,
+        });
+        return of(true);
+      }),
+      catchError(error => {
+        this.loggerService.logError(`OidcConfigService 'load_using_stsServer' threw an error on calling ${url}`, error);
+        this.configurationLoadedInternal.next(undefined);
+        return of(false);
+      })
+    );
+  }
 }


### PR DESCRIPTION
custom discovery url, along with a change in the security.config service on line 68 to add a check to see if a custom url exists and if not to fall back to the default.

This is in regards to issue 539... The case for a custom discovery url is sometimes asked for in such cases as the following: http://www.hl7.org/fhir/smart-app-launch/#for-example in section 6.1.1 they refer to the meta data url (pretty much the discovery url) as  .well-known/smart-configuration.json instead of  .well-known/openid-configuration.json and to support these cases is why I think this pull request should be merged into the master branch