### PR TITLE
Load checksession iframe right after checkSessionService.start() is invoked

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
@@ -1,4 +1,5 @@
 import { async, TestBed } from '@angular/core/testing';
+import { of } from 'rxjs';
 import { ConfigurationProvider } from '../config/config.provider';
 import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
@@ -167,6 +168,44 @@ describe('SecurityCheckSessionTests', () => {
             spyOnProperty(configurationProvider, 'openIDConfiguration').and.returnValue({ startCheckSession: true });
             const result = checkSessionService.serverStateChanged();
             expect(result).toBeTrue();
+        });
+    });
+
+    describe('pollServerSession', () => {
+        beforeEach(() => {
+            spyOn<any>(checkSessionService, 'init').and.returnValue(of(undefined));
+        });
+
+        it('increases outstandingMessages', () => {
+            spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({});
+            spyOn(storagePersistanceService, 'read').withArgs('session_state').and.returnValue('session_state');
+            spyOn(loggerService, 'logDebug').and.callFake(() => {});
+            (checkSessionService as any).pollServerSession('clientId');
+            expect((checkSessionService as any).outstandingMessages).toBe(1);
+        });
+
+        it('logs warning if iframe does not exist', () => {
+            spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue(null);
+            const spyLogWarning = spyOn(loggerService, 'logWarning').and.callFake(() => {});
+            spyOn(loggerService, 'logDebug').and.callFake(() => {});
+            (checkSessionService as any).pollServerSession('clientId');
+            expect(spyLogWarning).toHaveBeenCalledWith('OidcSecurityCheckSession pollServerSession checkSession IFrame does not exist');
+        });
+
+        it('logs warning if clientId is not set', () => {
+            spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({});
+            const spyLogWarning = spyOn(loggerService, 'logWarning').and.callFake(() => {});
+            spyOn(loggerService, 'logDebug').and.callFake(() => {});
+            (checkSessionService as any).pollServerSession('');
+            expect(spyLogWarning).toHaveBeenCalledWith('OidcSecurityCheckSession pollServerSession checkSession IFrame does not exist');
+        });
+
+        it('logs debug if session_state is not set', () => {
+            spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({});
+            spyOn(storagePersistanceService, 'read').withArgs('session_state').and.returnValue(null);
+            const spyLogDebug = spyOn(loggerService, 'logDebug').and.callFake(() => {});
+            (checkSessionService as any).pollServerSession('clientId');
+            expect(spyLogDebug).toHaveBeenCalledWith('OidcSecurityCheckSession pollServerSession session_state is blank');
         });
     });
 });

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
@@ -180,6 +180,7 @@ describe('SecurityCheckSessionTests', () => {
             spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({ contentWindow: { postMessage: () => {} } });
             spyOn(storagePersistanceService, 'read').withArgs('session_state').and.returnValue('session_state');
             spyOn(loggerService, 'logDebug').and.callFake(() => {});
+            spyOnProperty(configurationProvider, 'openIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
             (checkSessionService as any).pollServerSession('clientId');
             expect((checkSessionService as any).outstandingMessages).toBe(1);
         });

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
@@ -177,7 +177,7 @@ describe('SecurityCheckSessionTests', () => {
         });
 
         it('increases outstandingMessages', () => {
-            spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({});
+            spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({ contentWindow: { postMessage: () => {} } });
             spyOn(storagePersistanceService, 'read').withArgs('session_state').and.returnValue('session_state');
             spyOn(loggerService, 'logDebug').and.callFake(() => {});
             (checkSessionService as any).pollServerSession('clientId');

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -125,6 +125,7 @@ export class CheckSessionService {
             });
         };
 
+        pollServerSessionRecur();
         this.zone.runOutsideAngular(() => {
             this.scheduledHeartBeatRunning = setInterval(pollServerSessionRecur, this.heartBeatInterval);
         });


### PR DESCRIPTION
Since `pollServerSessionRecur()` is called in setInterval, it used to be called for the first time after 3 seconds from when `checkSessionService.start()` was called.

I added a call to `pollServerSessionRecur()` before setInterval so that it is called also right after `checkSessionService.start()` is called.

Fixes #750