### PR TITLE
Use window object safely by injecting DOCUMENT

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auth.module.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth.module.ts
@@ -29,7 +29,6 @@ import { FlowHelper } from './utils/flowHelper/flow-helper.service';
 import { PlatformProvider } from './utils/platform-provider/platform.provider';
 import { TokenHelperService } from './utils/tokenHelper/oidc-token-helper.service';
 import { UrlService } from './utils/url/url.service';
-import { WINDOW, _window } from './utils/window/window.reference';
 import { StateValidationService } from './validation/state-validation.service';
 import { TokenValidationService } from './validation/token-validation.service';
 
@@ -75,7 +74,6 @@ export class AuthModule {
                     provide: AbstractSecurityStorage,
                     useClass: token.storage || BrowserStorageService,
                 },
-                { provide: WINDOW, useFactory: _window, deps: [] },
             ],
         };
     }

--- a/projects/angular-auth-oidc-client/src/lib/flows/random/random.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/random/random.service.ts
@@ -1,9 +1,13 @@
-import { Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
 import { LoggerService } from '../../logging/logger.service';
 
 @Injectable()
 export class RandomService {
-    constructor(private loggerService: LoggerService) {}
+    constructor(
+      @Inject(DOCUMENT) private readonly doc: Document,
+      private loggerService: LoggerService,
+    ) {}
 
     createRandom(requiredLength: number): string {
         if (requiredLength <= 0) {
@@ -17,7 +21,9 @@ export class RandomService {
 
         const length = requiredLength - 6;
         const arr = new Uint8Array((length || length) / 2);
-        this.getCrypto().getRandomValues(arr);
+        if (this.getCrypto()) {
+          this.getCrypto().getRandomValues(arr);
+        }
         return Array.from(arr, this.toHex).join('') + this.randomString(7);
     }
 
@@ -25,20 +31,22 @@ export class RandomService {
         return ('0' + dec.toString(16)).substr(-2);
     }
 
-    private randomString(length) {
+    private randomString(length): string {
         let result = '';
         const characters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
         const values = new Uint32Array(length);
-        this.getCrypto().getRandomValues(values);
-        for (let i = 0; i < length; i++) {
-            result += characters[values[i] % characters.length];
+        if (this.getCrypto()) {
+          this.getCrypto().getRandomValues(values);
+          for (let i = 0; i < length; i++) {
+              result += characters[values[i] % characters.length];
+          }
         }
 
         return result;
     }
     private getCrypto() {
         // support for IE,  (window.crypto || window.msCrypto)
-        return window.crypto || (window as any).msCrypto;
+        return this.doc.defaultView.crypto || (this.doc.defaultView as any).msCrypto;
     }
 }

--- a/projects/angular-auth-oidc-client/src/lib/iframe/existing-iframe.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/existing-iframe.service.ts
@@ -1,9 +1,13 @@
-import { Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
 import { LoggerService } from '../logging/logger.service';
 
 @Injectable()
 export class IFrameService {
-    constructor(private loggerService: LoggerService) {}
+    constructor(
+      @Inject(DOCUMENT) private readonly doc: Document,
+      private loggerService: LoggerService,
+    ) {}
 
     getExistingIFrame(identifier: string): HTMLIFrameElement | null {
         const iFrameOnParent = this.getIFrameFromParentWindow(identifier);
@@ -19,17 +23,17 @@ export class IFrameService {
     }
 
     addIFrameToWindowBody(identifier: string): HTMLIFrameElement {
-        const sessionIframe = window.document.createElement('iframe');
+        const sessionIframe = this.doc.createElement('iframe');
         sessionIframe.id = identifier;
         this.loggerService.logDebug(sessionIframe);
         sessionIframe.style.display = 'none';
-        window.document.body.appendChild(sessionIframe);
+        this.doc.body.appendChild(sessionIframe);
         return sessionIframe;
     }
 
     private getIFrameFromParentWindow(identifier: string): HTMLIFrameElement | null {
         try {
-            const iFrameElement = window.parent.document.getElementById(identifier);
+            const iFrameElement = this.doc.defaultView.parent.document.getElementById(identifier);
             if (this.isIFrameElement(iFrameElement)) {
                 return iFrameElement;
             }
@@ -40,7 +44,7 @@ export class IFrameService {
     }
 
     private getIFrameFromWindow(identifier: string): HTMLIFrameElement | null {
-        const iFrameElement = window.document.getElementById(identifier);
+        const iFrameElement = this.doc.getElementById(identifier);
         if (this.isIFrameElement(iFrameElement)) {
             return iFrameElement;
         }

--- a/projects/angular-auth-oidc-client/src/lib/iframe/refresh-session-iframe.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/refresh-session-iframe.service.ts
@@ -1,4 +1,5 @@
-import { Injectable, Renderer2, RendererFactory2 } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable, Renderer2, RendererFactory2 } from '@angular/core';
 import { Observable } from 'rxjs';
 import { LoggerService } from '../logging/logger.service';
 import { UrlService } from '../utils/url/url.service';
@@ -9,6 +10,7 @@ export class RefreshSessionIframeService {
     private renderer: Renderer2;
 
     constructor(
+        @Inject(DOCUMENT) private readonly doc: Document,
         private loggerService: LoggerService,
         private urlService: UrlService,
         private silentRenewService: SilentRenewService,
@@ -53,7 +55,7 @@ export class RefreshSessionIframeService {
             this.silentRenewService.silentRenewEventHandler(e)
         );
 
-        window.dispatchEvent(
+        this.doc.defaultView.dispatchEvent(
             new CustomEvent('oidc-silent-renew-init', {
                 detail: instanceId,
             })

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
@@ -1,4 +1,5 @@
-import { Injectable } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+import { Inject, Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { catchError, map, switchMap } from 'rxjs/operators';
 import { AuthStateService } from './authState/auth-state.service';
@@ -20,6 +21,7 @@ import { TokenHelperService } from './utils/tokenHelper/oidc-token-helper.servic
 
 @Injectable()
 export class OidcSecurityService {
+
     get configuration(): PublicConfiguration {
         return {
             configuration: this.configurationProvider.openIDConfiguration,
@@ -44,6 +46,7 @@ export class OidcSecurityService {
     }
 
     constructor(
+        @Inject(DOCUMENT) private readonly doc: Document,
         private checkSessionService: CheckSessionService,
         private silentRenewService: SilentRenewService,
         private userService: UserService,
@@ -68,7 +71,7 @@ export class OidcSecurityService {
 
         this.loggerService.logDebug('STS server: ' + this.configurationProvider.openIDConfiguration.stsServer);
 
-        const currentUrl = url || window.location.toString();
+        const currentUrl = url || this.doc.defaultView.location.toString();
         const isCallback = this.callbackService.isCallback(currentUrl);
 
         this.loggerService.logDebug('currentUrl to check auth with: ', currentUrl);
@@ -161,7 +164,7 @@ export class OidcSecurityService {
     authorizeWithPopUp(authOptions?: AuthOptions) {
         const internalUrlHandler = (authUrl) => {
             // handle the authorization URL
-            window.open(authUrl, '_blank', 'toolbar=0,location=0,menubar=0');
+            this.doc.defaultView.open(authUrl, '_blank', 'toolbar=0,location=0,menubar=0');
         };
 
         const urlHandler = authOptions?.urlHandler || internalUrlHandler;

--- a/projects/angular-auth-oidc-client/src/lib/utils/redirect/redirect.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/redirect/redirect.service.ts
@@ -1,11 +1,14 @@
+import { DOCUMENT } from '@angular/common';
 import { Inject, Injectable } from '@angular/core';
-import { WINDOW } from '../window/window.reference';
 
+/** @dynamic */
 @Injectable({ providedIn: 'root' })
 export class RedirectService {
-    constructor(@Inject(WINDOW) private window: any) {}
+    constructor(
+      @Inject(DOCUMENT) private readonly doc: Document,
+    ) {}
 
     redirectTo(url) {
-        this.window.location.href = url;
+        this.doc.location.href = url;
     }
 }

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -1,4 +1,6 @@
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
+
 import { ConfigurationProvider } from '../../config/config.provider';
 import { OpenIdConfiguration } from '../../config/openid-configuration';
 import { FlowsDataService } from '../../flows/flows-data.service';
@@ -12,7 +14,6 @@ import { TokenValidationServiceMock } from '../../validation/token-validation.se
 import { FlowHelper } from '../flowHelper/flow-helper.service';
 import { PlatformProvider } from '../platform-provider/platform.provider';
 import { PlatformProviderMock } from '../platform-provider/platform.provider-mock';
-import { WINDOW } from '../window/window.reference';
 import { UrlService } from './url.service';
 
 describe('UrlService Tests', () => {
@@ -39,17 +40,6 @@ describe('UrlService Tests', () => {
                 { provide: TokenValidationService, useClass: TokenValidationServiceMock },
                 RandomService,
                 FlowHelper,
-                {
-                    provide: WINDOW,
-                    useValue: {
-                        location: {
-                            get href() {
-                                return 'fakeUrl';
-                            },
-                            set href(v) {},
-                        },
-                    },
-                },
             ],
         });
     });
@@ -61,7 +51,7 @@ describe('UrlService Tests', () => {
         flowsDataService = TestBed.inject(FlowsDataService);
         tokenValidationService = TestBed.inject(TokenValidationService);
         storagePersistanceService = TestBed.inject(StoragePersistanceService);
-        mywindow = TestBed.inject(WINDOW);
+        mywindow = TestBed.inject(DOCUMENT).defaultView;
     });
 
     afterEach(() => {

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -278,7 +278,7 @@ export class UrlService {
             return this.createAuthorizeUrl(codeChallenge, silentRenewUrl, nonce, state, 'none');
         }
 
-        // this.loggerService.logWarning('authWellKnownEndpoints is undefined');
+        this.loggerService.logWarning('authWellKnownEndpoints is undefined');
         return null;
     }
 

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -1,5 +1,5 @@
 import { HttpParams } from '@angular/common/http';
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { oneLineTrim } from 'common-tags';
 import { ConfigurationProvider } from '../../config/config.provider';
 import { FlowsDataService } from '../../flows/flows-data.service';
@@ -7,7 +7,6 @@ import { LoggerService } from '../../logging/logger.service';
 import { StoragePersistanceService } from '../../storage/storage-persistance.service';
 import { TokenValidationService } from '../../validation/token-validation.service';
 import { FlowHelper } from '../flowHelper/flow-helper.service';
-import { WINDOW } from '../window/window.reference';
 import { UriEncoder } from './uri-encoder';
 
 @Injectable()
@@ -21,7 +20,6 @@ export class UrlService {
         private readonly flowHelper: FlowHelper,
         private tokenValidationService: TokenValidationService,
         private storagePersistanceService: StoragePersistanceService,
-        @Inject(WINDOW) private window: any
     ) {}
 
     getUrlParameter(urlToCheck: any, name: any): string {
@@ -280,7 +278,7 @@ export class UrlService {
             return this.createAuthorizeUrl(codeChallenge, silentRenewUrl, nonce, state, 'none');
         }
 
-        this.loggerService.logWarning('authWellKnownEndpoints is undefined');
+        // this.loggerService.logWarning('authWellKnownEndpoints is undefined');
         return null;
     }
 

--- a/projects/angular-auth-oidc-client/src/lib/utils/window/window.reference.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/window/window.reference.ts
@@ -1,7 +1,0 @@
-import { InjectionToken } from '@angular/core';
-
-export function _window(): any {
-    return window;
-}
-
-export const WINDOW = new InjectionToken('WindowToken');


### PR DESCRIPTION
Using the global object window on the server-side produces errors, and it is discouraged.

The correct approach is to use the defaultView of the DOCUMENT injecting it.

Some features such as storage and crypto may not be available on the server, so we need to check before using them.

It is fine to go this way since there is no storage in the backend, thus there is no authentication happening there.

References: https://github.com/angular/universal/blob/master/docs/gotchas.md#window-is-not-defined