### PR TITLE
Fix redirect getting overwritten in localStorage

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -74,6 +74,10 @@ export class CustomStorage implements AbstractSecurityStorage {
     public remove(key: string): void {
         ...
     }
+    
+    public clear(): void {
+        ...
+    }
 }
 ```
 

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-service.ts
@@ -1,18 +1,20 @@
 import { Injectable } from '@angular/core';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
 
 const STORAGE_KEY = 'redirect';
 
 @Injectable()
 export class AutoLoginService {
+  constructor(private readonly storageService: StoragePersistenceService) {}
   getStoredRedirectRoute() {
-    return localStorage.getItem(STORAGE_KEY);
+    return this.storageService.read(STORAGE_KEY);
   }
 
   saveStoredRedirectRoute(url: string) {
-    localStorage.setItem(STORAGE_KEY, url);
+    this.storageService.write(STORAGE_KEY, url);
   }
 
   deleteStoredRedirectRoute() {
-    localStorage.removeItem(STORAGE_KEY);
+    this.storageService.remove(STORAGE_KEY);
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.spec.ts
@@ -10,6 +10,8 @@ import { LoginService } from '../login/login.service';
 import { LoginServiceMock } from '../login/login.service-mock';
 import { AutoLoginService } from './auto-login-service';
 import { AutoLoginGuard } from './auto-login.guard';
+import { StoragePersistenceService } from '../storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from '../storage/storage-persistence-service-mock.service';
 
 describe(`AutoLoginGuard`, () => {
   let autoLoginGuard: AutoLoginGuard;
@@ -17,6 +19,7 @@ describe(`AutoLoginGuard`, () => {
   let loginService: LoginService;
   let authStateService: AuthStateService;
   let router: Router;
+  let storagePersistenceService: StoragePersistenceService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -27,6 +30,10 @@ describe(`AutoLoginGuard`, () => {
         {
           provide: LoginService,
           useClass: LoginServiceMock,
+        },
+        {
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
         },
         {
           provide: CheckAuthService,
@@ -42,10 +49,11 @@ describe(`AutoLoginGuard`, () => {
     authStateService = TestBed.inject(AuthStateService);
     router = TestBed.inject(Router);
     loginService = TestBed.inject(LoginService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
   });
 
   afterEach(() => {
-    localStorage.clear();
+    storagePersistenceService.clear();
   });
 
   it('should create', () => {
@@ -100,13 +108,13 @@ describe(`AutoLoginGuard`, () => {
     );
 
     it(
-      'if no route is stored, setItem on localStorage is called',
+      'if no route is stored, write on StoragePersistenceService is called',
       waitForAsync(() => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(null));
-        const localStorageSpy = spyOn(localStorage, 'setItem');
+        const storageServiceSpy = spyOn(storagePersistenceService, 'write');
 
         autoLoginGuard.canActivate(null, { url: 'some-url5' } as RouterStateSnapshot).subscribe((result) => {
-          expect(localStorageSpy).toHaveBeenCalledOnceWith('redirect', 'some-url5');
+          expect(storageServiceSpy).toHaveBeenCalledOnceWith('redirect', 'some-url5');
         });
       })
     );
@@ -115,11 +123,11 @@ describe(`AutoLoginGuard`, () => {
       'returns true if authorized',
       waitForAsync(() => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(true));
-        const localStorageSpy = spyOn(localStorage, 'setItem');
+        const storageServiceSpy = spyOn(storagePersistenceService, 'write');
 
         autoLoginGuard.canActivate(null, { url: 'some-url6' } as RouterStateSnapshot).subscribe((result) => {
           expect(result).toBe(true);
-          expect(localStorageSpy).not.toHaveBeenCalled();
+          expect(storageServiceSpy).not.toHaveBeenCalled();
         });
       })
     );
@@ -128,14 +136,14 @@ describe(`AutoLoginGuard`, () => {
       'if authorized and stored route exists: remove item, navigate to route and return true',
       waitForAsync(() => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(true));
-        spyOn(localStorage, 'getItem').and.returnValue('stored-route');
-        const localStorageSpy = spyOn(localStorage, 'removeItem');
+        spyOn(storagePersistenceService, 'read').and.returnValue('stored-route');
+        const storageServiceSpy = spyOn(storagePersistenceService, 'remove');
         const routerSpy = spyOn(router, 'navigateByUrl');
         const loginSpy = spyOn(loginService, 'login');
 
         autoLoginGuard.canActivate(null, { url: 'some-url7' } as RouterStateSnapshot).subscribe((result) => {
           expect(result).toBe(true);
-          expect(localStorageSpy).toHaveBeenCalledOnceWith('redirect');
+          expect(storageServiceSpy).toHaveBeenCalledOnceWith('redirect');
           expect(routerSpy).toHaveBeenCalledOnceWith('stored-route');
           expect(loginSpy).not.toHaveBeenCalled();
         });
@@ -191,13 +199,13 @@ describe(`AutoLoginGuard`, () => {
     );
 
     it(
-      'if no route is stored, setItem on localStorage is called',
+      'if no route is stored, write on StoragePersistenceService is called',
       waitForAsync(() => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(null));
-        const localStorageSpy = spyOn(localStorage, 'setItem');
+        const storageServiceSpy = spyOn(storagePersistenceService, 'write');
 
         autoLoginGuard.canLoad({ path: 'some-url12' }, []).subscribe((result) => {
-          expect(localStorageSpy).toHaveBeenCalledOnceWith('redirect', 'some-url12');
+          expect(storageServiceSpy).toHaveBeenCalledOnceWith('redirect', 'some-url12');
         });
       })
     );
@@ -206,11 +214,11 @@ describe(`AutoLoginGuard`, () => {
       'returns true if authorized',
       waitForAsync(() => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(true));
-        const localStorageSpy = spyOn(localStorage, 'setItem');
+        const storageServiceSpy = spyOn(storagePersistenceService, 'write');
 
         autoLoginGuard.canLoad({ path: 'some-url13' }, []).subscribe((result) => {
           expect(result).toBe(true);
-          expect(localStorageSpy).not.toHaveBeenCalled();
+          expect(storageServiceSpy).not.toHaveBeenCalled();
         });
       })
     );
@@ -219,14 +227,14 @@ describe(`AutoLoginGuard`, () => {
       'if authorized and stored route exists: remove item, navigate to route and return true',
       waitForAsync(() => {
         spyOn(checkAuthService, 'checkAuth').and.returnValue(of(true));
-        spyOn(localStorage, 'getItem').and.returnValue('stored-route');
-        const localStorageSpy = spyOn(localStorage, 'removeItem');
+        spyOn(storagePersistenceService, 'read').and.returnValue('stored-route');
+        const storageServiceSpy = spyOn(storagePersistenceService, 'remove');
         const routerSpy = spyOn(router, 'navigateByUrl');
         const loginSpy = spyOn(loginService, 'login');
 
         autoLoginGuard.canLoad({ path: 'some-url14' }, []).subscribe((result) => {
           expect(result).toBe(true);
-          expect(localStorageSpy).toHaveBeenCalledOnceWith('redirect');
+          expect(storageServiceSpy).toHaveBeenCalledOnceWith('redirect');
           expect(routerSpy).toHaveBeenCalledOnceWith('stored-route');
           expect(loginSpy).not.toHaveBeenCalled();
         });

--- a/projects/angular-auth-oidc-client/src/lib/check-auth.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/check-auth.service.spec.ts
@@ -26,6 +26,8 @@ import { PopUpService } from './login/popup/popup.service';
 import { PopUpServiceMock } from './login/popup/popup.service-mock';
 import { UserService } from './userData/user-service';
 import { UserServiceMock } from './userData/user-service-mock';
+import { StoragePersistenceService } from './storage/storage-persistence.service';
+import { StoragePersistenceServiceMock } from './storage/storage-persistence-service-mock.service';
 
 describe('CheckAuthService', () => {
   let checkAuthService: CheckAuthService;
@@ -40,6 +42,7 @@ describe('CheckAuthService', () => {
   let popUpService: PopUpService;
   let autoLoginService: AutoLoginService;
   let router: Router;
+  let storagePersistenceService: StoragePersistenceService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -56,6 +59,10 @@ describe('CheckAuthService', () => {
         { provide: PeriodicallyTokenCheckService, useClass: PeriodicallyTokenCheckServiceMock },
         { provide: PopUpService, useClass: PopUpServiceMock },
         { provide: StsConfigLoader, useClass: StsConfigLoaderMock },
+        {
+          provide: StoragePersistenceService,
+          useClass: StoragePersistenceServiceMock,
+        },
         AutoLoginService,
         CheckAuthService,
       ],
@@ -75,10 +82,11 @@ describe('CheckAuthService', () => {
     popUpService = TestBed.inject(PopUpService);
     autoLoginService = TestBed.inject(AutoLoginService);
     router = TestBed.inject(Router);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
   });
 
   afterEach(() => {
-    localStorage.clear();
+    storagePersistenceService.clear();
   });
 
   it('should create', () => {

--- a/projects/angular-auth-oidc-client/src/lib/storage/abstract-security-storage.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/abstract-security-storage.ts
@@ -15,6 +15,7 @@ export abstract class AbstractSecurityStorage {
   /**
    * This method must contain the logic to write the storage.
    *
+   * @param key The key for the stored value
    * @param value The value for the given key
    */
   public abstract write(key: string, value: any): void;
@@ -25,4 +26,9 @@ export abstract class AbstractSecurityStorage {
    * @param key The value for the key to be removed
    */
   public abstract remove(key: string): void;
+
+  /**
+   * This method must contain the logic to remove all items from the storage.
+   */
+  public abstract clear(): void;
 }

--- a/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service-mock.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service-mock.ts
@@ -17,4 +17,8 @@ export class BrowserStorageMock implements AbstractSecurityStorage {
   remove(key: string) {
     delete this.store[key];
   }
+
+  clear() {
+    this.store = {};
+  }
 }

--- a/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.ts
@@ -56,6 +56,22 @@ export class BrowserStorageService implements AbstractSecurityStorage {
     return true;
   }
 
+  clear(): boolean {
+    if (!this.hasStorage()) {
+      this.loggerService.logDebug(`Wanted to clear storage but Storage was falsy`);
+      return false;
+    }
+
+    const storage = this.getStorage();
+    if (!storage) {
+      this.loggerService.logDebug(`Wanted to clear storage but Storage was falsy`);
+      return false;
+    }
+
+    storage.clear();
+    return true;
+  }
+
   private getStorage() {
     const config = this.configProvider.getOpenIDConfiguration();
     if (!config) {

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence-service-mock.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence-service-mock.service.ts
@@ -20,6 +20,8 @@ export class StoragePersistenceServiceMock {
 
   remove(key: StorageKeys) {}
 
+  clear() {}
+
   resetStorageFlowData() {
     this.remove('session_state');
     this.remove('storageSilentRenewRunning');

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
@@ -14,7 +14,8 @@ export type StorageKeys =
   | 'session_state'
   | 'storageSilentRenewRunning'
   | 'storageCustomRequestParams'
-  | 'jwtKeys';
+  | 'jwtKeys'
+  | 'redirect';
 
 @Injectable()
 export class StoragePersistenceService {

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
@@ -39,6 +39,10 @@ export class StoragePersistenceService {
     this.oidcSecurityStorage.remove(keyToStore);
   }
 
+  clear() {
+    this.oidcSecurityStorage.clear();
+  }
+
   resetStorageFlowData() {
     this.remove('session_state');
     this.remove('storageSilentRenewRunning');


### PR DESCRIPTION
Issue #1060 refers to application's having their own internal `redirect` record in `localStorage` overwritten by the `AutoLoginService`. The `StoragePersistenceService` already handles prefixing stored values to remedy this issue. I've converted the `AutoLoginService` to use `StoragePersistenceService` instead of `localStorage`.