### PR TITLE
Use the race observable instead of the deprecated RxJS race operator 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "angular-auth-oidc-client",
-    "version": "10.0.13",
+    "version": "10.0.15",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
The use of the operator version of `race` is deprecated.
https://rxjs.dev/api/operators/race

Updated the code to use the observable version of `race`.
https://rxjs.dev/api/index/function/race

This improves the readability and understandability of the code in my opinion. That is most probably also the reason they deprecated the operator version.