### PR TITLE
fix(randomService): fix misuse of Uint8Array

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/flows/random/random.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/random/random.service.ts
@@ -17,7 +17,7 @@ export class RandomService {
     }
 
     const length = requiredLength - 6;
-    const arr = new Uint8Array((length || length) / 2);
+    const arr = new Uint8Array(Math.floor((length || length) / 2));
     if (this.getCrypto()) {
       this.getCrypto().getRandomValues(arr);
     }


### PR DESCRIPTION
Necessary for compatibility with old browsers. Tested with Firefox 52, has mentioned in the issue

fixes #1070