### PR TITLE
Added Title to Silent Renew IFrame

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/iframe/existing-iframe.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/existing-iframe.service.ts
@@ -22,6 +22,7 @@ export class IFrameService {
   addIFrameToWindowBody(identifier: string): HTMLIFrameElement {
     const sessionIframe = this.doc.createElement('iframe');
     sessionIframe.id = identifier;
+    sessionIframe.title = identifier;
     this.loggerService.logDebug(sessionIframe);
     sessionIframe.style.display = 'none';
     this.doc.body.appendChild(sessionIframe);


### PR DESCRIPTION
According to WCAG and Deque, frames should have a title for accessibility reasons. I've added the title property to the generated IFrame to be compliant with accessibility standards.

References:
[Deque](https://dequeuniversity.com/rules/axe/4.0/frame-title?application=axeAPI)
[W3](https://www.w3.org/TR/2014/NOTE-WCAG20-TECHS-20140408/H64)
