### PR TITLE
Renamed all occurrences of "Persistance" to "Persistence"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@
 /bazel-out
 
 # dependencies
-/node_modules
+node_modules
 
 # profiling files
 chrome-profiler-events*.json

--- a/projects/angular-auth-oidc-client/src/lib/auth.module.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth.module.ts
@@ -39,7 +39,7 @@ import { OidcSecurityService } from './oidc.security.service';
 import { PublicEventsService } from './public-events/public-events.service';
 import { AbstractSecurityStorage } from './storage/abstract-security-storage';
 import { BrowserStorageService } from './storage/browser-storage.service';
-import { StoragePersistanceService } from './storage/storage-persistance.service';
+import { StoragePersistenceService } from './storage/storage-persistence.service';
 import { UserService } from './userData/user-service';
 import { EqualityService } from './utils/equality/equality.service';
 import { FlowHelper } from './utils/flowHelper/flow-helper.service';
@@ -77,7 +77,7 @@ export class AuthModule {
         UrlService,
         AuthStateService,
         SigninKeyDataService,
-        StoragePersistanceService,
+        StoragePersistenceService,
         TokenHelperService,
         LoggerService,
         IFrameService,

--- a/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.spec.ts
@@ -4,8 +4,8 @@ import { EventTypes, PublicEventsService } from '../../public-api';
 import { ConfigurationProvider } from '../config/config.provider';
 import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { PlatformProvider } from '../utils/platform-provider/platform.provider';
 import { PlatformProviderMock } from '../utils/platform-provider/platform.provider-mock';
 import { TokenValidationService } from '../validation/token-validation.service';
@@ -14,7 +14,7 @@ import { AuthStateService } from './auth-state.service';
 
 describe('Auth State Service', () => {
   let authStateService: AuthStateService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let eventsService: PublicEventsService;
   let tokenValidationService: TokenValidationService;
   let configurationProvider: ConfigurationProvider;
@@ -29,8 +29,8 @@ describe('Auth State Service', () => {
         { provide: TokenValidationService, useClass: TokenValidationServiceMock },
         { provide: PlatformProvider, useClass: PlatformProviderMock },
         {
-          provide: StoragePersistanceService,
-          useClass: StoragePersistanceServiceMock,
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
       ],
     });
@@ -38,7 +38,7 @@ describe('Auth State Service', () => {
 
   beforeEach(() => {
     authStateService = TestBed.inject(AuthStateService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     eventsService = TestBed.inject(PublicEventsService);
     tokenValidationService = TestBed.inject(TokenValidationService);
     configurationProvider = TestBed.inject(ConfigurationProvider);
@@ -62,7 +62,7 @@ describe('Auth State Service', () => {
 
   describe('setUnauthorizedAndFireEvent', () => {
     it('persist AuthState In Storage', () => {
-      const spy = spyOn(storagePersistanceService, 'resetAuthStateInStorage');
+      const spy = spyOn(storagePersistenceService, 'resetAuthStateInStorage');
       authStateService.setUnauthorizedAndFireEvent();
       expect(spy).toHaveBeenCalled();
     });
@@ -84,7 +84,7 @@ describe('Auth State Service', () => {
 
   describe('setAuthorizationData', () => {
     it('stores accessToken', () => {
-      const spy = spyOn(storagePersistanceService, 'write');
+      const spy = spyOn(storagePersistenceService, 'write');
       const authResult = {
         id_token: 'idtoken',
         access_token: 'accesstoken',
@@ -118,22 +118,22 @@ describe('Auth State Service', () => {
 
   describe('getAccessToken', () => {
     it('isAuthorized is false returns empty string', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('');
       const result = authStateService.getAccessToken();
       expect(result).toBe('');
     });
 
-    it('returns false if storagePersistanceService returns something falsy but authorized', () => {
+    it('returns false if storagePersistenceService returns something falsy but authorized', () => {
       spyOnProperty(authStateService as any, 'isAuthorized', 'get').and.returnValue(true);
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('');
       const result = authStateService.getAccessToken();
       expect(result).toBe('');
     });
 
     it('isAuthorized is true returns decodeURIComponent(token)', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('HenloLegger');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('HenloFuriend');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('HenloLegger');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('HenloFuriend');
       const result = authStateService.getAccessToken();
       expect(result).toBe(decodeURIComponent('HenloLegger'));
     });
@@ -141,15 +141,15 @@ describe('Auth State Service', () => {
 
   describe('getIdToken', () => {
     it('isAuthorized is false returns empty string', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('');
       const result = authStateService.getIdToken();
       expect(result).toBe('');
     });
 
     it('isAuthorized is true returns decodeURIComponent(token)', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('HenloLegger');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('HenloFuriend');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('HenloLegger');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('HenloFuriend');
       const result = authStateService.getIdToken();
       expect(result).toBe(decodeURIComponent('HenloFuriend'));
     });
@@ -157,16 +157,16 @@ describe('Auth State Service', () => {
 
   describe('getRefreshToken', () => {
     it('isAuthorized is false returns empty string', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('');
       const result = authStateService.getRefreshToken();
       expect(result).toBe('');
     });
 
     it('isAuthorized is truereturns decodeURIComponent(token)', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('HenloLegger');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('HenloFuriend');
-      spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue('HenloRefreshLegger');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('HenloLegger');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('HenloFuriend');
+      spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue('HenloRefreshLegger');
       const result = authStateService.getRefreshToken();
       expect(result).toBe(decodeURIComponent('HenloRefreshLegger'));
     });
@@ -174,15 +174,15 @@ describe('Auth State Service', () => {
 
   describe('areAuthStorageTokensValid', () => {
     it('isAuthorized is false returns false', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('');
       const result = authStateService.areAuthStorageTokensValid();
       expect(result).toBeFalse();
     });
 
     it('isAuthorized is true and id_token is expired returns true', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('HenloLegger');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('HenloFuriend');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('HenloLegger');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('HenloFuriend');
 
       spyOn(authStateService as any, 'hasIdTokenExpired').and.returnValue(true);
       spyOn(authStateService as any, 'hasAccessTokenExpiredIfExpiryExists').and.returnValue(false);
@@ -191,8 +191,8 @@ describe('Auth State Service', () => {
     });
 
     it('isAuthorized is true  and access_token is expired returns true', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('HenloLegger');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('HenloFuriend');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('HenloLegger');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('HenloFuriend');
 
       spyOn(authStateService as any, 'hasIdTokenExpired').and.returnValue(false);
       spyOn(authStateService as any, 'hasAccessTokenExpiredIfExpiryExists').and.returnValue(true);
@@ -201,8 +201,8 @@ describe('Auth State Service', () => {
     });
 
     it('isAuthorized is true  and id_token is not expired returns true', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('HenloLegger');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('HenloFuriend');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('HenloLegger');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('HenloFuriend');
 
       spyOn(authStateService as any, 'hasIdTokenExpired').and.returnValue(false);
       spyOn(authStateService as any, 'hasAccessTokenExpiredIfExpiryExists').and.returnValue(false);
@@ -211,8 +211,8 @@ describe('Auth State Service', () => {
     });
 
     it('authState is AuthorizedState.Authorized and id_token is not expired fires event', () => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('HenloLegger');
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue('HenloFuriend');
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('HenloLegger');
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue('HenloFuriend');
 
       spyOn(authStateService as any, 'hasIdTokenExpired').and.returnValue(false);
       spyOn(authStateService as any, 'hasAccessTokenExpiredIfExpiryExists').and.returnValue(false);
@@ -224,7 +224,7 @@ describe('Auth State Service', () => {
   describe('hasIdTokenExpired', () => {
     it('tokenValidationService gets called with id token if id_token is set', () => {
       configurationProvider.setConfig({ renewTimeBeforeTokenExpiresInSeconds: 30 });
-      spyOn(storagePersistanceService, 'read').withArgs('authnResult').and.returnValue({ id_token: 'idToken' });
+      spyOn(storagePersistenceService, 'read').withArgs('authnResult').and.returnValue({ id_token: 'idToken' });
       const spy = spyOn(tokenValidationService, 'hasIdTokenExpired').and.callFake((a, b) => true);
       authStateService.hasIdTokenExpired();
       expect(spy).toHaveBeenCalledWith('idToken', 30);
@@ -236,7 +236,7 @@ describe('Auth State Service', () => {
 
       const spy = spyOn(eventsService, 'fireEvent');
 
-      spyOn(storagePersistanceService, 'read').withArgs('authnResult').and.returnValue('idToken');
+      spyOn(storagePersistenceService, 'read').withArgs('authnResult').and.returnValue('idToken');
       const result = authStateService.hasIdTokenExpired();
       expect(result).toBe(true);
       expect(spy).toHaveBeenCalledWith(EventTypes.IdTokenExpired, true);
@@ -248,7 +248,7 @@ describe('Auth State Service', () => {
 
       const spy = spyOn(eventsService, 'fireEvent');
 
-      spyOn(storagePersistanceService, 'read').withArgs('authnResult').and.returnValue('idToken');
+      spyOn(storagePersistenceService, 'read').withArgs('authnResult').and.returnValue('idToken');
       const result = authStateService.hasIdTokenExpired();
       expect(result).toBe(false);
       expect(spy).not.toHaveBeenCalled();
@@ -261,7 +261,7 @@ describe('Auth State Service', () => {
       const expectedResult = !validateAccessTokenNotExpiredResult;
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ renewTimeBeforeTokenExpiresInSeconds: 5 });
       const date = new Date(new Date().toUTCString());
-      spyOn(storagePersistanceService, 'read').withArgs('access_token_expires_at').and.returnValue(date);
+      spyOn(storagePersistenceService, 'read').withArgs('access_token_expires_at').and.returnValue(date);
       const spy = spyOn(tokenValidationService, 'validateAccessTokenNotExpired').and.returnValue(validateAccessTokenNotExpiredResult);
       const result = authStateService.hasAccessTokenExpiredIfExpiryExists();
       expect(spy).toHaveBeenCalledWith(date, 5);
@@ -276,7 +276,7 @@ describe('Auth State Service', () => {
 
       spyOn(eventsService, 'fireEvent');
 
-      spyOn(storagePersistanceService, 'read').withArgs('access_token_expires_at').and.returnValue(date);
+      spyOn(storagePersistenceService, 'read').withArgs('access_token_expires_at').and.returnValue(date);
       spyOn(tokenValidationService, 'validateAccessTokenNotExpired').and.returnValue(validateAccessTokenNotExpiredResult);
       authStateService.hasAccessTokenExpiredIfExpiryExists();
       expect(eventsService.fireEvent).toHaveBeenCalledWith(EventTypes.TokenExpired, expectedResult);

--- a/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/authState/auth-state.service.ts
@@ -4,7 +4,7 @@ import { ConfigurationProvider } from '../config/config.provider';
 import { LoggerService } from '../logging/logger.service';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { TokenValidationService } from '../validation/token-validation.service';
 import { AuthorizationResult } from './authorization-result';
 
@@ -17,11 +17,11 @@ export class AuthStateService {
   }
 
   private get isAuthorized() {
-    return !!this.storagePersistanceService.getAccessToken() && !!this.storagePersistanceService.getIdToken();
+    return !!this.storagePersistenceService.getAccessToken() && !!this.storagePersistenceService.getIdToken();
   }
 
   constructor(
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private loggerService: LoggerService,
     private publicEventsService: PublicEventsService,
     private configurationProvider: ConfigurationProvider,
@@ -33,7 +33,7 @@ export class AuthStateService {
   }
 
   setUnauthorizedAndFireEvent(): void {
-    this.storagePersistanceService.resetAuthStateInStorage();
+    this.storagePersistenceService.resetAuthStateInStorage();
     this.authorizedInternal$.next(false);
   }
 
@@ -45,7 +45,7 @@ export class AuthStateService {
     this.loggerService.logDebug(accessToken);
     this.loggerService.logDebug('storing the accessToken');
 
-    this.storagePersistanceService.write('authzData', accessToken);
+    this.storagePersistenceService.write('authzData', accessToken);
     this.persistAccessTokenExpirationTime(authResult);
     this.setAuthorizedAndFireEvent();
   }
@@ -55,7 +55,7 @@ export class AuthStateService {
       return '';
     }
 
-    const token = this.storagePersistanceService.getAccessToken();
+    const token = this.storagePersistenceService.getAccessToken();
     return this.decodeURIComponentSafely(token);
   }
 
@@ -64,7 +64,7 @@ export class AuthStateService {
       return '';
     }
 
-    const token = this.storagePersistanceService.getIdToken();
+    const token = this.storagePersistenceService.getIdToken();
     return this.decodeURIComponentSafely(token);
   }
 
@@ -73,7 +73,7 @@ export class AuthStateService {
       return '';
     }
 
-    const token = this.storagePersistanceService.getRefreshToken();
+    const token = this.storagePersistenceService.getRefreshToken();
     return this.decodeURIComponentSafely(token);
   }
 
@@ -97,7 +97,7 @@ export class AuthStateService {
   }
 
   hasIdTokenExpired() {
-    const tokenToCheck = this.storagePersistanceService.getIdToken();
+    const tokenToCheck = this.storagePersistenceService.getIdToken();
     const { renewTimeBeforeTokenExpiresInSeconds } = this.configurationProvider.getOpenIDConfiguration();
 
     const idTokenExpired = this.tokenValidationService.hasIdTokenExpired(tokenToCheck, renewTimeBeforeTokenExpiresInSeconds);
@@ -111,7 +111,7 @@ export class AuthStateService {
 
   hasAccessTokenExpiredIfExpiryExists() {
     const { renewTimeBeforeTokenExpiresInSeconds } = this.configurationProvider.getOpenIDConfiguration();
-    const accessTokenExpiresIn = this.storagePersistanceService.read('access_token_expires_at');
+    const accessTokenExpiresIn = this.storagePersistenceService.read('access_token_expires_at');
     const accessTokenHasNotExpired = this.tokenValidationService.validateAccessTokenNotExpired(
       accessTokenExpiresIn,
       renewTimeBeforeTokenExpiresInSeconds
@@ -137,7 +137,7 @@ export class AuthStateService {
   private persistAccessTokenExpirationTime(authResult: any) {
     if (authResult?.expires_in) {
       const accessTokenExpiryTime = new Date(new Date().toUTCString()).valueOf() + authResult.expires_in * 1000;
-      this.storagePersistanceService.write('access_token_expires_at', accessTokenExpiryTime);
+      this.storagePersistenceService.write('access_token_expires_at', accessTokenExpiryTime);
     }
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.spec.ts
@@ -13,7 +13,7 @@ import { RefreshSessionIframeServiceMock } from '../iframe/refresh-session-ifram
 import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
 import { AbstractSecurityStorage } from '../storage/abstract-security-storage';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { UserService } from '../userData/user-service';
 import { UserServiceMock } from '../userData/user-service-mock';
 import { FlowHelper } from '../utils/flowHelper/flow-helper.service';
@@ -32,7 +32,7 @@ describe('PeriodicallyTokenCheckService', () => {
   let refreshSessionIframeService: RefreshSessionIframeService;
   let refreshSessionRefreshTokenService: RefreshSessionRefreshTokenService;
   let userService: UserService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let resetAuthDataService: ResetAuthDataService;
 
   beforeEach(() => {
@@ -52,7 +52,7 @@ describe('PeriodicallyTokenCheckService', () => {
           useClass: RefreshSessionIframeServiceMock,
         },
         IntervallService,
-        StoragePersistanceService,
+        StoragePersistenceService,
         AbstractSecurityStorage,
       ],
     });
@@ -68,7 +68,7 @@ describe('PeriodicallyTokenCheckService', () => {
     refreshSessionIframeService = TestBed.inject(RefreshSessionIframeService);
     refreshSessionRefreshTokenService = TestBed.inject(RefreshSessionRefreshTokenService);
     userService = TestBed.inject(UserService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     resetAuthDataService = TestBed.inject(ResetAuthDataService);
   });
 
@@ -172,7 +172,7 @@ describe('PeriodicallyTokenCheckService', () => {
       const resetAuthorizationDataSpy = spyOn(resetAuthDataService, 'resetAuthorizationData');
 
       spyOn(authStateService, 'hasIdTokenExpired').and.returnValue(true);
-      spyOn(storagePersistanceService, 'read').withArgs('storageCustomRequestParams').and.returnValue(undefined);
+      spyOn(storagePersistenceService, 'read').withArgs('storageCustomRequestParams').and.returnValue(undefined);
       spyOn(authStateService, 'hasAccessTokenExpiredIfExpiryExists').and.returnValue(true);
 
       spyOn(refreshSessionIframeService, 'refreshSessionWithIframe').and.returnValue(of(true));
@@ -193,7 +193,7 @@ describe('PeriodicallyTokenCheckService', () => {
       spyOn(authStateService, 'getIdToken').and.returnValue('some-id-token');
       spyOn(flowsDataService, 'isSilentRenewRunning').and.returnValue(false);
       spyOn(userService, 'getUserDataFromStore').and.returnValue('some-userdata');
-      spyOn(storagePersistanceService, 'read').withArgs('storageCustomRequestParams').and.returnValue(undefined);
+      spyOn(storagePersistenceService, 'read').withArgs('storageCustomRequestParams').and.returnValue(undefined);
       spyOn(resetAuthDataService, 'resetAuthorizationData');
 
       spyOn(authStateService, 'hasIdTokenExpired').and.returnValue(true);

--- a/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/periodically-token-check.service.ts
@@ -7,7 +7,7 @@ import { FlowsDataService } from '../flows/flows-data.service';
 import { ResetAuthDataService } from '../flows/reset-auth-data.service';
 import { RefreshSessionIframeService } from '../iframe/refresh-session-iframe.service';
 import { LoggerService } from '../logging/logger.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { UserService } from '../userData/user-service';
 import { FlowHelper } from '../utils/flowHelper/flow-helper.service';
 import { IntervallService } from './intervall.service';
@@ -26,7 +26,7 @@ export class PeriodicallyTokenCheckService {
     private refreshSessionIframeService: RefreshSessionIframeService,
     private refreshSessionRefreshTokenService: RefreshSessionRefreshTokenService,
     private intervalService: IntervallService,
-    private storagePersistanceService: StoragePersistanceService
+    private storagePersistenceService: StoragePersistenceService
   ) {}
 
   startTokenValidationPeriodically(repeatAfterSeconds: number) {
@@ -73,7 +73,7 @@ export class PeriodicallyTokenCheckService {
         this.flowsDataService.setSilentRenewRunning();
 
         // Retrieve Dynamically Set Custom Params
-        const customParams: { [key: string]: string | number | boolean } = this.storagePersistanceService.read(
+        const customParams: { [key: string]: string | number | boolean } = this.storagePersistenceService.read(
           'storageCustomRequestParams'
         );
 

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known.service.spec.ts
@@ -4,22 +4,22 @@ import { DataService } from '../api/data.service';
 import { DataServiceMock } from '../api/data.service-mock';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { AuthWellKnownDataService } from './auth-well-known-data.service';
 import { AuthWellKnownService } from './auth-well-known.service';
 
 describe('AuthWellKnownService', () => {
   let service: AuthWellKnownService;
   let dataService: AuthWellKnownDataService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let publicEventsService: PublicEventsService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
         AuthWellKnownService,
-        { provide: StoragePersistanceService, useClass: StoragePersistanceServiceMock },
+        { provide: StoragePersistenceService, useClass: StoragePersistenceServiceMock },
         { provide: DataService, useClass: DataServiceMock },
         AuthWellKnownDataService,
         PublicEventsService,
@@ -30,7 +30,7 @@ describe('AuthWellKnownService', () => {
   beforeEach(() => {
     service = TestBed.inject(AuthWellKnownService);
     dataService = TestBed.inject(AuthWellKnownDataService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     publicEventsService = TestBed.inject(PublicEventsService);
   });
 
@@ -43,7 +43,7 @@ describe('AuthWellKnownService', () => {
       'getAuthWellKnownEndPoints return stored endpoints if they exist',
       waitForAsync(() => {
         const dataServiceSpy = spyOn(dataService, 'getWellKnownEndPointsFromUrl');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ issuer: 'anything' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ issuer: 'anything' });
         service.getAuthWellKnownEndPoints('any-url').subscribe((result) => {
           expect(dataServiceSpy).not.toHaveBeenCalled();
           expect(result).toEqual({ issuer: 'anything' });
@@ -55,7 +55,7 @@ describe('AuthWellKnownService', () => {
       'getAuthWellKnownEndPoints calls dataservice if none is stored',
       waitForAsync(() => {
         const dataServiceSpy = spyOn(dataService, 'getWellKnownEndPointsFromUrl').and.returnValue(of({ issuer: 'anything' }));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         service.getAuthWellKnownEndPoints('any-url').subscribe((result) => {
           expect(dataServiceSpy).toHaveBeenCalled();
           expect(result).toEqual({ issuer: 'anything' });
@@ -67,7 +67,7 @@ describe('AuthWellKnownService', () => {
       'getAuthWellKnownEndPoints stored the result if http cal is made',
       waitForAsync(() => {
         const dataServiceSpy = spyOn(dataService, 'getWellKnownEndPointsFromUrl').and.returnValue(of({ issuer: 'anything' }));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         const storeSpy = spyOn(service, 'storeWellKnownEndpoints');
         service.getAuthWellKnownEndPoints('any-url').subscribe((result) => {
           expect(dataServiceSpy).toHaveBeenCalled();

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known.service.ts
@@ -3,7 +3,7 @@ import { of, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { AuthWellKnownDataService } from './auth-well-known-data.service';
 import { AuthWellKnownEndpoints } from './auth-well-known-endpoints';
 import { PublicConfiguration } from './public-configuration';
@@ -13,11 +13,11 @@ export class AuthWellKnownService {
   constructor(
     private publicEventsService: PublicEventsService,
     private dataService: AuthWellKnownDataService,
-    private storagePersistanceService: StoragePersistanceService
+    private storagePersistenceService: StoragePersistenceService
   ) {}
 
   getAuthWellKnownEndPoints(authWellknownEndpointUrl: string) {
-    const alreadySavedWellKnownEndpoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const alreadySavedWellKnownEndpoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     if (!!alreadySavedWellKnownEndpoints) {
       return of(alreadySavedWellKnownEndpoints);
     }
@@ -32,7 +32,7 @@ export class AuthWellKnownService {
   }
 
   storeWellKnownEndpoints(mappedWellKnownEndpoints: AuthWellKnownEndpoints) {
-    this.storagePersistanceService.write('authWellKnownEndPoints', mappedWellKnownEndpoints);
+    this.storagePersistenceService.write('authWellKnownEndPoints', mappedWellKnownEndpoints);
   }
 
   private getWellKnownEndPointsFromUrl(authWellknownEndpoint: string) {

--- a/projects/angular-auth-oidc-client/src/lib/config/config.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/config.service.spec.ts
@@ -7,8 +7,8 @@ import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { AuthWellKnownService } from './auth-well-known.service';
 import { AuthWellKnownServiceMock } from './auth-well-known.service-mock';
 import { ConfigurationProvider } from './config.provider';
@@ -21,7 +21,7 @@ describe('Configuration Service', () => {
   let eventsService: PublicEventsService;
   let configurationProvider: ConfigurationProvider;
   let authWellKnownService: AuthWellKnownService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let configValidationService: ConfigValidationService;
 
   beforeEach(() => {
@@ -45,8 +45,8 @@ describe('Configuration Service', () => {
           useClass: AuthWellKnownServiceMock,
         },
         {
-          provide: StoragePersistanceService,
-          useClass: StoragePersistanceServiceMock,
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
         PublicEventsService,
         ConfigValidationService,
@@ -60,7 +60,7 @@ describe('Configuration Service', () => {
     eventsService = TestBed.inject(PublicEventsService);
     configurationProvider = TestBed.inject(ConfigurationProvider);
     authWellKnownService = TestBed.inject(AuthWellKnownService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     configValidationService = TestBed.inject(ConfigValidationService);
   });
 
@@ -92,7 +92,7 @@ describe('Configuration Service', () => {
       'if authWellKnownEndPointsAlreadyStored the events are fired and resolve',
       waitForAsync(() => {
         const config = { stsServer: 'stsServerForTesting', authWellknownEndpoint: null };
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ any: 'thing' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ any: 'thing' });
         const eventServiceSpy = spyOn(eventsService, 'fireEvent');
         spyOn(configValidationService, 'validateConfig').and.returnValue(true);
         const promise = oidcConfigService.withConfig(config);
@@ -113,7 +113,7 @@ describe('Configuration Service', () => {
       waitForAsync(() => {
         const config = { stsServer: 'stsServerForTesting', authWellknownEndpoint: null };
         const authWellKnown = { issuer: 'issuerForTesting' };
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         spyOn(configValidationService, 'validateConfig').and.returnValue(true);
         const eventServiceSpy = spyOn(eventsService, 'fireEvent');
         const storeWellKnownEndpointsSpy = spyOn(authWellKnownService, 'storeWellKnownEndpoints');
@@ -135,7 +135,7 @@ describe('Configuration Service', () => {
       'if eagerLoadAuthWellKnownEndpoints is true: call getAuthWellKnownEndPoints',
       waitForAsync(() => {
         const config = { stsServer: 'stsServerForTesting', eagerLoadAuthWellKnownEndpoints: true };
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         spyOn(configurationProvider, 'setConfig').and.returnValue(config);
         spyOn(configValidationService, 'validateConfig').and.returnValue(true);
         const getWellKnownEndPointsFromUrlSpy = spyOn(authWellKnownService, 'getAuthWellKnownEndPoints').and.returnValue(of(null));
@@ -150,7 +150,7 @@ describe('Configuration Service', () => {
       'if eagerLoadAuthWellKnownEndpoints is false: DO NOT call getAuthWellKnownEndPoints',
       waitForAsync(() => {
         const config = { stsServer: 'stsServerForTesting', eagerLoadAuthWellKnownEndpoints: false };
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         const storeWellKnownEndpointsSpy = spyOn(authWellKnownService, 'getAuthWellKnownEndPoints').and.returnValue(of(null));
         spyOn(configurationProvider, 'setConfig').and.returnValue(config);
         spyOn(configValidationService, 'validateConfig').and.returnValue(true);
@@ -165,7 +165,7 @@ describe('Configuration Service', () => {
       'if eagerLoadAuthWellKnownEndpoints is true: fire event',
       waitForAsync(() => {
         const config = { stsServer: 'stsServerForTesting', eagerLoadAuthWellKnownEndpoints: true };
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         spyOn(configurationProvider, 'setConfig').and.returnValue(config);
         spyOn(configValidationService, 'validateConfig').and.returnValue(true);
         spyOn(authWellKnownService, 'getAuthWellKnownEndPoints').and.returnValue(of({ issuer: 'issuerForTesting' }));

--- a/projects/angular-auth-oidc-client/src/lib/config/config.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/config.service.ts
@@ -6,7 +6,7 @@ import { ConfigurationProvider } from '../config/config.provider';
 import { LoggerService } from '../logging/logger.service';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { AuthWellKnownEndpoints } from './auth-well-known-endpoints';
 import { AuthWellKnownService } from './auth-well-known.service';
 import { OpenIdConfiguration } from './openid-configuration';
@@ -19,7 +19,7 @@ export class OidcConfigService {
     private publicEventsService: PublicEventsService,
     private configurationProvider: ConfigurationProvider,
     private authWellKnownService: AuthWellKnownService,
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private configValidationService: ConfigValidationService
   ) {}
 
@@ -36,7 +36,7 @@ export class OidcConfigService {
 
       const usedConfig = this.configurationProvider.setConfig(passedConfig);
 
-      const alreadyExistingAuthWellKnownEndpoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+      const alreadyExistingAuthWellKnownEndpoints = this.storagePersistenceService.read('authWellKnownEndPoints');
       if (!!alreadyExistingAuthWellKnownEndpoints) {
         this.publicEventsService.fireEvent<PublicConfiguration>(EventTypes.ConfigLoaded, {
           configuration: passedConfig,

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.spec.ts
@@ -8,8 +8,8 @@ import { ConfigurationProvider } from '../../config/config.provider';
 import { ConfigurationProviderMock } from '../../config/config.provider-mock';
 import { LoggerService } from '../../logging/logger.service';
 import { LoggerServiceMock } from '../../logging/logger.service-mock';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../../storage/storage-persistence-service-mock.service';
 import { UrlService } from '../../utils/url/url.service';
 import { UrlServiceMock } from '../../utils/url/url.service-mock';
 import { TokenValidationService } from '../../validation/token-validation.service';
@@ -22,7 +22,7 @@ import { CodeFlowCallbackHandlerService } from './code-flow-callback-handler.ser
 describe('CodeFlowCallbackHandlerService', () => {
   let service: CodeFlowCallbackHandlerService;
   let dataService: DataService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let tokenValidationService: TokenValidationService;
   let configurationProvider: ConfigurationProvider;
   let urlService: UrlService;
@@ -36,7 +36,7 @@ describe('CodeFlowCallbackHandlerService', () => {
         { provide: TokenValidationService, useClass: TokenValidationServiceMock },
         { provide: FlowsDataService, useClass: FlowsDataServiceMock },
         { provide: ConfigurationProvider, useClass: ConfigurationProviderMock },
-        { provide: StoragePersistanceService, useClass: StoragePersistanceServiceMock },
+        { provide: StoragePersistenceService, useClass: StoragePersistenceServiceMock },
         { provide: DataService, useClass: DataServiceMock },
       ],
     });
@@ -47,7 +47,7 @@ describe('CodeFlowCallbackHandlerService', () => {
     dataService = TestBed.inject(DataService);
     urlService = TestBed.inject(UrlService);
     configurationProvider = TestBed.inject(ConfigurationProvider);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     tokenValidationService = TestBed.inject(TokenValidationService);
   });
 
@@ -145,7 +145,7 @@ describe('CodeFlowCallbackHandlerService', () => {
       'calls dataService if all params are good',
       waitForAsync(() => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(of({}));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
 
         service.codeFlowCodeRequest({} as CallbackContext).subscribe((callbackContext) => {
           expect(postSpy).toHaveBeenCalledWith('tokenEndpoint', '', jasmine.any(HttpHeaders));
@@ -157,7 +157,7 @@ describe('CodeFlowCallbackHandlerService', () => {
       'calls url service with custom token params',
       waitForAsync(() => {
         const urlServiceSpy = spyOn(urlService, 'createBodyForCodeFlowCodeRequest');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
 
         const postSpy = spyOn(dataService, 'post').and.returnValue(of({}));
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ customTokenParams: { foo: 'bar' } });
@@ -173,7 +173,7 @@ describe('CodeFlowCallbackHandlerService', () => {
       'calls dataService with correct headers if all params are good',
       waitForAsync(() => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(of({}));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
 
         service.codeFlowCodeRequest({} as CallbackContext).subscribe((callbackContext) => {
           const httpHeaders = postSpy.calls.mostRecent().args[2] as HttpHeaders;
@@ -187,7 +187,7 @@ describe('CodeFlowCallbackHandlerService', () => {
       'returns error in case of http error',
       waitForAsync(() => {
         spyOn(dataService, 'post').and.returnValue(throwError(HTTP_ERROR));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
 
         service.codeFlowCodeRequest({} as CallbackContext).subscribe({
@@ -202,7 +202,7 @@ describe('CodeFlowCallbackHandlerService', () => {
       'retries request in case of no connection http error and succeeds',
       waitForAsync(() => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(createRetriableStream(throwError(CONNECTION_ERROR), of({})));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
 
         service.codeFlowCodeRequest({} as CallbackContext).subscribe({
@@ -224,7 +224,7 @@ describe('CodeFlowCallbackHandlerService', () => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(
           createRetriableStream(throwError(CONNECTION_ERROR), throwError(HTTP_ERROR))
         );
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
 
         service.codeFlowCodeRequest({} as CallbackContext).subscribe({

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
@@ -5,7 +5,7 @@ import { catchError, mergeMap, retryWhen, switchMap } from 'rxjs/operators';
 import { DataService } from '../../api/data.service';
 import { ConfigurationProvider } from '../../config/config.provider';
 import { LoggerService } from '../../logging/logger.service';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
 import { UrlService } from '../../utils/url/url.service';
 import { TokenValidationService } from '../../validation/token-validation.service';
 import { CallbackContext } from '../callback-context';
@@ -19,7 +19,7 @@ export class CodeFlowCallbackHandlerService {
     private readonly tokenValidationService: TokenValidationService,
     private readonly flowsDataService: FlowsDataService,
     private readonly configurationProvider: ConfigurationProvider,
-    private readonly storagePersistanceService: StoragePersistanceService,
+    private readonly storagePersistenceService: StoragePersistenceService,
     private readonly dataService: DataService
   ) {}
 
@@ -67,7 +67,7 @@ export class CodeFlowCallbackHandlerService {
       return throwError('codeFlowCodeRequest incorrect state');
     }
 
-    const authWellKnown = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnown = this.storagePersistenceService.read('authWellKnownEndPoints');
     const tokenEndpoint = authWellKnown?.tokenEndpoint;
     if (!tokenEndpoint) {
       return throwError('Token Endpoint not defined');

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
@@ -5,7 +5,7 @@ import { AuthStateService } from '../../authState/auth-state.service';
 import { AuthorizedState } from '../../authState/authorized-state';
 import { ConfigurationProvider } from '../../config/config.provider';
 import { LoggerService } from '../../logging/logger.service';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
 import { JwtKeys } from '../../validation/jwtkeys';
 import { ValidationResult } from '../../validation/validation-result';
 import { CallbackContext } from '../callback-context';
@@ -23,13 +23,13 @@ export class HistoryJwtKeysCallbackHandlerService {
     private readonly authStateService: AuthStateService,
     private readonly flowsDataService: FlowsDataService,
     private readonly signInKeyDataService: SigninKeyDataService,
-    private readonly storagePersistanceService: StoragePersistanceService,
+    private readonly storagePersistenceService: StoragePersistenceService,
     private readonly resetAuthDataService: ResetAuthDataService
   ) {}
 
   // STEP 3 Code Flow, STEP 2 Implicit Flow, STEP 3 Refresh Token
   callbackHistoryAndResetJwtKeys(callbackContext: CallbackContext): Observable<CallbackContext> {
-    this.storagePersistanceService.write('authnResult', callbackContext.authResult);
+    this.storagePersistenceService.write('authnResult', callbackContext.authResult);
 
     if (this.historyCleanUpTurnedOn() && !callbackContext.isRenewProcess) {
       this.resetBrowserHistory();
@@ -104,10 +104,10 @@ export class HistoryJwtKeysCallbackHandlerService {
   }
 
   private storeSigningKeys(jwtKeys: JwtKeys) {
-    this.storagePersistanceService.write(JWT_KEYS, jwtKeys);
+    this.storagePersistenceService.write(JWT_KEYS, jwtKeys);
   }
 
   private readSigningKeys() {
-    return this.storagePersistanceService.read(JWT_KEYS);
+    return this.storagePersistenceService.read(JWT_KEYS);
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.spec.ts
@@ -8,8 +8,8 @@ import { ConfigurationProvider } from '../../config/config.provider';
 import { ConfigurationProviderMock } from '../../config/config.provider-mock';
 import { LoggerService } from '../../logging/logger.service';
 import { LoggerServiceMock } from '../../logging/logger.service-mock';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../../storage/storage-persistence-service-mock.service';
 import { UrlService } from '../../utils/url/url.service';
 import { UrlServiceMock } from '../../utils/url/url.service-mock';
 import { CallbackContext } from '../callback-context';
@@ -17,7 +17,7 @@ import { RefreshTokenCallbackHandlerService } from './refresh-token-callback-han
 
 describe('RefreshTokenCallbackHandlerService', () => {
   let service: RefreshTokenCallbackHandlerService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let dataService: DataService;
   let configurationProvider: ConfigurationProvider;
 
@@ -29,14 +29,14 @@ describe('RefreshTokenCallbackHandlerService', () => {
         { provide: LoggerService, useClass: LoggerServiceMock },
         { provide: ConfigurationProvider, useClass: ConfigurationProviderMock },
         { provide: DataService, useClass: DataServiceMock },
-        { provide: StoragePersistanceService, useClass: StoragePersistanceServiceMock },
+        { provide: StoragePersistenceService, useClass: StoragePersistenceServiceMock },
       ],
     });
   });
 
   beforeEach(() => {
     service = TestBed.inject(RefreshTokenCallbackHandlerService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     dataService = TestBed.inject(DataService);
     configurationProvider = TestBed.inject(ConfigurationProvider);
   });
@@ -69,7 +69,7 @@ describe('RefreshTokenCallbackHandlerService', () => {
       'calls data service if all params are good',
       waitForAsync(() => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(of({}));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
 
         (service as any).refreshTokensRequestTokens({} as CallbackContext).subscribe((callbackContext) => {
           expect(postSpy).toHaveBeenCalledWith('tokenEndpoint', '', jasmine.any(HttpHeaders));
@@ -84,7 +84,7 @@ describe('RefreshTokenCallbackHandlerService', () => {
       'calls data service with correct headers if all params are good',
       waitForAsync(() => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(of({}));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
 
         (service as any).refreshTokensRequestTokens({} as CallbackContext).subscribe((callbackContext) => {
           const httpHeaders = postSpy.calls.mostRecent().args[2] as HttpHeaders;
@@ -98,7 +98,7 @@ describe('RefreshTokenCallbackHandlerService', () => {
       'returns error in case of http error',
       waitForAsync(() => {
         spyOn(dataService, 'post').and.returnValue(throwError(HTTP_ERROR));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
 
         (service as any).refreshTokensRequestTokens({} as CallbackContext).subscribe({
@@ -113,7 +113,7 @@ describe('RefreshTokenCallbackHandlerService', () => {
       'retries request in case of no connection http error and succeeds',
       waitForAsync(() => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(createRetriableStream(throwError(CONNECTION_ERROR), of({})));
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
 
         (service as any).refreshTokensRequestTokens({} as CallbackContext).subscribe({
@@ -135,7 +135,7 @@ describe('RefreshTokenCallbackHandlerService', () => {
         const postSpy = spyOn(dataService, 'post').and.returnValue(
           createRetriableStream(throwError(CONNECTION_ERROR), throwError(HTTP_ERROR))
         );
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ tokenEndpoint: 'tokenEndpoint' });
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ stsServer: 'stsServer' });
 
         (service as any).refreshTokensRequestTokens({} as CallbackContext).subscribe({

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.ts
@@ -5,7 +5,7 @@ import { catchError, mergeMap, retryWhen, switchMap } from 'rxjs/operators';
 import { DataService } from '../../api/data.service';
 import { ConfigurationProvider } from '../../config/config.provider';
 import { LoggerService } from '../../logging/logger.service';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
 import { UrlService } from '../../utils/url/url.service';
 import { CallbackContext } from '../callback-context';
 
@@ -16,7 +16,7 @@ export class RefreshTokenCallbackHandlerService {
     private readonly loggerService: LoggerService,
     private readonly configurationProvider: ConfigurationProvider,
     private readonly dataService: DataService,
-    private readonly storagePersistanceService: StoragePersistanceService
+    private readonly storagePersistenceService: StoragePersistenceService
   ) {}
 
   // STEP 2 Refresh Token
@@ -27,7 +27,7 @@ export class RefreshTokenCallbackHandlerService {
     let headers: HttpHeaders = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
 
-    const authWellKnown = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnown = this.storagePersistenceService.read('authWellKnownEndPoints');
     const tokenEndpoint = authWellKnown?.tokenEndpoint;
     if (!tokenEndpoint) {
       return throwError('Token Endpoint not defined');

--- a/projects/angular-auth-oidc-client/src/lib/flows/flows-data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/flows-data.service.spec.ts
@@ -3,14 +3,14 @@ import { ConfigurationProvider } from '../config/config.provider';
 import { ConfigurationProviderMock } from '../config/config.provider-mock';
 import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { FlowsDataService } from './flows-data.service';
 import { RandomService } from './random/random.service';
 
 describe('Flows Data Service', () => {
   let service: FlowsDataService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let configurationProvider: ConfigurationProvider;
 
   beforeEach(() => {
@@ -20,14 +20,14 @@ describe('Flows Data Service', () => {
         RandomService,
         { provide: ConfigurationProvider, useClass: ConfigurationProviderMock },
         { provide: LoggerService, useClass: LoggerServiceMock },
-        { provide: StoragePersistanceService, useClass: StoragePersistanceServiceMock },
+        { provide: StoragePersistenceService, useClass: StoragePersistenceServiceMock },
       ],
     });
   });
 
   beforeEach(() => {
     service = TestBed.inject(FlowsDataService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     configurationProvider = TestBed.inject(ConfigurationProvider);
   });
 
@@ -41,7 +41,7 @@ describe('Flows Data Service', () => {
 
   describe('nonce', () => {
     it('createNonce returns nonce and stores it', () => {
-      const spy = spyOn(storagePersistanceService, 'write');
+      const spy = spyOn(storagePersistenceService, 'write');
 
       const result = service.createNonce();
 
@@ -52,7 +52,7 @@ describe('Flows Data Service', () => {
 
   describe('AuthStateControl', () => {
     it('getAuthStateControl returns property from store', () => {
-      const spy = spyOn(storagePersistanceService, 'read');
+      const spy = spyOn(storagePersistenceService, 'read');
 
       service.getAuthStateControl();
 
@@ -60,7 +60,7 @@ describe('Flows Data Service', () => {
     });
 
     it('setAuthStateControl saves property in store', () => {
-      const spy = spyOn(storagePersistanceService, 'write');
+      const spy = spyOn(storagePersistenceService, 'write');
 
       service.setAuthStateControl('ToSave');
 
@@ -70,8 +70,8 @@ describe('Flows Data Service', () => {
 
   describe('getExistingOrCreateAuthStateControl', () => {
     it('if nothing stored it creates a 40 char one and saves the authStateControl', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('authStateControl').and.returnValue(null);
-      const setSpy = spyOn(storagePersistanceService, 'write');
+      spyOn(storagePersistenceService, 'read').withArgs('authStateControl').and.returnValue(null);
+      const setSpy = spyOn(storagePersistenceService, 'write');
 
       const result = service.getExistingOrCreateAuthStateControl();
 
@@ -81,8 +81,8 @@ describe('Flows Data Service', () => {
     });
 
     it('if stored it returns the value and does NOT Store the value again', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('authStateControl').and.returnValue('someAuthStateControl');
-      const setSpy = spyOn(storagePersistanceService, 'write');
+      spyOn(storagePersistenceService, 'read').withArgs('authStateControl').and.returnValue('someAuthStateControl');
+      const setSpy = spyOn(storagePersistenceService, 'write');
 
       const result = service.getExistingOrCreateAuthStateControl();
 
@@ -94,7 +94,7 @@ describe('Flows Data Service', () => {
 
   describe('setSessionState', () => {
     it('setSessionState saves the value in the storage', () => {
-      const spy = spyOn(storagePersistanceService, 'write');
+      const spy = spyOn(storagePersistenceService, 'write');
 
       service.setSessionState('Genesis');
 
@@ -103,8 +103,8 @@ describe('Flows Data Service', () => {
   });
 
   describe('resetStorageFlowData', () => {
-    it('resetStorageFlowData calls correct method on storagePersistanceService', () => {
-      const spy = spyOn(storagePersistanceService, 'resetStorageFlowData');
+    it('resetStorageFlowData calls correct method on storagePersistenceService', () => {
+      const spy = spyOn(storagePersistenceService, 'resetStorageFlowData');
 
       service.resetStorageFlowData();
 
@@ -114,7 +114,7 @@ describe('Flows Data Service', () => {
 
   describe('codeVerifier', () => {
     it('getCodeVerifier returns value from the store', () => {
-      const spy = spyOn(storagePersistanceService, 'read').withArgs('codeVerifier').and.returnValue('Genesis');
+      const spy = spyOn(storagePersistenceService, 'read').withArgs('codeVerifier').and.returnValue('Genesis');
 
       const result = service.getCodeVerifier();
 
@@ -123,7 +123,7 @@ describe('Flows Data Service', () => {
     });
 
     it('createCodeVerifier returns random createCodeVerifier and stores it', () => {
-      const setSpy = spyOn(storagePersistanceService, 'write');
+      const setSpy = spyOn(storagePersistenceService, 'write');
 
       const result = service.createCodeVerifier();
 
@@ -151,8 +151,8 @@ describe('Flows Data Service', () => {
       };
       const storedJsonString = JSON.stringify(storageObject);
 
-      spyOn(storagePersistanceService, 'read').withArgs('storageSilentRenewRunning').and.returnValue(storedJsonString);
-      const spyWrite = spyOn(storagePersistanceService, 'write');
+      spyOn(storagePersistenceService, 'read').withArgs('storageSilentRenewRunning').and.returnValue(storedJsonString);
+      const spyWrite = spyOn(storagePersistenceService, 'write');
 
       jasmine.clock().tick((openIDConfiguration.silentRenewTimeoutInSeconds + 1) * 1000);
 
@@ -179,8 +179,8 @@ describe('Flows Data Service', () => {
       };
       const storedJsonString = JSON.stringify(storageObject);
 
-      spyOn(storagePersistanceService, 'read').withArgs('storageSilentRenewRunning').and.returnValue(storedJsonString);
-      const spyWrite = spyOn(storagePersistanceService, 'write');
+      spyOn(storagePersistenceService, 'read').withArgs('storageSilentRenewRunning').and.returnValue(storedJsonString);
+      const spyWrite = spyOn(storagePersistenceService, 'write');
 
       const isSilentRenewRunningResult = service.isSilentRenewRunning();
 
@@ -189,7 +189,7 @@ describe('Flows Data Service', () => {
     });
 
     it('state object does not exist returns false result', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('storageSilentRenewRunning').and.returnValue(null);
+      spyOn(storagePersistenceService, 'read').withArgs('storageSilentRenewRunning').and.returnValue(null);
 
       const isSilentRenewRunningResult = service.isSilentRenewRunning();
       expect(isSilentRenewRunningResult).toBeFalse();
@@ -209,7 +209,7 @@ describe('Flows Data Service', () => {
       };
       const expectedJsonString = JSON.stringify(storageObject);
 
-      const spy = spyOn(storagePersistanceService, 'write');
+      const spy = spyOn(storagePersistenceService, 'write');
       service.setSilentRenewRunning();
       expect(spy).toHaveBeenCalledWith('storageSilentRenewRunning', expectedJsonString);
     });
@@ -217,7 +217,7 @@ describe('Flows Data Service', () => {
 
   describe('resetSilentRenewRunning', () => {
     it('set resetSilentRenewRunning to `` when called', () => {
-      const spy = spyOn(storagePersistanceService, 'write');
+      const spy = spyOn(storagePersistenceService, 'write');
       service.resetSilentRenewRunning();
       expect(spy).toHaveBeenCalledWith('storageSilentRenewRunning', ``);
     });

--- a/projects/angular-auth-oidc-client/src/lib/flows/flows-data.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/flows-data.service.ts
@@ -1,13 +1,13 @@
 import { Injectable } from '@angular/core';
 import { ConfigurationProvider } from '../config/config.provider';
 import { LoggerService } from '../logging/logger.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { RandomService } from './random/random.service';
 
 @Injectable()
 export class FlowsDataService {
   constructor(
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private randomService: RandomService,
     private configurationProvider: ConfigurationProvider,
     private loggerService: LoggerService
@@ -20,46 +20,46 @@ export class FlowsDataService {
   }
 
   setNonce(nonce: string) {
-    this.storagePersistanceService.write('authNonce', nonce);
+    this.storagePersistenceService.write('authNonce', nonce);
   }
 
   getAuthStateControl(): any {
-    return this.storagePersistanceService.read('authStateControl');
+    return this.storagePersistenceService.read('authStateControl');
   }
 
   setAuthStateControl(authStateControl: string) {
-    this.storagePersistanceService.write('authStateControl', authStateControl);
+    this.storagePersistenceService.write('authStateControl', authStateControl);
   }
 
   getExistingOrCreateAuthStateControl(): any {
-    let state = this.storagePersistanceService.read('authStateControl');
+    let state = this.storagePersistenceService.read('authStateControl');
     if (!state) {
       state = this.randomService.createRandom(40);
-      this.storagePersistanceService.write('authStateControl', state);
+      this.storagePersistenceService.write('authStateControl', state);
     }
     return state;
   }
 
   setSessionState(sessionState: any) {
-    this.storagePersistanceService.write('session_state', sessionState);
+    this.storagePersistenceService.write('session_state', sessionState);
   }
 
   resetStorageFlowData() {
-    this.storagePersistanceService.resetStorageFlowData();
+    this.storagePersistenceService.resetStorageFlowData();
   }
 
   getCodeVerifier() {
-    return this.storagePersistanceService.read('codeVerifier');
+    return this.storagePersistenceService.read('codeVerifier');
   }
 
   createCodeVerifier() {
     const codeVerifier = this.randomService.createRandom(67);
-    this.storagePersistanceService.write('codeVerifier', codeVerifier);
+    this.storagePersistenceService.write('codeVerifier', codeVerifier);
     return codeVerifier;
   }
 
   isSilentRenewRunning() {
-    const storageObject = JSON.parse(this.storagePersistanceService.read('storageSilentRenewRunning'));
+    const storageObject = JSON.parse(this.storagePersistenceService.read('storageSilentRenewRunning'));
 
     if (storageObject) {
       const { silentRenewTimeoutInSeconds } = this.configurationProvider.getOpenIDConfiguration();
@@ -87,10 +87,10 @@ export class FlowsDataService {
       dateOfLaunchedProcessUtc: new Date().toISOString(),
     };
 
-    this.storagePersistanceService.write('storageSilentRenewRunning', JSON.stringify(storageObject));
+    this.storagePersistenceService.write('storageSilentRenewRunning', JSON.stringify(storageObject));
   }
 
   resetSilentRenewRunning() {
-    this.storagePersistanceService.write('storageSilentRenewRunning', '');
+    this.storagePersistenceService.write('storageSilentRenewRunning', '');
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/flows/signin-key-data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/signin-key-data.service.spec.ts
@@ -6,8 +6,8 @@ import { DataService } from '../api/data.service';
 import { DataServiceMock } from '../api/data.service-mock';
 import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { SigninKeyDataService } from './signin-key-data.service';
 
 const DUMMY_JWKS = {
@@ -28,7 +28,7 @@ const DUMMY_JWKS = {
 
 describe('Signin Key Data Service', () => {
   let service: SigninKeyDataService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let dataService: DataService;
   let loggerService: LoggerService;
 
@@ -38,14 +38,14 @@ describe('Signin Key Data Service', () => {
         SigninKeyDataService,
         { provide: DataService, useClass: DataServiceMock },
         { provide: LoggerService, useClass: LoggerServiceMock },
-        { provide: StoragePersistanceService, useClass: StoragePersistanceServiceMock },
+        { provide: StoragePersistenceService, useClass: StoragePersistenceServiceMock },
       ],
     });
   });
 
   beforeEach(() => {
     service = TestBed.inject(SigninKeyDataService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     dataService = TestBed.inject(DataService);
     loggerService = TestBed.inject(LoggerService);
   });
@@ -58,7 +58,7 @@ describe('Signin Key Data Service', () => {
     it(
       'throws error when no wellKnownEndpoints given',
       waitForAsync(() => {
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         const result = service.getSigningKeys();
 
         result.subscribe({
@@ -72,7 +72,7 @@ describe('Signin Key Data Service', () => {
     it(
       'throws error when no jwksUri given',
       waitForAsync(() => {
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: null });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: null });
         const result = service.getSigningKeys();
 
         result.subscribe({
@@ -86,7 +86,7 @@ describe('Signin Key Data Service', () => {
     it(
       'calls dataservice if jwksurl is given',
       waitForAsync(() => {
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
         const spy = spyOn(dataService, 'get').and.callFake(() => of());
 
         const result = service.getSigningKeys();
@@ -102,7 +102,7 @@ describe('Signin Key Data Service', () => {
     it(
       'should retry once',
       waitForAsync(() => {
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
         spyOn(dataService, 'get').and.returnValue(createRetriableStream(throwError({}), of(DUMMY_JWKS)));
 
         service.getSigningKeys().subscribe({
@@ -117,7 +117,7 @@ describe('Signin Key Data Service', () => {
     it(
       'should retry twice',
       waitForAsync(() => {
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
         spyOn(dataService, 'get').and.returnValue(createRetriableStream(throwError({}), throwError({}), of(DUMMY_JWKS)));
 
         service.getSigningKeys().subscribe({
@@ -132,7 +132,7 @@ describe('Signin Key Data Service', () => {
     it(
       'should fail after three tries',
       waitForAsync(() => {
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ jwksUri: 'someUrl' });
         spyOn(dataService, 'get').and.returnValue(createRetriableStream(throwError({}), throwError({}), throwError({}), of(DUMMY_JWKS)));
 
         service.getSigningKeys().subscribe({

--- a/projects/angular-auth-oidc-client/src/lib/flows/signin-key-data.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/signin-key-data.service.ts
@@ -4,19 +4,19 @@ import { throwError } from 'rxjs';
 import { catchError, retry } from 'rxjs/operators';
 import { DataService } from '../api/data.service';
 import { LoggerService } from '../logging/logger.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { JwtKeys } from '../validation/jwtkeys';
 
 @Injectable()
 export class SigninKeyDataService {
   constructor(
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private loggerService: LoggerService,
     private dataService: DataService
   ) {}
 
   getSigningKeys() {
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     const jwksUri = authWellKnownEndPoints?.jwksUri;
     if (!jwksUri) {
       const error = `getSigningKeys: authWellKnownEndpoints.jwksUri is: '${jwksUri}'`;

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
@@ -7,8 +7,8 @@ import { OidcSecurityService } from '../oidc.security.service';
 import { PublicEventsService } from '../public-events/public-events.service';
 import { AbstractSecurityStorage } from '../storage/abstract-security-storage';
 import { BrowserStorageMock } from '../storage/browser-storage.service-mock';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { PlatformProvider } from '../utils/platform-provider/platform.provider';
 import { PlatformProviderMock } from '../utils/platform-provider/platform.provider-mock';
 import { CheckSessionService } from './check-session.service';
@@ -19,7 +19,7 @@ describe('SecurityCheckSessionTests', () => {
   let loggerService: LoggerService;
   let configurationProvider: ConfigurationProvider;
   let iFrameService: IFrameService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -30,8 +30,8 @@ describe('SecurityCheckSessionTests', () => {
         IFrameService,
         PublicEventsService,
         {
-          provide: StoragePersistanceService,
-          useClass: StoragePersistanceServiceMock,
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
         { provide: LoggerService, useClass: LoggerServiceMock },
         { provide: AbstractSecurityStorage, useClass: BrowserStorageMock },
@@ -45,7 +45,7 @@ describe('SecurityCheckSessionTests', () => {
     configurationProvider = TestBed.inject(ConfigurationProvider);
     loggerService = TestBed.inject(LoggerService);
     iFrameService = TestBed.inject(IFrameService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
   });
 
   afterEach(() => {
@@ -92,7 +92,7 @@ describe('SecurityCheckSessionTests', () => {
         checkSessionIframe: 'https://some-testing-url.com',
       };
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
       spyOn<any>(loggerService, 'logDebug').and.callFake(() => {});
 
       (checkSessionService as any).init();
@@ -118,7 +118,7 @@ describe('SecurityCheckSessionTests', () => {
   it('log warning if authWellKnownEndpoints.check_session_iframe is not existing', () => {
     const spyLogWarning = spyOn<any>(loggerService, 'logWarning');
     spyOn<any>(loggerService, 'logDebug').and.callFake(() => {});
-    spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ checkSessionIframe: undefined });
+    spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ checkSessionIframe: undefined });
     (checkSessionService as any).init();
 
     expect(spyLogWarning).toHaveBeenCalledWith('init check session: checkSessionIframe is not configured to run');
@@ -184,7 +184,7 @@ describe('SecurityCheckSessionTests', () => {
       const authWellKnownEndpoints = {
         checkSessionIframe: 'https://some-testing-url.com',
       };
-      spyOn(storagePersistanceService, 'read')
+      spyOn(storagePersistenceService, 'read')
         .withArgs('authWellKnownEndPoints')
         .and.returnValue(authWellKnownEndpoints)
         .withArgs('session_state')
@@ -199,7 +199,7 @@ describe('SecurityCheckSessionTests', () => {
       const authWellKnownEndpoints = {
         checkSessionIframe: 'https://some-testing-url.com',
       };
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
       const spyLogWarning = spyOn(loggerService, 'logWarning').and.callFake(() => {});
       spyOn(loggerService, 'logDebug').and.callFake(() => {});
       (checkSessionService as any).pollServerSession('clientId');
@@ -211,7 +211,7 @@ describe('SecurityCheckSessionTests', () => {
       const authWellKnownEndpoints = {
         checkSessionIframe: 'https://some-testing-url.com',
       };
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
       const spyLogWarning = spyOn(loggerService, 'logWarning').and.callFake(() => {});
       spyOn(loggerService, 'logDebug').and.callFake(() => {});
       (checkSessionService as any).pollServerSession('');
@@ -224,7 +224,7 @@ describe('SecurityCheckSessionTests', () => {
         checkSessionIframe: 'https://some-testing-url.com',
       };
 
-      spyOn(storagePersistanceService, 'read')
+      spyOn(storagePersistenceService, 'read')
         .withArgs('authWellKnownEndPoints')
         .and.returnValue(authWellKnownEndpoints)
         .withArgs('session_state')
@@ -239,7 +239,7 @@ describe('SecurityCheckSessionTests', () => {
       spyOn<any>(checkSessionService, 'getExistingIframe').and.returnValue({});
       const authWellKnownEndpoints = null;
 
-      spyOn(storagePersistanceService, 'read')
+      spyOn(storagePersistenceService, 'read')
         .withArgs('authWellKnownEndPoints')
         .and.returnValue(authWellKnownEndpoints)
         .withArgs('session_state')

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -5,7 +5,7 @@ import { ConfigurationProvider } from '../config/config.provider';
 import { LoggerService } from '../logging/logger.service';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { IFrameService } from './existing-iframe.service';
 
 const IFRAME_FOR_CHECK_SESSION_IDENTIFIER = 'myiFrameForCheckSession';
@@ -27,7 +27,7 @@ export class CheckSessionService {
   }
 
   constructor(
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private loggerService: LoggerService,
     private iFrameService: IFrameService,
     private eventService: PublicEventsService,
@@ -72,7 +72,7 @@ export class CheckSessionService {
       return of(undefined);
     }
 
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
 
     if (!authWellKnownEndPoints) {
       this.loggerService.logWarning('init check session: authWellKnownEndpoints is undefined. Returning.');
@@ -106,8 +106,8 @@ export class CheckSessionService {
           const existingIframe = this.getExistingIframe();
           if (existingIframe && clientId) {
             this.loggerService.logDebug(existingIframe);
-            const sessionState = this.storagePersistanceService.read('session_state');
-            const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+            const sessionState = this.storagePersistenceService.read('session_state');
+            const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
 
             if (sessionState && authWellKnownEndPoints?.checkSessionIframe) {
               const iframeOrigin = new URL(authWellKnownEndPoints.checkSessionIframe)?.origin;
@@ -148,7 +148,7 @@ export class CheckSessionService {
 
   private messageHandler(e: any) {
     const existingIFrame = this.getExistingIframe();
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     const startsWith = !!authWellKnownEndPoints?.checkSessionIframe?.startsWith(e.origin);
     this.outstandingMessages = 0;
     if (existingIFrame && startsWith && e.source === existingIFrame.contentWindow) {

--- a/projects/angular-auth-oidc-client/src/lib/login/par/par.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/par/par.service.spec.ts
@@ -5,10 +5,10 @@ import { createRetriableStream } from '../../../test/create-retriable-stream.hel
 import { DataService } from '../../api/data.service';
 import { LoggerService } from '../../logging/logger.service';
 import { LoggerServiceMock } from '../../logging/logger.service-mock';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
 import { UrlService } from '../../utils/url/url.service';
 import { DataServiceMock } from './../../api/data.service-mock';
-import { StoragePersistanceServiceMock } from './../../storage/storage-persistance.service-mock';
+import { StoragePersistenceServiceMock } from '../../storage/storage-persistence-service-mock.service';
 import { UrlServiceMock } from './../../utils/url/url.service-mock';
 import { ParService } from './par.service';
 
@@ -17,7 +17,7 @@ describe('ParService', () => {
   let loggerService: LoggerService;
   let urlService: UrlService;
   let dataService: DataService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -36,8 +36,8 @@ describe('ParService', () => {
           useClass: DataServiceMock,
         },
         {
-          provide: StoragePersistanceService,
-          useClass: StoragePersistanceServiceMock,
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
       ],
     });
@@ -47,7 +47,7 @@ describe('ParService', () => {
     service = TestBed.inject(ParService);
     dataService = TestBed.inject(DataService);
     loggerService = TestBed.inject(LoggerService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     urlService = TestBed.inject(UrlService);
   });
 
@@ -60,7 +60,7 @@ describe('ParService', () => {
       'throws error if authWellKnownEndPoints does not exist in storage',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue(null);
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         service.postParRequest().subscribe({
           error: (err) => {
             expect(err).toBe('Could not read PAR endpoint because authWellKnownEndPoints are not given');
@@ -73,7 +73,7 @@ describe('ParService', () => {
       'throws error if par endpoint does not exist in storage',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue(null);
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ some: 'thing' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ some: 'thing' });
         service.postParRequest().subscribe({
           error: (err) => {
             expect(err).toBe('Could not read PAR endpoint from authWellKnownEndpoints');
@@ -86,7 +86,7 @@ describe('ParService', () => {
       'calls data service with correct params',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue('some-url123');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
         const dataServiceSpy = spyOn(dataService, 'post').and.returnValue(of({}));
         service.postParRequest().subscribe(() => {
           expect(dataServiceSpy).toHaveBeenCalledOnceWith('parEndpoint', 'some-url123', jasmine.any(HttpHeaders));
@@ -98,7 +98,7 @@ describe('ParService', () => {
       'Gives back correct object properties',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue('some-url456');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
         spyOn(dataService, 'post').and.returnValue(of({ expires_in: 123, request_uri: 'request_uri' }));
         service.postParRequest().subscribe((result) => {
           expect(result).toEqual({ expiresIn: 123, requestUri: 'request_uri' });
@@ -110,7 +110,7 @@ describe('ParService', () => {
       'throws error if data service has got an error',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue('some-url789');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
         spyOn(dataService, 'post').and.returnValue(throwError('AN ERROR'));
         const loggerSpy = spyOn(loggerService, 'logError');
 
@@ -127,7 +127,7 @@ describe('ParService', () => {
       'should retry once',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue('some-url456');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
         spyOn(dataService, 'post').and.returnValue(
           createRetriableStream(throwError({}), of({ expires_in: 123, request_uri: 'request_uri' }))
         );
@@ -145,7 +145,7 @@ describe('ParService', () => {
       'should retry twice',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue('some-url456');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
         spyOn(dataService, 'post').and.returnValue(
           createRetriableStream(throwError({}), throwError({}), of({ expires_in: 123, request_uri: 'request_uri' }))
         );
@@ -163,7 +163,7 @@ describe('ParService', () => {
       'should fail after three tries',
       waitForAsync(() => {
         spyOn(urlService, 'createBodyForParCodeFlowRequest').and.returnValue('some-url456');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ parEndpoint: 'parEndpoint' });
         spyOn(dataService, 'post').and.returnValue(
           createRetriableStream(throwError({}), throwError({}), throwError({}), of({ expires_in: 123, request_uri: 'request_uri' }))
         );

--- a/projects/angular-auth-oidc-client/src/lib/login/par/par.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/par/par.service.ts
@@ -4,7 +4,7 @@ import { Observable, throwError } from 'rxjs';
 import { catchError, map, retry } from 'rxjs/operators';
 import { DataService } from '../../api/data.service';
 import { LoggerService } from '../../logging/logger.service';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
 import { UrlService } from '../../utils/url/url.service';
 import { ParResponse } from './par-response';
 
@@ -14,14 +14,14 @@ export class ParService {
     private loggerService: LoggerService,
     private urlService: UrlService,
     private dataService: DataService,
-    private storagePersistanceService: StoragePersistanceService
+    private storagePersistenceService: StoragePersistenceService
   ) {}
 
   postParRequest(customParams?: { [key: string]: string | number | boolean }): Observable<ParResponse> {
     let headers: HttpHeaders = new HttpHeaders();
     headers = headers.set('Content-Type', 'application/x-www-form-urlencoded');
 
-    const authWellKnown = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnown = this.storagePersistenceService.read('authWellKnownEndPoints');
 
     if (!authWellKnown) {
       return throwError('Could not read PAR endpoint because authWellKnownEndPoints are not given');

--- a/projects/angular-auth-oidc-client/src/lib/logoffRevoke/logoff-revocation.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/logoffRevoke/logoff-revocation.service.spec.ts
@@ -11,10 +11,10 @@ import { CheckSessionService } from '../iframe/check-session.service';
 import { CheckSessionServiceMock } from '../iframe/check-session.service-mock';
 import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { RedirectServiceMock } from '../utils/redirect/redirect.service-mock';
 import { UrlService } from '../utils/url/url.service';
-import { StoragePersistanceServiceMock } from './../storage/storage-persistance.service-mock';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { RedirectService } from './../utils/redirect/redirect.service';
 import { UrlServiceMock } from './../utils/url/url.service-mock';
 import { LogoffRevocationService } from './logoff-revocation.service';
@@ -23,7 +23,7 @@ describe('Logout and Revoke Service', () => {
   let service: LogoffRevocationService;
   let dataService: DataService;
   let loggerService: LoggerService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let urlService: UrlService;
   let checkSessionService: CheckSessionService;
   let resetAuthDataService: ResetAuthDataService;
@@ -35,7 +35,7 @@ describe('Logout and Revoke Service', () => {
         LogoffRevocationService,
         { provide: DataService, useClass: DataServiceMock },
         { provide: LoggerService, useClass: LoggerServiceMock },
-        { provide: StoragePersistanceService, useClass: StoragePersistanceServiceMock },
+        { provide: StoragePersistenceService, useClass: StoragePersistenceServiceMock },
         { provide: UrlService, useClass: UrlServiceMock },
         { provide: CheckSessionService, useClass: CheckSessionServiceMock },
         { provide: ResetAuthDataService, useClass: ResetAuthDataServiceMock },
@@ -49,7 +49,7 @@ describe('Logout and Revoke Service', () => {
     service = TestBed.inject(LogoffRevocationService);
     dataService = TestBed.inject(DataService);
     loggerService = TestBed.inject(LoggerService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     urlService = TestBed.inject(UrlService);
     checkSessionService = TestBed.inject(CheckSessionService);
     resetAuthDataService = TestBed.inject(ResetAuthDataService);
@@ -71,10 +71,10 @@ describe('Logout and Revoke Service', () => {
       expect(revocationSpy).toHaveBeenCalledWith(paramToken);
     });
 
-    it('uses token parameter from persistance if no param is provided', () => {
+    it('uses token parameter from persistence if no param is provided', () => {
       // Arrange
       const paramToken = 'damien';
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue(paramToken);
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue(paramToken);
       const revocationSpy = spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
       // Act
       service.revokeAccessToken();
@@ -85,7 +85,7 @@ describe('Logout and Revoke Service', () => {
     it('returns type observable', () => {
       // Arrange
       const paramToken = 'damien';
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue(paramToken);
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue(paramToken);
       spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
 
       // Act
@@ -100,7 +100,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logDebug');
         spyOn(dataService, 'post').and.returnValue(of({ data: 'anything' }));
@@ -119,7 +119,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logError');
         spyOn(dataService, 'post').and.returnValue(throwError('FAILUUURE'));
@@ -139,7 +139,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logDebug');
         spyOn(dataService, 'post').and.returnValue(createRetriableStream(throwError({}), of({ data: 'anything' })));
@@ -160,7 +160,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logDebug');
         spyOn(dataService, 'post').and.returnValue(createRetriableStream(throwError({}), throwError({}), of({ data: 'anything' })));
@@ -181,7 +181,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logError');
         spyOn(dataService, 'post').and.returnValue(
@@ -209,10 +209,10 @@ describe('Logout and Revoke Service', () => {
       expect(revocationSpy).toHaveBeenCalledWith(paramToken);
     });
 
-    it('uses refresh token parameter from persistance if no param is provided', () => {
+    it('uses refresh token parameter from persistence if no param is provided', () => {
       // Arrange
       const paramToken = 'damien';
-      spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+      spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
       const revocationSpy = spyOn(urlService, 'createRevocationEndpointBodyRefreshToken');
       // Act
       service.revokeRefreshToken();
@@ -223,7 +223,7 @@ describe('Logout and Revoke Service', () => {
     it('returns type observable', () => {
       // Arrange
       const paramToken = 'damien';
-      spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+      spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
       spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
 
       // Act
@@ -238,7 +238,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logDebug');
         spyOn(dataService, 'post').and.returnValue(of({ data: 'anything' }));
@@ -257,7 +257,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logError');
         spyOn(dataService, 'post').and.returnValue(throwError('FAILUUURE'));
@@ -277,7 +277,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logDebug');
         spyOn(dataService, 'post').and.returnValue(createRetriableStream(throwError({}), of({ data: 'anything' })));
@@ -298,7 +298,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logDebug');
         spyOn(dataService, 'post').and.returnValue(createRetriableStream(throwError({}), throwError({}), of({ data: 'anything' })));
@@ -319,7 +319,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(urlService, 'createRevocationEndpointBodyAccessToken');
         const loggerSpy = spyOn(loggerService, 'logError');
         spyOn(dataService, 'post').and.returnValue(
@@ -337,10 +337,10 @@ describe('Logout and Revoke Service', () => {
   });
 
   describe('getEndSessionUrl', () => {
-    it('uses id_token parameter from persistance if no param is provided', () => {
+    it('uses id_token parameter from persistence if no param is provided', () => {
       // Arrange
       const paramToken = 'damienId';
-      spyOn(storagePersistanceService, 'getIdToken').and.returnValue(paramToken);
+      spyOn(storagePersistenceService, 'getIdToken').and.returnValue(paramToken);
       const revocationSpy = spyOn(urlService, 'createEndSessionUrl');
       // Act
       // Act
@@ -418,7 +418,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         const revokeRefreshTokenSpy = spyOn(service, 'revokeRefreshToken').and.returnValue(of({ any: 'thing' }));
         const revokeAccessTokenSpy = spyOn(service, 'revokeAccessToken').and.returnValue(of({ any: 'thing' }));
 
@@ -436,7 +436,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(service, 'revokeRefreshToken').and.returnValue(of({ any: 'thing' }));
         const loggerSpy = spyOn(loggerService, 'logError');
         spyOn(service, 'revokeAccessToken').and.returnValue(throwError('FAILUUURE'));
@@ -456,7 +456,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(service, 'revokeRefreshToken').and.returnValue(of({ any: 'thing' }));
         spyOn(service, 'revokeAccessToken').and.returnValue(of({ any: 'thing' }));
         const logoffSpy = spyOn(service, 'logoff');
@@ -474,7 +474,7 @@ describe('Logout and Revoke Service', () => {
       waitForAsync(() => {
         // Arrange
         const paramToken = 'damien';
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(paramToken);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(paramToken);
         spyOn(service, 'revokeRefreshToken').and.returnValue(of({ any: 'thing' }));
         spyOn(service, 'revokeAccessToken').and.returnValue(of({ any: 'thing' }));
         const logoffSpy = spyOn(service, 'logoff');
@@ -491,7 +491,7 @@ describe('Logout and Revoke Service', () => {
       'calls revokeAccessToken when storage does not hold a refreshtoken',
       waitForAsync(() => {
         // Arrange
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(null);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(null);
         const revokeRefreshTokenSpy = spyOn(service, 'revokeRefreshToken');
         const revokeAccessTokenSpy = spyOn(service, 'revokeAccessToken').and.returnValue(of({ any: 'thing' }));
 
@@ -508,7 +508,7 @@ describe('Logout and Revoke Service', () => {
       'loggs error when revokeaccesstoken throws an error',
       waitForAsync(() => {
         // Arrange
-        spyOn(storagePersistanceService, 'getRefreshToken').and.returnValue(null);
+        spyOn(storagePersistenceService, 'getRefreshToken').and.returnValue(null);
         const loggerSpy = spyOn(loggerService, 'logError');
         spyOn(service, 'revokeAccessToken').and.returnValue(throwError('FAILUUURE'));
 

--- a/projects/angular-auth-oidc-client/src/lib/logoffRevoke/logoff-revocation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/logoffRevoke/logoff-revocation.service.ts
@@ -6,7 +6,7 @@ import { DataService } from '../api/data.service';
 import { ResetAuthDataService } from '../flows/reset-auth-data.service';
 import { CheckSessionService } from '../iframe/check-session.service';
 import { LoggerService } from '../logging/logger.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { RedirectService } from '../utils/redirect/redirect.service';
 import { UrlService } from '../utils/url/url.service';
 
@@ -14,7 +14,7 @@ import { UrlService } from '../utils/url/url.service';
 export class LogoffRevocationService {
   constructor(
     private dataService: DataService,
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private loggerService: LoggerService,
     private urlService: UrlService,
     private checkSessionService: CheckSessionService,
@@ -51,12 +51,12 @@ export class LogoffRevocationService {
   // The refresh token and and the access token are revoked on the server. If the refresh token does not exist
   // only the access token is revoked. Then the logout run.
   logoffAndRevokeTokens(urlHandler?: (url: string) => any) {
-    if (!this.storagePersistanceService.read('authWellKnownEndPoints')?.revocationEndpoint) {
+    if (!this.storagePersistenceService.read('authWellKnownEndPoints')?.revocationEndpoint) {
       this.loggerService.logDebug('revocation endpoint not supported');
       this.logoff(urlHandler);
     }
 
-    if (this.storagePersistanceService.getRefreshToken()) {
+    if (this.storagePersistenceService.getRefreshToken()) {
       return this.revokeRefreshToken().pipe(
         switchMap((result) => this.revokeAccessToken(result)),
         catchError((error) => {
@@ -83,7 +83,7 @@ export class LogoffRevocationService {
   // the storage is revoked. You can pass any token to revoke. This makes it possible to
   // manage your own tokens. The is a public API.
   revokeAccessToken(accessToken?: any) {
-    const accessTok = accessToken || this.storagePersistanceService.getAccessToken();
+    const accessTok = accessToken || this.storagePersistenceService.getAccessToken();
     const body = this.urlService.createRevocationEndpointBodyAccessToken(accessTok);
     const url = this.urlService.getRevocationEndpointUrl();
 
@@ -109,7 +109,7 @@ export class LogoffRevocationService {
   // If no token is provided, then the token from the storage is revoked. You can pass any token to revoke.
   // This makes it possible to manage your own tokens.
   revokeRefreshToken(refreshToken?: any) {
-    const refreshTok = refreshToken || this.storagePersistanceService.getRefreshToken();
+    const refreshTok = refreshToken || this.storagePersistenceService.getRefreshToken();
     const body = this.urlService.createRevocationEndpointBodyRefreshToken(refreshTok);
     const url = this.urlService.getRevocationEndpointUrl();
 
@@ -131,7 +131,7 @@ export class LogoffRevocationService {
   }
 
   getEndSessionUrl(): string | null {
-    const idToken = this.storagePersistanceService.getIdToken();
+    const idToken = this.storagePersistenceService.getIdToken();
     return this.urlService.createEndSessionUrl(idToken);
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -19,8 +19,8 @@ import { LoginServiceMock } from './login/login.service-mock';
 import { LogoffRevocationService } from './logoffRevoke/logoff-revocation.service';
 import { LogoffRevocationServiceMock } from './logoffRevoke/logoff-revocation.service-mock';
 import { OidcSecurityService } from './oidc.security.service';
-import { StoragePersistanceService } from './storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from './storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from './storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from './storage/storage-persistence-service-mock.service';
 import { UserService } from './userData/user-service';
 import { UserServiceMock } from './userData/user-service-mock';
 import { TokenHelperService } from './utils/tokenHelper/oidc-token-helper.service';
@@ -37,7 +37,7 @@ describe('OidcSecurityService', () => {
   let logoffRevocationService: LogoffRevocationService;
   let loginService: LoginService;
   let refreshSessionService: RefreshSessionService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let checkAuthService: CheckAuthService;
 
   beforeEach(() => {
@@ -74,8 +74,8 @@ describe('OidcSecurityService', () => {
         { provide: LogoffRevocationService, useClass: LogoffRevocationServiceMock },
         { provide: LoginService, useClass: LoginServiceMock },
         {
-          provide: StoragePersistanceService,
-          useClass: StoragePersistanceServiceMock,
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
         { provide: RefreshSessionService, useClass: RefreshSessionServiceMock },
       ],
@@ -92,7 +92,7 @@ describe('OidcSecurityService', () => {
     flowsDataService = TestBed.inject(FlowsDataService);
     logoffRevocationService = TestBed.inject(LogoffRevocationService);
     loginService = TestBed.inject(LoginService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     refreshSessionService = TestBed.inject(RefreshSessionService);
     checkAuthService = TestBed.inject(CheckAuthService);
   });
@@ -168,10 +168,10 @@ describe('OidcSecurityService', () => {
     );
 
     it(
-      'calls storagePersistanceService.write when customParams are given',
+      'calls storagePersistenceService.write when customParams are given',
       waitForAsync(() => {
         const spy = spyOn(refreshSessionService, 'forceRefreshSession').and.returnValue(of(null));
-        const writeSpy = spyOn(storagePersistanceService, 'write');
+        const writeSpy = spyOn(storagePersistenceService, 'write');
         oidcSecurityService.forceRefreshSession({ my: 'custom', params: 1 }).subscribe(() => {
           expect(spy).toHaveBeenCalled();
           expect(writeSpy).toHaveBeenCalledWith('storageCustomRequestParams', { my: 'custom', params: 1 });

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
@@ -12,7 +12,7 @@ import { AuthOptions } from './login/auth-options';
 import { LoginService } from './login/login.service';
 import { PopupOptions } from './login/popup/popup-options';
 import { LogoffRevocationService } from './logoffRevoke/logoff-revocation.service';
-import { StoragePersistanceService } from './storage/storage-persistance.service';
+import { StoragePersistenceService } from './storage/storage-persistence.service';
 import { UserService } from './userData/user-service';
 import { TokenHelperService } from './utils/tokenHelper/oidc-token-helper.service';
 
@@ -23,7 +23,7 @@ export class OidcSecurityService {
 
     return {
       configuration: openIDConfiguration,
-      wellknown: this.storagePersistanceService.read('authWellKnownEndPoints'),
+      wellknown: this.storagePersistenceService.read('authWellKnownEndPoints'),
     };
   }
 
@@ -54,7 +54,7 @@ export class OidcSecurityService {
     private callbackService: CallbackService,
     private logoffRevocationService: LogoffRevocationService,
     private loginService: LoginService,
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private refreshSessionService: RefreshSessionService
   ) {}
 
@@ -94,7 +94,7 @@ export class OidcSecurityService {
   // Code Flow with PCKE or Implicit Flow
   authorize(authOptions?: AuthOptions) {
     if (authOptions?.customParams) {
-      this.storagePersistanceService.write('storageCustomRequestParams', authOptions.customParams);
+      this.storagePersistenceService.write('storageCustomRequestParams', authOptions.customParams);
     }
 
     this.loginService.login(authOptions);
@@ -102,7 +102,7 @@ export class OidcSecurityService {
 
   authorizeWithPopUp(authOptions?: AuthOptions, popupOptions?: PopupOptions) {
     if (authOptions?.customParams) {
-      this.storagePersistanceService.write('storageCustomRequestParams', authOptions.customParams);
+      this.storagePersistenceService.write('storageCustomRequestParams', authOptions.customParams);
     }
 
     return this.loginService.loginWithPopUp(authOptions, popupOptions);
@@ -110,7 +110,7 @@ export class OidcSecurityService {
 
   forceRefreshSession(customParams?: { [key: string]: string | number | boolean }) {
     if (customParams) {
-      this.storagePersistanceService.write('storageCustomRequestParams', customParams);
+      this.storagePersistenceService.write('storageCustomRequestParams', customParams);
     }
 
     return this.refreshSessionService.forceRefreshSession(customParams);

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistance.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistance.service.spec.ts
@@ -3,10 +3,10 @@ import { ConfigurationProvider } from '../config/config.provider';
 import { ConfigurationProviderMock } from '../config/config.provider-mock';
 import { AbstractSecurityStorage } from './abstract-security-storage';
 import { BrowserStorageMock } from './browser-storage.service-mock';
-import { StoragePersistanceService } from './storage-persistance.service';
+import { StoragePersistenceService } from './storage-persistence.service';
 
-describe('Storage Persistance Service', () => {
-  let service: StoragePersistanceService;
+describe('Storage Persistence Service', () => {
+  let service: StoragePersistenceService;
   let configurationProvider: ConfigurationProvider;
   let securityStorage: AbstractSecurityStorage;
   let storageSpy: jasmine.Spy;
@@ -16,7 +16,7 @@ describe('Storage Persistance Service', () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [
-        StoragePersistanceService,
+        StoragePersistenceService,
         { provide: AbstractSecurityStorage, useClass: BrowserStorageMock },
         { provide: ConfigurationProvider, useClass: ConfigurationProviderMock },
       ],
@@ -26,7 +26,7 @@ describe('Storage Persistance Service', () => {
   beforeEach(() => {
     configurationProvider = TestBed.inject(ConfigurationProvider);
 
-    service = TestBed.inject(StoragePersistanceService);
+    service = TestBed.inject(StoragePersistenceService);
     securityStorage = TestBed.inject(AbstractSecurityStorage);
 
     storageSpy = spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ clientId: storagePrefix });

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence-service-mock.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence-service-mock.service.ts
@@ -13,7 +13,7 @@ export type StorageKeys =
   | 'access_token_expires_at';
 
 @Injectable()
-export class StoragePersistanceServiceMock {
+export class StoragePersistenceServiceMock {
   read(key: StorageKeys): any {}
 
   write(key: StorageKeys, value: any) {}

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
@@ -17,7 +17,7 @@ export type StorageKeys =
   | 'jwtKeys';
 
 @Injectable()
-export class StoragePersistanceService {
+export class StoragePersistenceService {
   constructor(
     private readonly oidcSecurityStorage: AbstractSecurityStorage,
     private readonly configurationProvider: ConfigurationProvider

--- a/projects/angular-auth-oidc-client/src/lib/userData/user-service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/userData/user-service.spec.ts
@@ -8,8 +8,8 @@ import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { FlowHelper } from '../utils/flowHelper/flow-helper.service';
 import { PlatformProvider } from '../utils/platform-provider/platform.provider';
 import { PlatformProviderMock } from '../utils/platform-provider/platform.provider-mock';
@@ -26,7 +26,7 @@ describe('User Service', () => {
   let configProvider: ConfigurationProvider;
   let loggerService: LoggerService;
   let userService: UserService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let eventsService: PublicEventsService;
   let dataService: DataService;
 
@@ -34,8 +34,8 @@ describe('User Service', () => {
     TestBed.configureTestingModule({
       providers: [
         {
-          provide: StoragePersistanceService,
-          useClass: StoragePersistanceServiceMock,
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
         { provide: LoggerService, useClass: LoggerServiceMock },
         { provide: DataService, useClass: DataServiceMock },
@@ -53,7 +53,7 @@ describe('User Service', () => {
     configProvider = TestBed.inject(ConfigurationProvider);
     loggerService = TestBed.inject(LoggerService);
     userService = TestBed.inject(UserService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     eventsService = TestBed.inject(PublicEventsService);
     dataService = TestBed.inject(DataService);
   });
@@ -182,7 +182,7 @@ describe('User Service', () => {
         spyOn(userService, 'getUserDataFromStore').and.returnValue(userDataInstore);
         const spy = spyOn(userService as any, 'getIdentityUserData').and.returnValue(of(userDataFromSts));
         spyOn(loggerService, 'logDebug');
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
 
         userService.getAndPersistUserDataInStore(isRenewProcess, idToken, decodedIdToken).subscribe((token) => {
           expect(userDataFromSts).toEqual(token);
@@ -213,7 +213,7 @@ describe('User Service', () => {
         spyOn(userService, 'getUserDataFromStore').and.returnValue(userDataInstore);
         const spyGetIdentityUserData = spyOn(userService as any, 'getIdentityUserData').and.returnValue(of(userDataFromSts));
         spyOn(loggerService, 'logDebug');
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
 
         userService.getAndPersistUserDataInStore(isRenewProcess, idToken, decodedIdToken).subscribe({
           error: (err) => {
@@ -262,15 +262,15 @@ describe('User Service', () => {
     });
 
     it('returns value if there is data', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('userData').and.returnValue('userData');
+      spyOn(storagePersistenceService, 'read').withArgs('userData').and.returnValue('userData');
       const result = userService.getUserDataFromStore();
       expect(result).toBeTruthy();
     });
   });
 
   describe('setUserDataToStore', () => {
-    it('sets userdata in storagePersistanceService', () => {
-      const spy = spyOn(storagePersistanceService, 'write');
+    it('sets userdata in storagePersistenceService', () => {
+      const spy = spyOn(storagePersistenceService, 'write');
       userService.setUserDataToStore('userDataForTest');
       expect(spy).toHaveBeenCalledWith('userData', 'userDataForTest');
     });
@@ -289,8 +289,8 @@ describe('User Service', () => {
   });
 
   describe('resetUserDataInStore', () => {
-    it('resets userdata sets null in storagePersistanceService', () => {
-      const spy = spyOn(storagePersistanceService, 'remove');
+    it('resets userdata sets null in storagePersistenceService', () => {
+      const spy = spyOn(storagePersistenceService, 'remove');
       userService.resetUserDataInStore();
       expect(spy).toHaveBeenCalledWith('userData');
     });
@@ -360,8 +360,8 @@ describe('User Service', () => {
       'does nothing if no authwellknownepdints are set',
       waitForAsync(() => {
         const serviceAsAny = userService as any;
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
         serviceAsAny.getIdentityUserData().subscribe({
           error: (err) => {
             expect(err).toBeTruthy();
@@ -374,8 +374,8 @@ describe('User Service', () => {
       'does nothing if no userinfoEndpoint is set',
       waitForAsync(() => {
         const serviceAsAny = userService as any;
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
-        spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: null });
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
+        spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: null });
         serviceAsAny.getIdentityUserData().subscribe({
           error: (err) => {
             expect(err).toBeTruthy();
@@ -389,8 +389,8 @@ describe('User Service', () => {
       waitForAsync(() => {
         const serviceAsAny = userService as any;
         const spy = spyOn(dataService, 'get').and.returnValue(of({}));
-        spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
-        spyOn(storagePersistanceService, 'read')
+        spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
+        spyOn(storagePersistenceService, 'read')
           .withArgs('authWellKnownEndPoints')
           .and.returnValue({ userinfoEndpoint: 'userinfoEndpoint' });
         serviceAsAny.getIdentityUserData().subscribe(() => {
@@ -403,8 +403,8 @@ describe('User Service', () => {
   it(
     'should retry once',
     waitForAsync(() => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: 'userinfoEndpoint' });
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: 'userinfoEndpoint' });
       spyOn(dataService, 'get').and.returnValue(createRetriableStream(throwError({}), of(DUMMY_USER_DATA)));
 
       (userService as any).getIdentityUserData().subscribe({
@@ -419,8 +419,8 @@ describe('User Service', () => {
   it(
     'should retry twice',
     waitForAsync(() => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: 'userinfoEndpoint' });
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: 'userinfoEndpoint' });
       spyOn(dataService, 'get').and.returnValue(createRetriableStream(throwError({}), throwError({}), of(DUMMY_USER_DATA)));
 
       (userService as any).getIdentityUserData().subscribe({
@@ -435,8 +435,8 @@ describe('User Service', () => {
   it(
     'should fail after three tries',
     waitForAsync(() => {
-      spyOn(storagePersistanceService, 'getAccessToken').and.returnValue('accessToken');
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: 'userinfoEndpoint' });
+      spyOn(storagePersistenceService, 'getAccessToken').and.returnValue('accessToken');
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ userinfoEndpoint: 'userinfoEndpoint' });
       spyOn(dataService, 'get').and.returnValue(createRetriableStream(throwError({}), throwError({}), throwError({}), of(DUMMY_USER_DATA)));
 
       (userService as any).getIdentityUserData().subscribe({

--- a/projects/angular-auth-oidc-client/src/lib/userData/user-service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/userData/user-service.ts
@@ -6,7 +6,7 @@ import { ConfigurationProvider } from '../config/config.provider';
 import { LoggerService } from '../logging/logger.service';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { FlowHelper } from '../utils/flowHelper/flow-helper.service';
 import { TokenHelperService } from '../utils/tokenHelper/oidc-token-helper.service';
 
@@ -20,7 +20,7 @@ export class UserService {
 
   constructor(
     private oidcDataService: DataService,
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private eventService: PublicEventsService,
     private loggerService: LoggerService,
     private tokenHelperService: TokenHelperService,
@@ -31,7 +31,7 @@ export class UserService {
   // TODO CHECK PARAMETERS
   //  validationResult.idToken can be the complete validationResult
   getAndPersistUserDataInStore(isRenewProcess = false, idToken?: any, decodedIdToken?: any): Observable<any> {
-    idToken = idToken || this.storagePersistanceService.getIdToken();
+    idToken = idToken || this.storagePersistenceService.getIdToken();
     decodedIdToken = decodedIdToken || this.tokenHelperService.getPayloadFromToken(idToken, false);
 
     const existingUserDataFromStorage = this.getUserDataFromStore();
@@ -39,7 +39,7 @@ export class UserService {
     const isCurrentFlowImplicitFlowWithAccessToken = this.flowHelper.isCurrentFlowImplicitFlowWithAccessToken();
     const isCurrentFlowCodeFlow = this.flowHelper.isCurrentFlowCodeFlow();
 
-    const accessToken = this.storagePersistanceService.getAccessToken();
+    const accessToken = this.storagePersistenceService.getAccessToken();
     if (!(isCurrentFlowImplicitFlowWithAccessToken || isCurrentFlowCodeFlow)) {
       this.loggerService.logDebug('authorizedCallback id_token flow');
       this.loggerService.logDebug('accessToken', accessToken);
@@ -68,7 +68,7 @@ export class UserService {
   }
 
   getUserDataFromStore(): any {
-    return this.storagePersistanceService.read('userData') || null;
+    return this.storagePersistenceService.read('userData') || null;
   }
 
   publishUserDataIfExists() {
@@ -80,13 +80,13 @@ export class UserService {
   }
 
   setUserDataToStore(value: any): void {
-    this.storagePersistanceService.write('userData', value);
+    this.storagePersistenceService.write('userData', value);
     this.userDataInternal$.next(value);
     this.eventService.fireEvent(EventTypes.UserDataChanged, value);
   }
 
   resetUserDataInStore(): void {
-    this.storagePersistanceService.remove('userData');
+    this.storagePersistenceService.remove('userData');
     this.eventService.fireEvent(EventTypes.UserDataChanged, null);
     this.userDataInternal$.next(null);
   }
@@ -109,9 +109,9 @@ export class UserService {
   }
 
   private getIdentityUserData(): Observable<any> {
-    const token = this.storagePersistanceService.getAccessToken();
+    const token = this.storagePersistenceService.getAccessToken();
 
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
 
     if (!authWellKnownEndPoints) {
       this.loggerService.logWarning('init check session: authWellKnownEndpoints is undefined');

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -6,8 +6,8 @@ import { FlowsDataService } from '../../flows/flows-data.service';
 import { RandomService } from '../../flows/random/random.service';
 import { LoggerService } from '../../logging/logger.service';
 import { LoggerServiceMock } from '../../logging/logger.service-mock';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../../storage/storage-persistence-service-mock.service';
 import { TokenValidationService } from '../../validation/token-validation.service';
 import { TokenValidationServiceMock } from '../../validation/token-validation.service-mock';
 import { FlowHelper } from '../flowHelper/flow-helper.service';
@@ -21,7 +21,7 @@ describe('UrlService Tests', () => {
   let flowHelper: FlowHelper;
   let flowsDataService: FlowsDataService;
   let tokenValidationService: TokenValidationService;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
   let mywindow: any;
 
   beforeEach(() => {
@@ -35,7 +35,7 @@ describe('UrlService Tests', () => {
           useClass: LoggerServiceMock,
         },
         { provide: PlatformProvider, useClass: PlatformProviderMock },
-        { provide: StoragePersistanceService, useClass: StoragePersistanceServiceMock },
+        { provide: StoragePersistenceService, useClass: StoragePersistenceServiceMock },
         { provide: TokenValidationService, useClass: TokenValidationServiceMock },
         RandomService,
         FlowHelper,
@@ -49,7 +49,7 @@ describe('UrlService Tests', () => {
     flowHelper = TestBed.inject(FlowHelper);
     flowsDataService = TestBed.inject(FlowsDataService);
     tokenValidationService = TestBed.inject(TokenValidationService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     mywindow = TestBed.inject(DOCUMENT).defaultView;
   });
 
@@ -170,7 +170,7 @@ describe('UrlService Tests', () => {
       const clientId = null;
       const authorizationEndpoint = 'authorizationEndpoint';
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ clientId });
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
 
       const value = (service as any).createAuthorizeUrl(
         '', // Implicit Flow
@@ -189,7 +189,7 @@ describe('UrlService Tests', () => {
       const responseType = null;
       const authorizationEndpoint = 'authorizationEndpoint';
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ clientId, responseType });
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
 
       const value = (service as any).createAuthorizeUrl(
         '', // Implicit Flow
@@ -209,7 +209,7 @@ describe('UrlService Tests', () => {
       const scope = null;
       const authorizationEndpoint = 'authorizationEndpoint';
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ clientId, responseType, scope });
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
 
       const value = (service as any).createAuthorizeUrl(
         '', // Implicit Flow
@@ -235,7 +235,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read')
+      spyOn(storagePersistenceService, 'read')
         .withArgs('authWellKnownEndPoints')
         .and.returnValue({ authorizationEndpoint: 'http://example' });
 
@@ -267,7 +267,7 @@ describe('UrlService Tests', () => {
       config.scope = 'openid email profile';
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -299,7 +299,7 @@ describe('UrlService Tests', () => {
       config.scope = 'openid email profile';
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -334,7 +334,7 @@ describe('UrlService Tests', () => {
       config.hdParam = 'myHdParam';
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -369,7 +369,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -407,7 +407,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -445,7 +445,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -482,7 +482,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -517,7 +517,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -551,7 +551,7 @@ describe('UrlService Tests', () => {
       config.scope = 'openid email profile';
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_sign_in',
       });
 
@@ -584,7 +584,7 @@ describe('UrlService Tests', () => {
 
       const endSessionEndpoint = 'https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/logout?p=b2c_1_sign_in';
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         endSessionEndpoint,
       });
       const value = service.createEndSessionUrl('UzI1NiIsImtpZCI6Il');
@@ -607,7 +607,7 @@ describe('UrlService Tests', () => {
 
       const revocationEndpoint = 'http://example?cod=ddd';
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         revocationEndpoint,
       });
 
@@ -638,7 +638,7 @@ describe('UrlService Tests', () => {
 
       const revocationEndpoint = 'http://example?cod=ddd';
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         revocationEndpoint,
       });
 
@@ -669,7 +669,7 @@ describe('UrlService Tests', () => {
 
       const revocationEndpoint = 'http://example?cod=ddd';
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         revocationEndpoint,
       });
 
@@ -690,7 +690,7 @@ describe('UrlService Tests', () => {
 
       const revocationEndpoint = 'http://example';
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         revocationEndpoint,
       });
 
@@ -703,7 +703,7 @@ describe('UrlService Tests', () => {
 
     it('getRevocationEndpointUrl returns null when there is not revociationendpoint given', () => {
       configurationProvider.setConfig(null);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         revocationEndpoint: null,
       });
       const value = service.getRevocationEndpointUrl();
@@ -994,7 +994,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'getExistingOrCreateAuthStateControl').and.returnValue(state);
       spyOn(flowsDataService, 'createNonce').and.returnValue(nonce);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint,
       });
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
@@ -1022,7 +1022,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'getExistingOrCreateAuthStateControl').and.returnValue(state);
       spyOn(flowsDataService, 'createNonce').and.returnValue(nonce);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         silentRenewUrl,
         clientId,
@@ -1075,7 +1075,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'createCodeVerifier').and.returnValue(codeVerifier);
       spyOn(tokenValidationService, 'generateCodeChallenge').and.returnValue(codeChallenge);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         silentRenewUrl,
         clientId,
@@ -1105,7 +1105,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'createCodeVerifier').and.returnValue(codeVerifier);
       spyOn(tokenValidationService, 'generateCodeChallenge').and.returnValue(codeChallenge);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ silentRenewUrl, clientId, responseType });
 
       const serviceAsAny = service as any;
@@ -1128,7 +1128,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'getExistingOrCreateAuthStateControl').and.returnValue(state);
       spyOn(flowsDataService, 'createNonce').and.returnValue(nonce);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         redirectUrl,
         clientId,
@@ -1154,7 +1154,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'getExistingOrCreateAuthStateControl').and.returnValue(state);
       spyOn(flowsDataService, 'createNonce').and.returnValue(nonce);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ redirectUrl, clientId, responseType });
 
       const serviceAsAny = service as any;
@@ -1173,7 +1173,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'getExistingOrCreateAuthStateControl').and.returnValue(state);
       spyOn(flowsDataService, 'createNonce').and.returnValue(nonce);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ redirectUrl, clientId, responseType });
 
       const serviceAsAny = service as any;
@@ -1218,7 +1218,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'createCodeVerifier').and.returnValue(codeVerifier);
       spyOn(tokenValidationService, 'generateCodeChallenge').and.returnValue(codeChallenge);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         redirectUrl,
         clientId,
@@ -1250,7 +1250,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'createCodeVerifier').and.returnValue(codeVerifier);
       spyOn(tokenValidationService, 'generateCodeChallenge').and.returnValue(codeChallenge);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({ authorizationEndpoint });
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         redirectUrl,
         clientId,
@@ -1281,7 +1281,7 @@ describe('UrlService Tests', () => {
       spyOn(flowsDataService, 'createCodeVerifier').and.returnValue(codeVerifier);
       spyOn(tokenValidationService, 'generateCodeChallenge').and.returnValue(codeChallenge);
 
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ redirectUrl, clientId, responseType });
 
       const serviceAsAny = service as any;
@@ -1303,7 +1303,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         endSessionEndpoint: 'http://example',
       });
 
@@ -1325,7 +1325,7 @@ describe('UrlService Tests', () => {
       };
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         endSessionEndpoint: 'http://example',
       });
 
@@ -1348,7 +1348,7 @@ describe('UrlService Tests', () => {
 
     it('createEndSessionUrl returns null if no wellknownEndpoints.endSessionEndpoint given', () => {
       configurationProvider.setConfig({});
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         endSessionEndpoint: null,
       });
 
@@ -1367,7 +1367,7 @@ describe('UrlService Tests', () => {
       config.scope = 'openid email profile';
 
       configurationProvider.setConfig(config);
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'http://example',
       });
 
@@ -1392,7 +1392,7 @@ describe('UrlService Tests', () => {
 
   describe('getAuthorizeParUrl', () => {
     it('returns null if authWellKnownEndPoints is undefined', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue(null);
 
       const result = service.getAuthorizeParUrl('');
 
@@ -1400,7 +1400,7 @@ describe('UrlService Tests', () => {
     });
 
     it('returns null if authWellKnownEndPoints-authorizationEndpoint is undefined', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         notAuthorizationEndpoint: 'anything',
       });
 
@@ -1410,7 +1410,7 @@ describe('UrlService Tests', () => {
     });
 
     it('returns null if configurationProvider.openIDConfiguration has no clientId', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'anything',
       });
 
@@ -1421,7 +1421,7 @@ describe('UrlService Tests', () => {
     });
 
     it('returns correct url when everything is given', () => {
-      spyOn(storagePersistanceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
+      spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints').and.returnValue({
         authorizationEndpoint: 'anything',
       });
 

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -4,7 +4,7 @@ import { oneLineTrim } from 'common-tags';
 import { ConfigurationProvider } from '../../config/config.provider';
 import { FlowsDataService } from '../../flows/flows-data.service';
 import { LoggerService } from '../../logging/logger.service';
-import { StoragePersistanceService } from '../../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../../storage/storage-persistence.service';
 import { TokenValidationService } from '../../validation/token-validation.service';
 import { FlowHelper } from '../flowHelper/flow-helper.service';
 import { UriEncoder } from './uri-encoder';
@@ -18,7 +18,7 @@ export class UrlService {
     private readonly flowsDataService: FlowsDataService,
     private readonly flowHelper: FlowHelper,
     private tokenValidationService: TokenValidationService,
-    private storagePersistanceService: StoragePersistanceService
+    private storagePersistenceService: StoragePersistenceService
   ) {}
 
   getUrlParameter(urlToCheck: any, name: any): string {
@@ -49,7 +49,7 @@ export class UrlService {
   }
 
   getAuthorizeParUrl(requestUri: string): string {
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
 
     if (!authWellKnownEndPoints) {
       this.loggerService.logError('authWellKnownEndpoints is undefined');
@@ -93,7 +93,7 @@ export class UrlService {
   }
 
   createEndSessionUrl(idTokenHint: string): string {
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     const endSessionEndpoint = authWellKnownEndPoints?.endSessionEndpoint;
 
     if (!endSessionEndpoint) {
@@ -140,7 +140,7 @@ export class UrlService {
   }
 
   getRevocationEndpointUrl(): string {
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     const revocationEndpoint = authWellKnownEndPoints?.revocationEndpoint;
 
     if (!revocationEndpoint) {
@@ -261,7 +261,7 @@ export class UrlService {
     prompt?: string,
     customRequestParams?: { [key: string]: string | number | boolean }
   ): string {
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     const authorizationEndpoint = authWellKnownEndPoints?.authorizationEndpoint;
 
     if (!authorizationEndpoint) {
@@ -341,7 +341,7 @@ export class UrlService {
 
     this.loggerService.logDebug('RefreshSession created. adding myautostate: ', state);
 
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     if (authWellKnownEndPoints) {
       return this.createAuthorizeUrl('', silentRenewUrl, nonce, state, 'none', customParams);
     }
@@ -366,7 +366,7 @@ export class UrlService {
       return null;
     }
 
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     if (authWellKnownEndPoints) {
       return this.createAuthorizeUrl(codeChallenge, silentRenewUrl, nonce, state, 'none', customParams);
     }
@@ -386,7 +386,7 @@ export class UrlService {
       return null;
     }
 
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     if (authWellKnownEndPoints) {
       return this.createAuthorizeUrl('', redirectUrl, nonce, state, null, customParams);
     }
@@ -410,7 +410,7 @@ export class UrlService {
     const codeVerifier = this.flowsDataService.createCodeVerifier();
     const codeChallenge = this.tokenValidationService.generateCodeChallenge(codeVerifier);
 
-    const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+    const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
     if (authWellKnownEndPoints) {
       return this.createAuthorizeUrl(codeChallenge, redirectUrl, nonce, state, null, customParams);
     }

--- a/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.spec.ts
@@ -7,8 +7,8 @@ import { OpenIdConfiguration } from '../config/openid-configuration';
 import { LogLevel } from '../logging/log-level';
 import { LoggerService } from '../logging/logger.service';
 import { LoggerServiceMock } from '../logging/logger.service-mock';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
-import { StoragePersistanceServiceMock } from '../storage/storage-persistance.service-mock';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 import { EqualityService } from '../utils/equality/equality.service';
 import { FlowHelper } from '../utils/flowHelper/flow-helper.service';
 import { TokenHelperService } from '../utils/tokenHelper/oidc-token-helper.service';
@@ -25,15 +25,15 @@ describe('State Validation Service', () => {
   let configProvider: ConfigurationProvider;
   let config: OpenIdConfiguration;
   let authWellKnownEndpoints: AuthWellKnownEndpoints;
-  let storagePersistanceService: StoragePersistanceService;
+  let storagePersistenceService: StoragePersistenceService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [],
       providers: [
         {
-          provide: StoragePersistanceService,
-          useClass: StoragePersistanceServiceMock,
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
         {
           provide: TokenValidationService,
@@ -61,7 +61,7 @@ describe('State Validation Service', () => {
     configProvider = TestBed.inject(ConfigurationProvider);
     tokenHelperService = TestBed.inject(TokenHelperService);
     loggerService = TestBed.inject(LoggerService);
-    storagePersistanceService = TestBed.inject(StoragePersistanceService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
   });
 
   beforeEach(() => {
@@ -103,7 +103,7 @@ describe('State Validation Service', () => {
 
   it('should return invalid result if validateStateFromHashCallback is false', () => {
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     spyOn(oidcSecurityValidation, 'validateStateFromHashCallback').and.returnValue(false);
@@ -166,7 +166,7 @@ describe('State Validation Service', () => {
 
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
 
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -199,7 +199,7 @@ describe('State Validation Service', () => {
     spyOn(tokenHelperService, 'getPayloadFromToken').and.returnValue('decoded_id_token');
     spyOn(oidcSecurityValidation, 'validateSignatureIdToken').and.returnValue(false);
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     const logDebugSpy = spyOn(loggerService, 'logDebug').and.callFake(() => {});
@@ -236,7 +236,7 @@ describe('State Validation Service', () => {
     spyOn(oidcSecurityValidation, 'validateSignatureIdToken').and.returnValue(true);
     spyOn(oidcSecurityValidation, 'validateIdTokenNonce').and.returnValue(false);
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -280,7 +280,7 @@ describe('State Validation Service', () => {
 
     spyOn(oidcSecurityValidation, 'validateRequiredIdToken').and.returnValue(false);
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -327,7 +327,7 @@ describe('State Validation Service', () => {
 
     config.maxIdTokenIatOffsetAllowedInSeconds = 0;
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -377,7 +377,7 @@ describe('State Validation Service', () => {
     config.maxIdTokenIatOffsetAllowedInSeconds = 0;
     spyOn(oidcSecurityValidation, 'validateIdTokenIss').and.returnValue(false);
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -429,7 +429,7 @@ describe('State Validation Service', () => {
 
     config.clientId = '';
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -482,7 +482,7 @@ describe('State Validation Service', () => {
     config.clientId = '';
     spyOn(oidcSecurityValidation, 'validateIdTokenExpNotExpired').and.returnValue(false);
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -528,7 +528,7 @@ describe('State Validation Service', () => {
     config.responseType = 'NOT id_token token';
     config.autoCleanStateAfterAuthentication = false;
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -577,7 +577,7 @@ describe('State Validation Service', () => {
     config.autoCleanStateAfterAuthentication = false;
     spyOn(oidcSecurityValidation, 'validateIdTokenAtHash').and.returnValue(false);
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -624,7 +624,7 @@ describe('State Validation Service', () => {
     spyOn(oidcSecurityValidation, 'validateIdTokenAtHash').and.returnValue(true);
     config.responseType = 'id_token token';
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');
@@ -685,7 +685,7 @@ describe('State Validation Service', () => {
     config.autoCleanStateAfterAuthentication = false;
 
     spyOn(configProvider, 'getOpenIDConfiguration').and.returnValue(config);
-    const readSpy = spyOn(storagePersistanceService, 'read');
+    const readSpy = spyOn(storagePersistenceService, 'read');
     readSpy.withArgs('authWellKnownEndPoints').and.returnValue(authWellKnownEndpoints);
     readSpy.withArgs('authStateControl').and.returnValue('authStateControl');
     readSpy.withArgs('authNonce').and.returnValue('authNonce');

--- a/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { ConfigurationProvider } from '../config/config.provider';
 import { CallbackContext } from '../flows/callback-context';
 import { LoggerService } from '../logging/logger.service';
-import { StoragePersistanceService } from '../storage/storage-persistance.service';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { EqualityService } from '../utils/equality/equality.service';
 import { FlowHelper } from '../utils/flowHelper/flow-helper.service';
 import { TokenHelperService } from '../utils/tokenHelper/oidc-token-helper.service';
@@ -13,7 +13,7 @@ import { ValidationResult } from './validation-result';
 @Injectable()
 export class StateValidationService {
   constructor(
-    private storagePersistanceService: StoragePersistanceService,
+    private storagePersistenceService: StoragePersistenceService,
     private tokenValidationService: TokenValidationService,
     private tokenHelperService: TokenHelperService,
     private loggerService: LoggerService,
@@ -36,7 +36,7 @@ export class StateValidationService {
 
   validateState(callbackContext): StateValidationResult {
     const toReturn = new StateValidationResult();
-    const authStateControl = this.storagePersistanceService.read('authStateControl');
+    const authStateControl = this.storagePersistenceService.read('authStateControl');
 
     if (!this.tokenValidationService.validateStateFromHashCallback(callbackContext.authResult.state, authStateControl)) {
       this.loggerService.logWarning('authorizedCallback incorrect state');
@@ -72,7 +72,7 @@ export class StateValidationService {
         return toReturn;
       }
 
-      const authNonce = this.storagePersistanceService.read('authNonce');
+      const authNonce = this.storagePersistenceService.read('authNonce');
 
       if (!this.tokenValidationService.validateIdTokenNonce(toReturn.decodedIdToken, authNonce, ignoreNonceAfterRefresh)) {
         this.loggerService.logWarning('authorizedCallback incorrect nonce');
@@ -101,7 +101,7 @@ export class StateValidationService {
         return toReturn;
       }
 
-      const authWellKnownEndPoints = this.storagePersistanceService.read('authWellKnownEndPoints');
+      const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints');
 
       if (authWellKnownEndPoints) {
         if (issValidationOff) {
@@ -254,20 +254,20 @@ export class StateValidationService {
 
   private handleSuccessfulValidation(): void {
     const { autoCleanStateAfterAuthentication } = this.configurationProvider.getOpenIDConfiguration();
-    this.storagePersistanceService.write('authNonce', '');
+    this.storagePersistenceService.write('authNonce', '');
 
     if (autoCleanStateAfterAuthentication) {
-      this.storagePersistanceService.write('authStateControl', '');
+      this.storagePersistenceService.write('authStateControl', '');
     }
     this.loggerService.logDebug('AuthorizedCallback token(s) validated, continue');
   }
 
   private handleUnsuccessfulValidation(): void {
     const { autoCleanStateAfterAuthentication } = this.configurationProvider.getOpenIDConfiguration();
-    this.storagePersistanceService.write('authNonce', '');
+    this.storagePersistenceService.write('authNonce', '');
 
     if (autoCleanStateAfterAuthentication) {
-      this.storagePersistanceService.write('authStateControl', '');
+      this.storagePersistenceService.write('authStateControl', '');
     }
     this.loggerService.logDebug('AuthorizedCallback token(s) invalid');
   }


### PR DESCRIPTION
I believe "Persistance" was used in place of "Persistence" in error. I've renamed all occurrences of "Persistance" to "Persistence".