### PR TITLE
Check session fails if sts server has a different origin than the check_session_iframe

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
@@ -181,15 +181,23 @@ describe('SecurityCheckSessionTests', () => {
 
         it('increases outstandingMessages', () => {
             spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({ contentWindow: { postMessage: () => {} } });
-            spyOn(storagePersistanceService, 'read').withArgs('session_state').and.returnValue('session_state');
+            const authWellKnownEndpoints = {
+              checkSessionIframe: 'someTestingValue',
+            };
+            spyOn(storagePersistanceService, 'read')
+              .withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints)
+              .withArgs('session_state').and.returnValue('session_state');
             spyOn(loggerService, 'logDebug').and.callFake(() => {});
-            spyOnProperty(configurationProvider, 'openIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
             (checkSessionService as any).pollServerSession('clientId');
             expect((checkSessionService as any).outstandingMessages).toBe(1);
         });
 
         it('logs warning if iframe does not exist', () => {
             spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue(null);
+            const authWellKnownEndpoints = {
+              checkSessionIframe: 'someTestingValue',
+            };
+            spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
             const spyLogWarning = spyOn(loggerService, 'logWarning').and.callFake(() => {});
             spyOn(loggerService, 'logDebug').and.callFake(() => {});
             (checkSessionService as any).pollServerSession('clientId');
@@ -198,6 +206,10 @@ describe('SecurityCheckSessionTests', () => {
 
         it('logs warning if clientId is not set', () => {
             spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({});
+            const authWellKnownEndpoints = {
+              checkSessionIframe: 'someTestingValue',
+            };
+            spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
             const spyLogWarning = spyOn(loggerService, 'logWarning').and.callFake(() => {});
             spyOn(loggerService, 'logDebug').and.callFake(() => {});
             (checkSessionService as any).pollServerSession('');
@@ -206,7 +218,12 @@ describe('SecurityCheckSessionTests', () => {
 
         it('logs debug if session_state is not set', () => {
             spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({});
-            spyOn(storagePersistanceService, 'read').withArgs('session_state').and.returnValue(null);
+            const authWellKnownEndpoints = {
+              checkSessionIframe: 'someTestingValue',
+            };
+            spyOn(storagePersistanceService, 'read')
+              .withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints)
+              .withArgs('session_state').and.returnValue(null);
             const spyLogDebug = spyOn(loggerService, 'logDebug').and.callFake(() => {});
             (checkSessionService as any).pollServerSession('clientId');
             expect(spyLogDebug).toHaveBeenCalledWith('OidcSecurityCheckSession pollServerSession session_state is blank');

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -101,11 +101,12 @@ export class CheckSessionService {
                     if (existingIframe && clientId) {
                         this.loggerService.logDebug(existingIframe);
                         const sessionState = this.storagePersistanceService.read('session_state');
+                        const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
                         if (sessionState) {
                             this.outstandingMessages++;
                             existingIframe.contentWindow.postMessage(
                                 clientId + ' ' + sessionState,
-                                this.configurationProvider.openIDConfiguration.stsServer
+                                authWellKnownEndPoints.checkSessionIframe.Origin
                             );
                         } else {
                             this.loggerService.logDebug('OidcSecurityCheckSession pollServerSession session_state is blank');
@@ -138,10 +139,11 @@ export class CheckSessionService {
 
     private messageHandler(e: any) {
         const existingIFrame = this.getExistingIframe();
+        const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
         this.outstandingMessages = 0;
         if (
             existingIFrame &&
-            this.configurationProvider.openIDConfiguration.stsServer.startsWith(e.origin) &&
+            authWellKnownEndPoints.checkSessionIframe.startsWith(e.origin) &&
             e.source === existingIFrame.contentWindow
         ) {
             if (e.data === 'error') {

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -106,7 +106,7 @@ export class CheckSessionService {
                             this.outstandingMessages++;
                             existingIframe.contentWindow.postMessage(
                                 clientId + ' ' + sessionState,
-                                authWellKnownEndPoints.checkSessionIframe.Origin
+                                new URL(authWellKnownEndPoints.checkSessionIframe).origin
                             );
                         } else {
                             this.loggerService.logDebug('OidcSecurityCheckSession pollServerSession session_state is blank');


### PR DESCRIPTION
**Describe the bug**
When the OICD provider configuration of the sts server contains a different origin for the check_session_iframe property the checkSession will fail with the following error:

> Failed to execute 'postMessage' on 'DOMWindow': The target origin provided ('https://issuer.org') does not match the recipient window's origin ('https://auth.org').

**To Reproduce**
Steps to reproduce the behaviour:
1. Use issuer as stsServer in config to resolve well-known configuration
2. Login using an IdentityServer that provides a different issuer URL as the check_session_iframe
3. Wait for the checkSession to be invoked
4. See the error in the console

**Expected behavior**
checkSession should use the origin of the sessionCheckIFrameUrl to communicate using postMessage.

**Config**
```
oidcConfigService.withConfig({
	stsServer: "https://issuer.org",
	redirectUrl: window.location.origin,
	postLogoutRedirectUri: window.location.origin,
	triggerAuthorizationResultEvent: true,
	clientId: clientId,
	scope: scope,
	responseType: 'code',
	startCheckSession: true,
	renewUserInfoAfterTokenRenew: true
});
```
```
{
	"issuer": "https://issuer.org",
	"jwks_uri": "https://issuer.org/.well-known/openid-configuration/jwks",
	"authorization_endpoint": "https://auth.org/connect/authorize",
	"token_endpoint": "https://auth.org/connect/token",
	"userinfo_endpoint": "https://auth.org/connect/userinfo",
	"end_session_endpoint": "https://auth.org/connect/endsession",
	"check_session_iframe": "https://auth.org/connect/checksession",
    	...
}
```

**Workaround and additional issue**
I found a workaround for this issue by just setting the stsServer to "https://auth.org" what also servers the same provider configuration document as the "https://issuer.org", but this leads me to another issue I discovered.

According to the [OpenID Connect Discovery specification](https://openid.net/specs/openid-connect-discovery-1_0.html#rfc.section.4.3) the issuer must be used to retrieve the configuration and the issuer returned in the configuration must be the same as the one used to retrieve the configuration. 

Currently that is not the case. The stsServer or authWellknownEndpoint configuration property is used to retrieve the provider configuration. Afterwards the issuer returned from that configuration is used to validate the token issuer.

I would expect that the issuer entry from the provider configuration is validated against the stsServer. 