### PR TITLE
ApplicationRef.isStable is always false when using this package

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/callback/intervall.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/intervall.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, NgZone } from '@angular/core';
-import { Subject, Subscription } from 'rxjs';
+import { Observable, Subscription } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class IntervallService {
@@ -16,10 +16,16 @@ export class IntervallService {
 
   startPeriodicTokenCheck(repeatAfterSeconds: number) {
     const millisecondsDelayBetweenTokenCheck = repeatAfterSeconds * 1000;
-    const update$ = new Subject();
 
-    this.zone.runOutsideAngular(() => setInterval(() => this.zone.run(() => update$.next({})), millisecondsDelayBetweenTokenCheck))
+    return new Observable((subscriber) => {
+      let intervalId;
+      this.zone.runOutsideAngular(() => {
+        intervalId = setInterval(() => this.zone.run(() => subscriber.next({})), millisecondsDelayBetweenTokenCheck);
+      });
 
-    return update$;
+      return () => {
+        clearInterval(intervalId);
+      };
+    });
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/callback/intervall.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/intervall.service.ts
@@ -20,7 +20,7 @@ export class IntervallService {
     return new Observable((subscriber) => {
       let intervalId;
       this.zone.runOutsideAngular(() => {
-        intervalId = setInterval(() => this.zone.run(() => subscriber.next({})), millisecondsDelayBetweenTokenCheck);
+        intervalId = setInterval(() => subscriber.next(), millisecondsDelayBetweenTokenCheck);
       });
 
       return () => {

--- a/projects/angular-auth-oidc-client/src/lib/callback/intervall.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/intervall.service.ts
@@ -1,9 +1,11 @@
-import { Injectable } from '@angular/core';
-import { interval, Subscription } from 'rxjs';
+import { Injectable, NgZone } from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
 export class IntervallService {
   runTokenValidationRunning: Subscription = null;
+
+  constructor(private zone: NgZone) {}
 
   stopPeriodicallTokenCheck(): void {
     if (this.runTokenValidationRunning) {
@@ -14,7 +16,10 @@ export class IntervallService {
 
   startPeriodicTokenCheck(repeatAfterSeconds: number) {
     const millisecondsDelayBetweenTokenCheck = repeatAfterSeconds * 1000;
+    const update$ = new Subject();
 
-    return interval(millisecondsDelayBetweenTokenCheck);
+    this.zone.runOutsideAngular(() => setInterval(() => this.zone.run(() => update$.next({})), millisecondsDelayBetweenTokenCheck))
+
+    return update$;
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, NgZone } from '@angular/core';
 import { BehaviorSubject, Observable, of } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { ConfigurationProvider } from '../config/config.provider';
@@ -31,7 +31,8 @@ export class CheckSessionService {
     private loggerService: LoggerService,
     private iFrameService: IFrameService,
     private eventService: PublicEventsService,
-    private configurationProvider: ConfigurationProvider
+    private configurationProvider: ConfigurationProvider,
+    private zone: NgZone
   ) {}
 
   isCheckSessionConfigured() {
@@ -129,7 +130,9 @@ export class CheckSessionService {
             );
           }
 
-          this.scheduledHeartBeatRunning = setTimeout(pollServerSessionRecur, this.heartBeatInterval);
+          this.zone.runOutsideAngular(() => {
+            this.scheduledHeartBeatRunning = setTimeout(() => this.zone.run(pollServerSessionRecur), this.heartBeatInterval);
+          });
         });
     };
 


### PR DESCRIPTION
**Describe the bug**
When you kick-off the setup (with [checkAuth](https://github.com/damienbod/angular-auth-oidc-client/blob/main/docs/public-api.md#checkauth-observable)) then this package will create intervals and timeouts. When using Service workers it's important to get the application into stable mode or else the new version isn't downloaded. However this is not possible because this package is making it unstable and it will never turn stable.
  
  
**To Reproduce**
Steps to reproduce the behavior:
1. Add this snippet somewhere (e.g. constructor of app.module.ts):
   ```ts
    this.applicationRef.isStable.pipe(
    	tap(isStable => console.log(`ApplicationRef::stable`, isStable))
    ).subscribe();
    ``` 
1. Initialize this package with calling checkAuth (we do it in the initializer, so that the guards are fully working with this package)
1. Notice that in the console the message 'ApplicationRef::stable false' is recieved but you will never get 'ApplicationRef::stable true'
    - When you do have a "stable" version you should see 'ApplicationRef::stable false' and than followed up by 'ApplicationRef::stable true'
  
  
**Expected behavior**
intervals and timeouts should be run outside the NgZone so that it wont interfere with the "stability" of Angular.

This package reaches stable for me when these two culprits are run outside angular:
https://github.com/damienbod/angular-auth-oidc-client/blob/710af82194bc9372d8a5ffedae00d94fc6f5417c/projects/angular-auth-oidc-client/src/lib/callback/intervall.service.ts#L18
https://github.com/damienbod/angular-auth-oidc-client/blob/03aa2ad53a5c4622300e7e283e2f4bd8535e1019/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts#L132

#961