### PR TITLE
Enable handling users closing login popup

### DIFF
--- a/docs/authorizing-popup.md
+++ b/docs/authorizing-popup.md
@@ -22,10 +22,11 @@ This allows you to have the provider's consent prompt display in a popup window 
   }
 
   loginWithPopup() {
-    this.oidcSecurityService.authorizeWithPopUp().subscribe(({ isAuthenticated, userData, accessToken }) => {
+    this.oidcSecurityService.authorizeWithPopUp().subscribe(({ isAuthenticated, userData, accessToken, errorMessage }) => {
       console.log(isAuthenticated);
       console.log(userData);
       console.log(accessToken);
+      console.log(errorMessage);
     });
   }
 ```
@@ -40,7 +41,7 @@ loginWithPopup() {
   const somePopupOptions = { width: 500, height: 500, left: 50, top: 50 };
 
   this.oidcSecurityService.authorizeWithPopUp(null, somePopupOptions)
-    .subscribe(({ isAuthenticated, userData, accessToken }) => {
+    .subscribe(({ isAuthenticated, userData, accessToken, errorMessage }) => {
     /* ... */
     });
 }

--- a/projects/angular-auth-oidc-client/src/lib/login/login-response.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/login-response.ts
@@ -2,4 +2,5 @@ export interface LoginResponse {
   isAuthenticated: boolean;
   userData?: any;
   accessToken?: string;
+  errorMessage?: string;
 }

--- a/projects/angular-auth-oidc-client/src/lib/login/login-response.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/login-response.ts
@@ -1,5 +1,5 @@
 export interface LoginResponse {
   isAuthenticated: boolean;
-  userData: any;
-  accessToken: string;
+  userData?: any;
+  accessToken?: string;
 }

--- a/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.spec.ts
@@ -425,7 +425,7 @@ describe('ParLoginService', () => {
           expect(getUserDataFromStoreSpy).not.toHaveBeenCalled();
           expect(getAccessTokenSpy).not.toHaveBeenCalled();
 
-          expect(result).toEqual({ isAuthenticated: false });
+          expect(result).toEqual({ isAuthenticated: false, errorMessage: 'User closed popup' });
         });
       })
     );

--- a/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.ts
@@ -111,15 +111,16 @@ export class ParLoginService {
 
         return this.popupService.result$.pipe(
           take(1),
-          switchMap((result) => (result.userClosed === true ? of(false) : this.checkAuthService.checkAuth(result.receivedUrl))),
-          map((isAuthenticated) =>
-            isAuthenticated
-              ? {
-                  isAuthenticated: true,
-                  userData: this.userService.getUserDataFromStore(),
-                  accessToken: this.authStateService.getAccessToken(),
-                }
-              : { isAuthenticated: false }
+          switchMap((result) =>
+            result.userClosed === true
+              ? of({ isAuthenticated: false, errorMessage: 'User closed popup' })
+              : this.checkAuthService.checkAuth(result.receivedUrl).pipe(
+                  map((isAuthenticated) => ({
+                    isAuthenticated,
+                    userData: this.userService.getUserDataFromStore(),
+                    accessToken: this.authStateService.getAccessToken(),
+                  }))
+                )
           )
         );
       })

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.spec.ts
@@ -168,7 +168,7 @@ describe('PopUpLoginService', () => {
     );
 
     it(
-      'returns one property if popup was closed by user',
+      'returns two properties if popup was closed by user',
       waitForAsync(() => {
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
           authWellknownEndpoint: 'authWellknownEndpoint',
@@ -189,7 +189,7 @@ describe('PopUpLoginService', () => {
           expect(getUserDataFromStoreSpy).not.toHaveBeenCalled();
           expect(getAccessTokenSpy).not.toHaveBeenCalled();
 
-          expect(result).toEqual({ isAuthenticated: false });
+          expect(result).toEqual({ isAuthenticated: false, errorMessage: 'User closed popup' });
         });
       })
     );

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.ts
@@ -55,15 +55,16 @@ export class PopUpLoginService {
 
         return this.popupService.result$.pipe(
           take(1),
-          switchMap((result) => (result.userClosed === true ? of(false) : this.checkAuthService.checkAuth(result.receivedUrl))),
-          map((isAuthenticated) =>
-            isAuthenticated
-              ? {
-                  isAuthenticated: true,
-                  userData: this.userService.getUserDataFromStore(),
-                  accessToken: this.authStateService.getAccessToken(),
-                }
-              : { isAuthenticated: false }
+          switchMap((result) =>
+            result.userClosed === true
+              ? of({ isAuthenticated: false, errorMessage: 'User closed popup' })
+              : this.checkAuthService.checkAuth(result.receivedUrl).pipe(
+                  map((isAuthenticated) => ({
+                    isAuthenticated,
+                    userData: this.userService.getUserDataFromStore(),
+                    accessToken: this.authStateService.getAccessToken(),
+                  }))
+                )
           )
         );
       })

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 import { AuthStateService } from '../../authState/auth-state.service';
 import { CheckAuthService } from '../../check-auth.service';
@@ -53,14 +53,18 @@ export class PopUpLoginService {
 
         this.popupService.openPopUp(authUrl, popupOptions);
 
-        return this.popupService.receivedUrl$.pipe(
+        return this.popupService.result$.pipe(
           take(1),
-          switchMap((url: string) => this.checkAuthService.checkAuth(url)),
-          map((isAuthenticated) => ({
-            isAuthenticated,
-            userData: this.userService.getUserDataFromStore(),
-            accessToken: this.authStateService.getAccessToken(),
-          }))
+          switchMap((result) => (result.userClosed === true ? of(false) : this.checkAuthService.checkAuth(result.receivedUrl))),
+          map((isAuthenticated) =>
+            isAuthenticated
+              ? {
+                  isAuthenticated: true,
+                  userData: this.userService.getUserDataFromStore(),
+                  accessToken: this.authStateService.getAccessToken(),
+                }
+              : { isAuthenticated: false }
+          )
         );
       })
     );

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup-result.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup-result.ts
@@ -1,0 +1,10 @@
+export interface PopupResultUserClosed {
+  userClosed: true;
+}
+
+export interface PopupResultReceivedUrl {
+  userClosed: false;
+  receivedUrl: string;
+}
+
+export type PopupResult = PopupResultUserClosed | PopupResultReceivedUrl;

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service-mock.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service-mock.ts
@@ -8,6 +8,10 @@ export class PopUpServiceMock {
     return of(null);
   }
 
+  get result$() {
+    return of(null);
+  }
+
   hasPopup() {
     return true;
   }

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service-mock.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service-mock.ts
@@ -4,10 +4,6 @@ import { PopupOptions } from './popup-options';
 
 @Injectable({ providedIn: 'root' })
 export class PopUpServiceMock {
-  get receivedUrl$() {
-    return of(null);
-  }
-
   get result$() {
     return of(null);
   }

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.spec.ts
@@ -1,4 +1,5 @@
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { PopupResult } from './popup-result';
 import { PopUpService } from './popup.service';
 
 describe('PopUpService', () => {
@@ -68,6 +69,21 @@ describe('PopUpService', () => {
     );
   });
 
+  describe('result$', () => {
+    it(
+      'emits when internal subject is called',
+      waitForAsync(() => {
+        const popupResult: PopupResult = { userClosed: false, receivedUrl: 'some-url1111' };
+
+        popUpService.result$.subscribe((result) => {
+          expect(result).toBe(popupResult);
+        });
+
+        (popUpService as any).resultInternal$.next(popupResult);
+      })
+    );
+  });
+
   describe('openPopup', () => {
     it(
       'popup opens with parameters and default options',
@@ -76,6 +92,8 @@ describe('PopUpService', () => {
           () =>
             ({
               sessionStorage: mockStorage,
+              closed: true,
+              close: () => {},
             } as Window)
         );
         popUpService.openPopUp('url');
@@ -91,6 +109,8 @@ describe('PopUpService', () => {
           () =>
             ({
               sessionStorage: mockStorage,
+              closed: true,
+              close: () => {},
             } as Window)
         );
         popUpService.openPopUp('url', { width: 100 });
@@ -98,6 +118,60 @@ describe('PopUpService', () => {
         expect(popupSpy).toHaveBeenCalledOnceWith('url', '_blank', 'width=100,height=500,left=50,top=50');
       })
     );
+
+    describe('popup closed', () => {
+      let popup: Window;
+      let popupResult: PopupResult;
+      let cleanUpSpy: jasmine.Spy;
+
+      beforeEach(() => {
+        popup = {
+          sessionStorage: mockStorage,
+          closed: false,
+          close: () => {},
+        } as Window;
+
+        spyOn(window, 'open').and.returnValue(popup);
+
+        cleanUpSpy = spyOn(popUpService as any, 'cleanUp').and.callThrough();
+
+        popupResult = undefined;
+
+        popUpService.result$.subscribe((result) => (popupResult = result));
+      });
+
+      it('message received', fakeAsync(() => {
+        let listener: (event: MessageEvent) => void;
+
+        spyOn(window, 'addEventListener').and.callFake((_, func) => (listener = func));
+
+        popUpService.openPopUp('url');
+
+        expect(popupResult).toBeUndefined();
+        expect(cleanUpSpy).not.toHaveBeenCalled();
+
+        listener(new MessageEvent('message', { data: 'some-url1111' }));
+
+        tick(200);
+
+        expect(popupResult).toEqual({ userClosed: false, receivedUrl: 'some-url1111' });
+        expect(cleanUpSpy).toHaveBeenCalledWith(listener);
+      }));
+
+      it('user closed', fakeAsync(() => {
+        popUpService.openPopUp('url');
+
+        expect(popupResult).toBeUndefined();
+        expect(cleanUpSpy).not.toHaveBeenCalled();
+
+        (popup as any).closed = true;
+
+        tick(200);
+
+        expect(popupResult).toEqual({ userClosed: true });
+        expect(cleanUpSpy).toHaveBeenCalled();
+      }));
+    });
   });
 
   describe('sendMessageToMainWindow', () => {

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.spec.ts
@@ -56,19 +56,6 @@ describe('PopUpService', () => {
     });
   });
 
-  describe('receivedUrl$', () => {
-    it(
-      'emits when internal subject is called',
-      waitForAsync(() => {
-        popUpService.receivedUrl$.subscribe((result) => {
-          expect(result).toBe('some-url1111');
-        });
-
-        (popUpService as any).receivedUrlInternal$.next('some-url1111');
-      })
-    );
-  });
-
   describe('result$', () => {
     it(
       'emits when internal subject is called',

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
@@ -1,15 +1,22 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { PopupOptions } from './popup-options';
+import { PopupResult } from './popup-result';
 
 @Injectable({ providedIn: 'root' })
 export class PopUpService {
   private STORAGE_IDENTIFIER = 'popupauth';
   private popUp: Window;
+  private handle: number;
   private receivedUrlInternal$ = new Subject<string>();
+  private resultInternal$ = new Subject<PopupResult>();
 
   get receivedUrl$(): Observable<string> {
     return this.receivedUrlInternal$.asObservable();
+  }
+
+  get result$(): Observable<PopupResult> {
+    return this.resultInternal$.asObservable();
   }
 
   isCurrentlyInPopup(): boolean {
@@ -29,10 +36,20 @@ export class PopUpService {
 
       this.receivedUrlInternal$.next(event.data);
 
+      this.resultInternal$.next({ userClosed: false, receivedUrl: event.data });
+
       this.cleanUp(listener);
     };
 
     window.addEventListener('message', listener, false);
+
+    this.handle = window.setInterval(() => {
+      if (this.popUp.closed) {
+        this.resultInternal$.next({ userClosed: true });
+
+        this.cleanUp(listener);
+      }
+    }, 200);
   }
 
   sendMessageToMainWindow(url: string): void {
@@ -44,8 +61,10 @@ export class PopUpService {
   private cleanUp(listener: any): void {
     window.removeEventListener('message', listener, false);
 
+    window.clearInterval(this.handle);
+
     if (this.popUp) {
-      this.popUp.sessionStorage.removeItem(this.STORAGE_IDENTIFIER);
+      this.popUp.sessionStorage?.removeItem(this.STORAGE_IDENTIFIER);
       this.popUp.close();
       this.popUp = null;
     }

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
@@ -8,12 +8,7 @@ export class PopUpService {
   private STORAGE_IDENTIFIER = 'popupauth';
   private popUp: Window;
   private handle: number;
-  private receivedUrlInternal$ = new Subject<string>();
   private resultInternal$ = new Subject<PopupResult>();
-
-  get receivedUrl$(): Observable<string> {
-    return this.receivedUrlInternal$.asObservable();
-  }
 
   get result$(): Observable<PopupResult> {
     return this.resultInternal$.asObservable();
@@ -33,8 +28,6 @@ export class PopUpService {
       if (!event?.data || typeof event.data !== 'string') {
         return;
       }
-
-      this.receivedUrlInternal$.next(event.data);
 
       this.resultInternal$.next({ userClosed: false, receivedUrl: event.data });
 

--- a/projects/sample-code-flow-popup/src/app/app.component.ts
+++ b/projects/sample-code-flow-popup/src/app/app.component.ts
@@ -31,10 +31,11 @@ export class AppComponent {
   }
 
   loginWithPopup() {
-    this.oidcSecurityService.authorizeWithPopUp().subscribe(({ isAuthenticated, userData, accessToken }) => {
+    this.oidcSecurityService.authorizeWithPopUp().subscribe(({ isAuthenticated, userData, accessToken, errorMessage }) => {
       console.log(isAuthenticated);
       console.log(userData);
       console.log(accessToken);
+      console.log(errorMessage);
     });
   }
 


### PR DESCRIPTION
I noticed there is no way of getting notified when a user closes the login popup. The registered event handler in the main window also does not get removed in this case. This PR solves these issues.

Open questions to discuss:
+ Is it problematic if `accessToken` and `userData` are undefined in `LoginResult`?
+ Should an `errorMessage` property be added to `LoginResult`?
  ```ts
  {
    isAuthenticated: false,
    errorMessage: "User closed popup"
  }
  ```