### PR TITLE
Store singing keys as fallback

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
@@ -13,6 +13,8 @@ import { FlowsDataService } from '../flows-data.service';
 import { ResetAuthDataService } from '../reset-auth-data.service';
 import { SigninKeyDataService } from '../signin-key-data.service';
 
+const JWT_KEYS = 'jwtKeys';
+
 @Injectable()
 export class HistoryJwtKeysCallbackHandlerService {
   constructor(
@@ -102,10 +104,10 @@ export class HistoryJwtKeysCallbackHandlerService {
   }
 
   private storeSigningKeys(jwtKeys: JwtKeys) {
-    this.storagePersistanceService.write('jwtKeys', jwtKeys);
+    this.storagePersistanceService.write(JWT_KEYS, jwtKeys);
   }
 
   private readSigningKeys() {
-    return this.storagePersistanceService.read('jwtKeys');
+    return this.storagePersistanceService.read(JWT_KEYS);
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
@@ -1,11 +1,12 @@
 import { Injectable } from '@angular/core';
 import { Observable, of, throwError } from 'rxjs';
-import { catchError, switchMap } from 'rxjs/operators';
+import { catchError, switchMap, tap } from 'rxjs/operators';
 import { AuthStateService } from '../../authState/auth-state.service';
 import { AuthorizedState } from '../../authState/authorized-state';
 import { ConfigurationProvider } from '../../config/config.provider';
 import { LoggerService } from '../../logging/logger.service';
 import { StoragePersistanceService } from '../../storage/storage-persistance.service';
+import { JwtKeys } from '../../validation/jwtkeys';
 import { ValidationResult } from '../../validation/validation-result';
 import { CallbackContext } from '../callback-context';
 import { FlowsDataService } from '../flows-data.service';
@@ -47,6 +48,17 @@ export class HistoryJwtKeysCallbackHandlerService {
     this.loggerService.logDebug('authorizedCallback created, begin token validation');
 
     return this.signInKeyDataService.getSigningKeys().pipe(
+      tap((jwtKeys: JwtKeys) => this.storeSigningKeys(jwtKeys)),
+      catchError((err) => {
+        // fallback: try to load jwtKeys from storage
+        const storedJwtKeys = this.readSigningKeys();
+        if (!!storedJwtKeys) {
+          this.loggerService.logWarning(`Failed to retrieve signing keys, fallback to stored keys`);
+          return of(storedJwtKeys);
+        }
+
+        return throwError(err);
+      }),
       switchMap((jwtKeys) => {
         if (jwtKeys) {
           callbackContext.jwtKeys = jwtKeys;
@@ -87,5 +99,13 @@ export class HistoryJwtKeysCallbackHandlerService {
 
   private resetBrowserHistory() {
     window.history.replaceState({}, window.document.title, window.location.origin + window.location.pathname);
+  }
+
+  private storeSigningKeys(jwtKeys: JwtKeys) {
+    this.storagePersistanceService.write('jwtKeys', jwtKeys);
+  }
+
+  private readSigningKeys() {
+    return this.storagePersistanceService.read('jwtKeys');
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistance.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistance.service.ts
@@ -13,7 +13,8 @@ export type StorageKeys =
   | 'authStateControl'
   | 'session_state'
   | 'storageSilentRenewRunning'
-  | 'storageCustomRequestParams';
+  | 'storageCustomRequestParams'
+  | 'jwtKeys';
 
 @Injectable()
 export class StoragePersistanceService {


### PR DESCRIPTION
I was thinking about how to cache the JWKS in `callbackHistoryAndResetJwtKeys()` of the `HistoryJwtKeysCallbackHandlerService` because the method is used in every refresh cycle. In production, the token refresh might succeed, but if the connection is lost before requesting the JWKS, the entire pipeline will break after two retries. However, storing the result like in `getAuthWellKnownEndPoints()` of the `AuthWellKnownService` is not feasible because of possible key rotations by the identity server. Therefore, I decided on a *network-first* strategy that tries the request for three times but falls back to the stored keys in case of failure. 

In addition, the retrieved JWKS always replace the stored keys, which minimizes the risk of validating the tokens against expired keys.

Any thoughts? 