### PR TITLE
remove id_token expire check

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.spec.ts
@@ -180,7 +180,7 @@ describe('Auth State Service', () => {
             spyOn(authStateService as any, 'hasIdTokenExpired').and.returnValue(true);
             spyOn(authStateService as any, 'hasAccessTokenExpiredIfExpiryExists').and.returnValue(false);
             const result = authStateService.areAuthStorageTokensValid();
-            expect(result).toBeFalse();
+            expect(result).toBeTrue();
         });
 
         it('isAuthorized is true  and access_token is expired returns true', () => {

--- a/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.ts
@@ -26,7 +26,7 @@ export class AuthStateService {
         private publicEventsService: PublicEventsService,
         private configurationProvider: ConfigurationProvider,
         private tokenValidationService: TokenValidationService
-    ) {}
+    ) { }
 
     setAuthorizedAndFireEvent(): void {
         this.authorizedInternal$.next(true);
@@ -82,17 +82,24 @@ export class AuthStateService {
             return false;
         }
 
-        if (this.hasIdTokenExpired()) {
+        const idTokenExpired = this.hasIdTokenExpired();
+        const accessTokenExpired = this.hasAccessTokenExpiredIfExpiryExists();
+
+        if (idTokenExpired) {
             this.loggerService.logDebug('persisted id_token is expired');
-            return false;
+            //return false;
         }
 
-        if (this.hasAccessTokenExpiredIfExpiryExists()) {
+        if (accessTokenExpired) {
             this.loggerService.logDebug('persisted access_token is expired');
             return false;
         }
 
-        this.loggerService.logDebug('persisted id_token and access token are valid');
+        if (!idTokenExpired)
+            this.loggerService.logDebug('persisted id_token and access token are valid');
+        else
+            this.loggerService.logDebug('persisted access token is valid');
+
         return true;
     }
 

--- a/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.spec.ts
@@ -115,14 +115,13 @@ describe('PeriodicallyTokenCheckService', () => {
             expect(resetSilentRenewRunning).toHaveBeenCalled();
         }));
 
-        it('calls hasIdTokenExpired and hasAccessTokenExpiredIfExpiryExists only when it should be executed', fakeAsync(() => {
+        it('calls hasAccessTokenExpiredIfExpiryExists only when it should be executed', fakeAsync(() => {
             spyOnProperty(configurationProvider, 'openIDConfiguration').and.returnValue({ silentRenew: true });
             spyOn(flowHelper, 'isCurrentFlowCodeFlowWithRefeshTokens');
             spyOn(authStateService, 'getIdToken').and.returnValue('some-id-token');
             spyOn(flowsDataService, 'isSilentRenewRunning').and.returnValue(false);
             spyOn(userService, 'getUserDataFromStore').and.returnValue('some-userdata');
 
-            const hasIdTokenExpiredSpy = spyOn(authStateService, 'hasIdTokenExpired');
             const hasAccessTokenExpiredIfExpiryExistsSpy = spyOn(authStateService, 'hasAccessTokenExpiredIfExpiryExists');
 
             spyOn(refreshSessionIframeService, 'refreshSessionWithIframe').and.returnValue(of(true));
@@ -132,7 +131,6 @@ describe('PeriodicallyTokenCheckService', () => {
             intervallService.runTokenValidationRunning.unsubscribe();
             intervallService.runTokenValidationRunning = null;
 
-            expect(hasIdTokenExpiredSpy).toHaveBeenCalled();
             expect(hasAccessTokenExpiredIfExpiryExistsSpy).toHaveBeenCalled();
         }));
 
@@ -156,7 +154,6 @@ describe('PeriodicallyTokenCheckService', () => {
             intervallService.runTokenValidationRunning.unsubscribe();
             intervallService.runTokenValidationRunning = null;
 
-            expect(hasIdTokenExpiredSpy).toHaveBeenCalled();
             expect(hasAccessTokenExpiredIfExpiryExistsSpy).toHaveBeenCalled();
         }));
 

--- a/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.ts
@@ -25,7 +25,7 @@ export class PeriodicallyTokenCheckService {
         private refreshSessionIframeService: RefreshSessionIframeService,
         private refreshSessionRefreshTokenService: RefreshSessionRefreshTokenService,
         private intervallService: IntervallService
-    ) {}
+    ) { }
 
     startTokenValidationPeriodically(repeatAfterSeconds: number) {
         if (!!this.intervallService.runTokenValidationRunning || !this.configurationProvider.openIDConfiguration.silentRenew) {
@@ -50,10 +50,9 @@ export class PeriodicallyTokenCheckService {
                     return of(null);
                 }
 
-                const idTokenHasExpired = this.authStateService.hasIdTokenExpired();
                 const accessTokenHasExpired = this.authStateService.hasAccessTokenExpiredIfExpiryExists();
 
-                if (!idTokenHasExpired && !accessTokenHasExpired) {
+                if (!accessTokenHasExpired) {
                     return of(null);
                 }
 


### PR DESCRIPTION
The `id_token? should only be checked on receive to the client,
but not after it is persisted.