### PR TITLE
UTC time

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "bugs": {
         "url": "https://github.com/damienbod/angular-auth-oidc-client/issues"
     },
-    "version": "11.2.1",
+    "version": "11.2.2",
     "scripts": {
         "ng": "ng",
         "build": "npm run build-lib",

--- a/projects/angular-auth-oidc-client/package.json
+++ b/projects/angular-auth-oidc-client/package.json
@@ -36,6 +36,6 @@
         "authorization"
     ],
     "license": "MIT",
-    "version": "11.2.1",
+    "version": "11.2.2",
     "description": "Angular Lib for OpenID Connect & OAuth2"
 }

--- a/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.spec.ts
@@ -253,7 +253,7 @@ describe('Auth State Service', () => {
             const validateAccessTokenNotExpiredResult = true;
             const expectedResult = !validateAccessTokenNotExpiredResult;
             spyOnProperty(configurationProvider, 'openIDConfiguration', 'get').and.returnValue({ renewTimeBeforeTokenExpiresInSeconds: 5 });
-            const date = new Date();
+            const date = new Date(new Date().toUTCString());
             spyOn(storagePersistanceService, 'read').withArgs('access_token_expires_at').and.returnValue(date);
             const spy = spyOn(tokenValidationService, 'validateAccessTokenNotExpired').and.returnValue(validateAccessTokenNotExpiredResult);
             const result = authStateService.hasAccessTokenExpiredIfExpiryExists();
@@ -265,7 +265,7 @@ describe('Auth State Service', () => {
             const validateAccessTokenNotExpiredResult = false;
             const expectedResult = !validateAccessTokenNotExpiredResult;
             spyOnProperty(configurationProvider, 'openIDConfiguration', 'get').and.returnValue({ renewTimeBeforeTokenExpiresInSeconds: 5 });
-            const date = new Date();
+            const date = new Date(new Date().toUTCString());
 
             spyOn(eventsService, 'fireEvent');
 

--- a/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.ts
@@ -128,7 +128,7 @@ export class AuthStateService {
 
     private persistAccessTokenExpirationTime(authResult: any) {
         if (authResult?.expires_in) {
-            const accessTokenExpiryTime = new Date().valueOf() + authResult.expires_in * 1000;
+            const accessTokenExpiryTime = new Date(new Date().toUTCString()).valueOf() + authResult.expires_in * 1000;
             this.storagePersistanceService.write('access_token_expires_at', accessTokenExpiryTime);
         }
     }

--- a/projects/angular-auth-oidc-client/src/lib/utils/tokenHelper/oidc-token-helper.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/tokenHelper/oidc-token-helper.service.ts
@@ -8,7 +8,7 @@ export class TokenHelperService {
 
     getTokenExpirationDate(dataIdToken: any): Date {
         if (!dataIdToken.hasOwnProperty('exp')) {
-            return new Date();
+            return new Date(new Date().toUTCString());
         }
 
         const date = new Date(0); // The 0 here is the key, which sets the date to the epoch

--- a/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
@@ -74,7 +74,7 @@ export class TokenValidationService {
         }
 
         const tokenExpirationValue = tokenExpirationDate.valueOf();
-        const nowWithOffset = new Date().valueOf() + offsetSeconds * 1000;
+        const nowWithOffset = new Date(new Date().toUTCString()).valueOf() + offsetSeconds * 1000;
         const tokenNotExpired = tokenExpirationValue > nowWithOffset;
 
         this.loggerService.logDebug(`Has id_token expired: ${!tokenNotExpired}, ${tokenExpirationValue} > ${nowWithOffset}`);
@@ -91,7 +91,7 @@ export class TokenValidationService {
 
         offsetSeconds = offsetSeconds || 0;
         const accessTokenExpirationValue = accessTokenExpiresAt.valueOf();
-        const nowWithOffset = new Date().valueOf() + offsetSeconds * 1000;
+        const nowWithOffset = new Date(new Date().toUTCString()).valueOf() + offsetSeconds * 1000;
         const tokenNotExpired = accessTokenExpirationValue > nowWithOffset;
 
         this.loggerService.logDebug(`Has access_token expired: ${!tokenNotExpired}, ${accessTokenExpirationValue} > ${nowWithOffset}`);
@@ -180,12 +180,12 @@ export class TokenValidationService {
 
         this.loggerService.logDebug(
             'validate_id_token_iat_max_offset: ' +
-                (new Date().valueOf() - dateTimeIatIdToken.valueOf()) +
+                (new Date(new Date().toUTCString()).valueOf() - dateTimeIatIdToken.valueOf()) +
                 ' < ' +
                 maxOffsetAllowedInSeconds * 1000
         );
 
-        const diff = new Date().valueOf() - dateTimeIatIdToken.valueOf();
+        const diff = new Date(new Date().toUTCString()).valueOf() - dateTimeIatIdToken.valueOf();
         if (diff > 0) {
             return diff < maxOffsetAllowedInSeconds * 1000;
         }


### PR DESCRIPTION
Make sure to always use utc time when validating token.

closes #175

- tested and validated on several QA environments and already live in production.