### PR TITLE
fix: use navigateByUrl to fix url params encoding

### DIFF
--- a/docs/guards.md
+++ b/docs/guards.md
@@ -19,7 +19,7 @@ export class AuthorizationGuard implements CanActivate {
         console.log('AuthorizationGuard, canActivate isAuthorized: ' + isAuthorized);
 
         if (!isAuthorized) {
-          this.router.navigate(['/unauthorized']);
+          this.router.navigateByUrl('/unauthorized');
           return false;
         }
 

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.spec.ts
@@ -130,13 +130,13 @@ describe(`AutoLoginGuard`, () => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(true));
         spyOn(localStorage, 'getItem').and.returnValue('stored-route');
         const localStorageSpy = spyOn(localStorage, 'removeItem');
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
         const loginSpy = spyOn(loginService, 'login');
 
         autoLoginGuard.canActivate(null, { url: 'some-url7' } as RouterStateSnapshot).subscribe((result) => {
           expect(result).toBe(true);
           expect(localStorageSpy).toHaveBeenCalledOnceWith('redirect');
-          expect(routerSpy).toHaveBeenCalledOnceWith(['stored-route']);
+          expect(routerSpy).toHaveBeenCalledOnceWith('stored-route');
           expect(loginSpy).not.toHaveBeenCalled();
         });
       })
@@ -221,13 +221,13 @@ describe(`AutoLoginGuard`, () => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(true));
         spyOn(localStorage, 'getItem').and.returnValue('stored-route');
         const localStorageSpy = spyOn(localStorage, 'removeItem');
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
         const loginSpy = spyOn(loginService, 'login');
 
         autoLoginGuard.canLoad({ path: 'some-url14' }, []).subscribe((result) => {
           expect(result).toBe(true);
           expect(localStorageSpy).toHaveBeenCalledOnceWith('redirect');
-          expect(routerSpy).toHaveBeenCalledOnceWith(['stored-route']);
+          expect(routerSpy).toHaveBeenCalledOnceWith('stored-route');
           expect(loginSpy).not.toHaveBeenCalled();
         });
       })

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.ts
@@ -35,7 +35,7 @@ export class AutoLoginGuard implements CanActivate, CanLoad {
         if (isAuthorized) {
           if (storedRoute) {
             this.autoLoginService.deleteStoredRedirectRoute();
-            this.router.navigate([storedRoute]);
+            this.router.navigateByUrl(storedRoute);
           }
           return true;
         }

--- a/projects/angular-auth-oidc-client/src/lib/callback/code-flow-callback.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/code-flow-callback.service.spec.ts
@@ -69,7 +69,7 @@ describe('CodeFlowCallbackService ', () => {
           existingIdToken: '',
         };
         const spy = spyOn(flowsService, 'processCodeFlowCallback').and.returnValue(of(callbackContext));
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ triggerAuthorizationResultEvent: true });
         codeFlowCallbackService.authorizedCallbackWithCode('some-url2').subscribe(() => {
           expect(spy).toHaveBeenCalledWith('some-url2');
@@ -93,14 +93,14 @@ describe('CodeFlowCallbackService ', () => {
           existingIdToken: '',
         };
         const spy = spyOn(flowsService, 'processCodeFlowCallback').and.returnValue(of(callbackContext));
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
           triggerAuthorizationResultEvent: false,
           postLoginRoute: 'postLoginRoute',
         });
         codeFlowCallbackService.authorizedCallbackWithCode('some-url3').subscribe(() => {
           expect(spy).toHaveBeenCalledWith('some-url3');
-          expect(routerSpy).toHaveBeenCalledWith(['postLoginRoute']);
+          expect(routerSpy).toHaveBeenCalledWith('postLoginRoute');
         });
       })
     );
@@ -134,7 +134,7 @@ describe('CodeFlowCallbackService ', () => {
         spyOn(flowsService, 'processCodeFlowCallback').and.returnValue(throwError('error'));
         const resetSilentRenewRunningSpy = spyOn(flowsDataService, 'resetSilentRenewRunning');
         const stopPeriodicallTokenCheckSpy = spyOn(intervallService, 'stopPeriodicallTokenCheck');
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
 
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
           triggerAuthorizationResultEvent: false,
@@ -145,7 +145,7 @@ describe('CodeFlowCallbackService ', () => {
             expect(resetSilentRenewRunningSpy).toHaveBeenCalled();
             expect(stopPeriodicallTokenCheckSpy).toHaveBeenCalled();
             expect(err).toBeTruthy();
-            expect(routerSpy).toHaveBeenCalledWith(['unauthorizedRoute']);
+            expect(routerSpy).toHaveBeenCalledWith('unauthorizedRoute');
           },
         });
       })

--- a/projects/angular-auth-oidc-client/src/lib/callback/code-flow-callback.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/code-flow-callback.service.ts
@@ -24,14 +24,14 @@ export class CodeFlowCallbackService {
     return this.flowsService.processCodeFlowCallback(urlToCheck).pipe(
       tap((callbackContext) => {
         if (!triggerAuthorizationResultEvent && !callbackContext.isRenewProcess) {
-          this.router.navigate([postLoginRoute]);
+          this.router.navigateByUrl(postLoginRoute);
         }
       }),
       catchError((error) => {
         this.flowsDataService.resetSilentRenewRunning();
         this.intervallService.stopPeriodicallTokenCheck();
         if (!triggerAuthorizationResultEvent && !isRenewProcess) {
-          this.router.navigate([unauthorizedRoute]);
+          this.router.navigateByUrl(unauthorizedRoute);
         }
         return throwError(error);
       })

--- a/projects/angular-auth-oidc-client/src/lib/callback/implicit-flow-callback.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/implicit-flow-callback.service.spec.ts
@@ -70,7 +70,7 @@ describe('ImplicitFlowCallbackService ', () => {
           existingIdToken: '',
         };
         const spy = spyOn(flowsService, 'processImplicitFlowCallback').and.returnValue(of(callbackContext));
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ triggerAuthorizationResultEvent: true });
         implicitFlowCallbackService.authorizedImplicitFlowCallback('some-hash').subscribe(() => {
           expect(spy).toHaveBeenCalledWith('some-hash');
@@ -94,14 +94,14 @@ describe('ImplicitFlowCallbackService ', () => {
           existingIdToken: '',
         };
         const spy = spyOn(flowsService, 'processImplicitFlowCallback').and.returnValue(of(callbackContext));
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
           triggerAuthorizationResultEvent: false,
           postLoginRoute: 'postLoginRoute',
         });
         implicitFlowCallbackService.authorizedImplicitFlowCallback('some-hash').subscribe(() => {
           expect(spy).toHaveBeenCalledWith('some-hash');
-          expect(routerSpy).toHaveBeenCalledWith(['postLoginRoute']);
+          expect(routerSpy).toHaveBeenCalledWith('postLoginRoute');
         });
       })
     );
@@ -135,7 +135,7 @@ describe('ImplicitFlowCallbackService ', () => {
         spyOn(flowsService, 'processImplicitFlowCallback').and.returnValue(throwError('error'));
         const resetSilentRenewRunningSpy = spyOn(flowsDataService, 'resetSilentRenewRunning');
         const stopPeriodicallTokenCheckSpy = spyOn(intervalService, 'stopPeriodicallTokenCheck');
-        const routerSpy = spyOn(router, 'navigate');
+        const routerSpy = spyOn(router, 'navigateByUrl');
 
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
           triggerAuthorizationResultEvent: false,
@@ -146,7 +146,7 @@ describe('ImplicitFlowCallbackService ', () => {
             expect(resetSilentRenewRunningSpy).toHaveBeenCalled();
             expect(stopPeriodicallTokenCheckSpy).toHaveBeenCalled();
             expect(err).toBeTruthy();
-            expect(routerSpy).toHaveBeenCalledWith(['unauthorizedRoute']);
+            expect(routerSpy).toHaveBeenCalledWith('unauthorizedRoute');
           },
         });
       })

--- a/projects/angular-auth-oidc-client/src/lib/callback/implicit-flow-callback.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/implicit-flow-callback.service.ts
@@ -24,14 +24,14 @@ export class ImplicitFlowCallbackService {
     return this.flowsService.processImplicitFlowCallback(hash).pipe(
       tap((callbackContext) => {
         if (!triggerAuthorizationResultEvent && !callbackContext.isRenewProcess) {
-          this.router.navigate([postLoginRoute]);
+          this.router.navigateByUrl(postLoginRoute);
         }
       }),
       catchError((error) => {
         this.flowsDataService.resetSilentRenewRunning();
         this.intervalService.stopPeriodicallTokenCheck();
         if (!triggerAuthorizationResultEvent && !isRenewProcess) {
-          this.router.navigate([unauthorizedRoute]);
+          this.router.navigateByUrl(unauthorizedRoute);
         }
         return throwError(error);
       })

--- a/projects/angular-auth-oidc-client/src/lib/check-auth.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/check-auth.service.spec.ts
@@ -296,11 +296,11 @@ describe('CheckAuthService', () => {
         spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(true);
         spyOn(autoLoginService, 'getStoredRedirectRoute').and.returnValue('some-saved-route');
         const deleteSpy = spyOn(autoLoginService, 'deleteStoredRedirectRoute');
-        const routeSpy = spyOn(router, 'navigate');
+        const routeSpy = spyOn(router, 'navigateByUrl');
 
         checkAuthService.checkAuth().subscribe((result) => {
           expect(deleteSpy).toHaveBeenCalledTimes(1);
-          expect(routeSpy).toHaveBeenCalledOnceWith(['some-saved-route']);
+          expect(routeSpy).toHaveBeenCalledOnceWith('some-saved-route');
         });
       })
     );

--- a/projects/angular-auth-oidc-client/src/lib/check-auth.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/check-auth.service.ts
@@ -76,7 +76,7 @@ export class CheckAuthService {
         const savedRouteForRedirect = this.autoLoginService.getStoredRedirectRoute();
         if (savedRouteForRedirect) {
           this.autoLoginService.deleteStoredRedirectRoute();
-          this.router.navigate([savedRouteForRedirect]);
+          this.router.navigateByUrl(savedRouteForRedirect);
         }
       }),
       catchError((error) => {

--- a/projects/sample-implicit-flow-google/src/app/app.component.ts
+++ b/projects/sample-implicit-flow-google/src/app/app.component.ts
@@ -17,7 +17,7 @@ export class AppComponent implements OnInit, OnDestroy {
         if (!isAuthenticated) {
           if ('/autologin' !== window.location.pathname) {
             this.write('redirect', window.location.pathname);
-            this.router.navigate(['/autologin']);
+            this.router.navigateByUrl('/autologin');
           }
         }
         if (isAuthenticated) {
@@ -51,9 +51,9 @@ export class AppComponent implements OnInit, OnDestroy {
     }
 
     if (path.toString().includes('/unauthorized')) {
-      this.router.navigate(['/']);
+      this.router.navigateByUrl('/');
     } else {
-      this.router.navigate([path]);
+      this.router.navigateByUrl(path);
     }
   }
 


### PR DESCRIPTION
Change `router.navigate()` calls to `router.navigateByUrl()`

Fixes #1028 