### PR TITLE
Support aud arrays which are not ordered in id_token validation of refresh token process #904

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.spec.ts
@@ -116,4 +116,82 @@ describe('EqualityService Tests', () => {
         const result = equalityHelperService.areEqual(array1, string2);
         expect(result).toBe(false);
     });
+
+    describe('areRefreshEqual', () => {
+        const testCases = [
+            {
+                input1: 'value1',
+                input2: 'value1',
+                expected: true,
+            },
+            {
+                input1: null,
+                input2: 'value2',
+                expected: false,
+            },
+            {
+                input1: 'value1',
+                input2: null,
+                expected: false,
+            },
+            {
+                input1: null,
+                input2: null,
+                expected: false,
+            },
+            {
+                input1: 'value1',
+                input2: 'value2',
+                expected: false,
+            },
+            // old "x" (string) , [x] new invalid
+            {
+                input1: 'value1',
+                input2: ['value2'],
+                expected: false,
+            },
+            // old [x], new "x" (string) invalid
+            {
+                input1: ['value2'],
+                input2: 'value1',
+                expected: false,
+            },
+            {
+                input1: ['value1'],
+                input2: ['value2'],
+                expected: false,
+            },
+            // old [x,y,z], new [x,y] invalid
+            // old [x], new [y,x] invalid
+            {
+                input1: ['value1'],
+                input2: ['value1', 'value2'],
+                expected: false,
+            },
+            {
+                input1: ['value1', 'value2'],
+                input2: ['value1', 'value2'],
+                expected: true,
+            },
+            // old [x,y], new [y,x] valid
+            {
+                input1: ['value1', 'value2'],
+                input2: ['value2', 'value1'],
+                expected: true,
+            },
+            // old [x,y,z], new [y,z,x] valid
+            {
+                input1: ['x', 'y', 'z'],
+                input2: ['y', 'z', 'x'],
+                expected: true,
+            },
+        ];
+
+        testCases.forEach(({ input1, input2, expected }) => {
+            it(`returns '${expected}' if '${input1}' and '${input2}' is given`, () => {
+                const result = equalityHelperService.areRefreshEqual(input1, input2);
+                expect(result).toBe(expected);
+            });
+        });
+    });
 });

--- a/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.spec.ts
@@ -117,7 +117,7 @@ describe('EqualityService Tests', () => {
         expect(result).toBe(false);
     });
 
-    describe('areRefreshEqual', () => {
+    describe('isStringEqualOrNonOrderedArrayEqual', () => {
         const testCases = [
             {
                 input1: 'value1',
@@ -189,7 +189,7 @@ describe('EqualityService Tests', () => {
 
         testCases.forEach(({ input1, input2, expected }) => {
             it(`returns '${expected}' if '${input1}' and '${input2}' is given`, () => {
-                const result = equalityHelperService.areRefreshEqual(input1, input2);
+                const result = equalityHelperService.isStringEqualOrNonOrderedArrayEqual(input1, input2);
                 expect(result).toBe(expected);
             });
         });

--- a/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.ts
@@ -2,13 +2,40 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class EqualityService {
+    areRefreshEqual(value1: string | any[], value2: string | any[]) {
+        if (this.isNullorUndefined(value1)) {
+            return false;
+        }
+
+        if (this.isNullorUndefined(value2)) {
+            return false;
+        }
+
+        if (this.oneValueIsStringAndTheOtherIsArray(value1, value2)) {
+            console.log('oneValueIsStringAndTheOtherIsArray');
+            return false;
+        }
+
+        if (this.bothValuesAreStrings(value1, value2)) {
+            console.log('bothValuesAreStrings');
+            return value1 === value2;
+        }
+
+        if (this.bothValuesAreArrays(value1, value2)) {
+            console.log('bothValuesAreArrays');
+            return this.arraysHaveEqualContent(value1 as any[], value2 as any[]);
+        }
+
+        return false;
+    }
+
     areEqual(value1: string | any[] | object | null | undefined, value2: string | any[] | object | null | undefined) {
         if (!value1 || !value2) {
             return false;
         }
 
         if (this.bothValuesAreArrays(value1, value2)) {
-            return this.arraysEqual(value1 as any[], value2 as any[]);
+            return this.arraysStrictEqual(value1 as any[], value2 as any[]);
         }
 
         if (this.bothValuesAreStrings(value1, value2)) {
@@ -53,7 +80,7 @@ export class EqualityService {
         return typeof value === 'object';
     }
 
-    private arraysEqual(arr1: Array<string>, arr2: Array<string>) {
+    private arraysStrictEqual(arr1: Array<string>, arr2: Array<string>) {
         if (arr1.length !== arr2.length) {
             return false;
         }
@@ -65,5 +92,17 @@ export class EqualityService {
         }
 
         return true;
+    }
+
+    private arraysHaveEqualContent(arr1: Array<string>, arr2: Array<string>) {
+        if (arr1.length !== arr2.length) {
+            return false;
+        }
+
+        return arr1.some((v) => arr2.includes(v));
+    }
+
+    private isNullorUndefined(val: any) {
+        return val === null || val === undefined;
     }
 }

--- a/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.ts
@@ -12,17 +12,14 @@ export class EqualityService {
         }
 
         if (this.oneValueIsStringAndTheOtherIsArray(value1, value2)) {
-            console.log('oneValueIsStringAndTheOtherIsArray');
             return false;
         }
 
         if (this.bothValuesAreStrings(value1, value2)) {
-            console.log('bothValuesAreStrings');
             return value1 === value2;
         }
 
         if (this.bothValuesAreArrays(value1, value2)) {
-            console.log('bothValuesAreArrays');
             return this.arraysHaveEqualContent(value1 as any[], value2 as any[]);
         }
 

--- a/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.ts
@@ -2,12 +2,12 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class EqualityService {
-    areRefreshEqual(value1: string | any[], value2: string | any[]) {
-        if (this.isNullorUndefined(value1)) {
+    isStringEqualOrNonOrderedArrayEqual(value1: string | any[], value2: string | any[]) {
+        if (this.isNullOrUndefined(value1)) {
             return false;
         }
 
-        if (this.isNullorUndefined(value2)) {
+        if (this.isNullOrUndefined(value2)) {
             return false;
         }
 
@@ -102,7 +102,7 @@ export class EqualityService {
         return arr1.some((v) => arr2.includes(v));
     }
 
-    private isNullorUndefined(val: any) {
+    private isNullOrUndefined(val: any) {
         return val === null || val === undefined;
     }
 }

--- a/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
@@ -3,6 +3,7 @@ import { ConfigurationProvider } from '../config/config.provider';
 import { CallbackContext } from '../flows/callback-context';
 import { LoggerService } from '../logging/logger.service';
 import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { EqualityService } from '../utils/equality/equality.service';
 import { FlowHelper } from '../utils/flowHelper/flow-helper.service';
 import { TokenHelperService } from '../utils/tokenHelper/oidc-token-helper.service';
 import { StateValidationResult } from './state-validation-result';
@@ -16,8 +17,9 @@ export class StateValidationService {
         private tokenValidationService: TokenValidationService,
         private tokenHelperService: TokenHelperService,
         private loggerService: LoggerService,
-        private readonly configurationProvider: ConfigurationProvider,
-        private readonly flowHelper: FlowHelper
+        private configurationProvider: ConfigurationProvider,
+        private equalityService: EqualityService,
+        private flowHelper: FlowHelper
     ) {}
 
     getValidatedStateResult(callbackContext: CallbackContext): StateValidationResult {
@@ -62,8 +64,8 @@ export class StateValidationService {
         }
 
         // its aud Claim Value MUST be the same as in the ID Token issued when the original authentication occurred,
-        if (decodedIdToken.aud !== newIdToken.aud) {
-            this.loggerService.logDebug(`aud do not match: ${decodedIdToken.aud} ${newIdToken.aud}`);
+        if (!this.equalityService.areRefreshEqual(decodedIdToken?.aud, newIdToken?.aud)) {
+            this.loggerService.logDebug(`aud do not match: '${decodedIdToken?.aud}' '${newIdToken.aud}'`);
             return false;
         }
 

--- a/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
@@ -64,8 +64,8 @@ export class StateValidationService {
         }
 
         // its aud Claim Value MUST be the same as in the ID Token issued when the original authentication occurred,
-        if (!this.equalityService.areRefreshEqual(decodedIdToken?.aud, newIdToken?.aud)) {
-            this.loggerService.logDebug(`aud do not match: '${decodedIdToken?.aud}' '${newIdToken.aud}'`);
+        if (!this.equalityService.isStringEqualOrNonOrderedArrayEqual(decodedIdToken?.aud, newIdToken?.aud)) {
+            this.loggerService.logDebug(`aud in new id_token is not valid: '${decodedIdToken?.aud}' '${newIdToken.aud}'`);
             return false;
         }
 


### PR DESCRIPTION
Fixing #904 adding validation also for strings and arrays