### PR TITLE
Add support custom params during token exchange

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -31,6 +31,7 @@ export interface OpenIdConfiguration {
   disableIatOffsetValidation?: boolean;
   storage?: any;
   customParams?: { [key: string]: string | number | boolean };
+  customTokenParams?: { [key: string]: string | number | boolean };
   eagerLoadAuthWellKnownEndpoints?: boolean;
 
   // Azure B2C have implemented this incorrectly. Add support for to disable this until fixed.

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.spec.ts
@@ -145,6 +145,20 @@ describe('CodeFlowCallbackHandlerService', () => {
     );
 
     it(
+      'calls url service with custom token params',
+      waitForAsync(() => {
+        const urlServiceSpy = spyOn(urlService, 'createBodyForCodeFlowCodeRequest');
+        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+
+        spyOnProperty(configurationProvider, 'openIDConfiguration', 'get').and.returnValue({ customTokenParams: { foo: 'bar' } });
+
+        service.codeFlowCodeRequest({ code: 'foo' } as CallbackContext).subscribe((callbackContext) => {
+          expect(urlServiceSpy).toHaveBeenCalledWith('foo', { foo: 'bar' });
+        });
+      })
+    );
+
+    it(
       'calls dataservice with correct headers if all params are good',
       waitForAsync(() => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(of({}));

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
@@ -75,8 +75,10 @@ export class CodeFlowCallbackHandlerService {
 
     let headers: HttpHeaders = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
-
-    const bodyForCodeFlow = this.urlService.createBodyForCodeFlowCodeRequest(callbackContext.code);
+    const bodyForCodeFlow = this.urlService.createBodyForCodeFlowCodeRequest(
+      callbackContext.code,
+      this.configurationProvider.openIDConfiguration?.customTokenParams
+    );
 
     return this.dataService.post(tokenEndpoint, bodyForCodeFlow, headers).pipe(
       switchMap((response) => {

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -831,6 +831,22 @@ describe('UrlService Tests', () => {
 
       expect(result).toBe(expected);
     });
+
+    it('returns correctUrl when customTokenParams are provided', () => {
+      const codeVerifier = 'codeverifier';
+      const code = 'code';
+      const silentRenewUrl = 'silentRenewUrl';
+      const clientId = 'clientId';
+      const customTokenParams = { foo: 'bar' };
+      spyOn(flowsDataService, 'getCodeVerifier').and.returnValue(codeVerifier);
+      spyOn(flowsDataService, 'isSilentRenewRunning').and.returnValue(true);
+      spyOnProperty(configurationProvider, 'openIDConfiguration', 'get').and.returnValue({ clientId, silentRenewUrl });
+
+      const result = service.createBodyForCodeFlowCodeRequest(code, customTokenParams);
+      const expected = `grant_type=authorization_code&client_id=${clientId}&code_verifier=${codeVerifier}&code=${code}&foo=bar&redirect_uri=${silentRenewUrl}`;
+
+      expect(result).toBe(expected);
+    });
   });
 
   describe('createBodyForCodeFlowRefreshTokensRequest', () => {

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -153,7 +153,7 @@ export class UrlService {
     return revocationEndpointUrl;
   }
 
-  createBodyForCodeFlowCodeRequest(code: string): string {
+  createBodyForCodeFlowCodeRequest(code: string, customTokenParams?: { [p: string]: string | number | boolean }): string {
     const codeVerifier = this.flowsDataService.getCodeVerifier();
     if (!codeVerifier) {
       this.loggerService.logError(`CodeVerifier is not set `, codeVerifier);
@@ -166,10 +166,15 @@ export class UrlService {
       return null;
     }
 
-    const dataForBody = oneLineTrim`grant_type=authorization_code
+    let dataForBody = oneLineTrim`grant_type=authorization_code
             &client_id=${clientId}
             &code_verifier=${codeVerifier}
             &code=${code}`;
+
+    if (customTokenParams) {
+      const customParamText = this.composeCustomParams({ ...customTokenParams });
+      dataForBody = oneLineTrim`${dataForBody}${customParamText}`;
+    }
 
     const silentRenewUrl = this.getSilentRenewUrl();
 


### PR DESCRIPTION
I have a use case where I need to pass custom params, like `roles`, during the token exchange. Are you open to accepting a PR that enables this behavior? 