### PR TITLE
fix: Start session checks in auto-login guard when already authenticated

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.spec.ts
@@ -78,6 +78,18 @@ describe(`AutoLoginGuard`, () => {
     );
 
     it(
+      'should call startCheckSessionAndValidation() if authenticated already',
+      waitForAsync(() => {
+        spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(true);
+        const checkAuthServiceSpy = spyOn(checkAuthService, 'startCheckSessionAndValidation').and.returnValue();
+
+        autoLoginGuard.canActivate(null, { url: 'some-url2' } as RouterStateSnapshot).subscribe(() => {
+          expect(checkAuthServiceSpy).toHaveBeenCalled();
+        });
+      })
+    );
+
+    it(
       'should call loginService.login() when not authorized',
       waitForAsync(() => {
         spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(false);
@@ -169,6 +181,18 @@ describe(`AutoLoginGuard`, () => {
 
         autoLoginGuard.canLoad(null, []).subscribe(() => {
           expect(checkAuthServiceSpy).not.toHaveBeenCalled();
+        });
+      })
+    );
+
+    it(
+      'should call startCheckSessionAndValidation() if authenticated already',
+      waitForAsync(() => {
+        spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(true);
+        const checkAuthServiceSpy = spyOn(checkAuthService, 'startCheckSessionAndValidation').and.returnValue();
+
+        autoLoginGuard.canActivate(null, { url: 'some-url2' } as RouterStateSnapshot).subscribe(() => {
+          expect(checkAuthServiceSpy).toHaveBeenCalled();
         });
       })
     );

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.guard.ts
@@ -31,6 +31,7 @@ export class AutoLoginGuard implements CanActivate, CanLoad {
     const isAuthenticated = this.authStateService.areAuthStorageTokensValid();
 
     if (isAuthenticated) {
+      this.checkAuthService.startCheckSessionAndValidation();
       return of(true);
     }
 

--- a/projects/angular-auth-oidc-client/src/lib/check-auth.service-mock.ts
+++ b/projects/angular-auth-oidc-client/src/lib/check-auth.service-mock.ts
@@ -10,4 +10,6 @@ export class CheckAuthServiceMock {
   checkAuthIncludingServer(): Observable<boolean> {
     return of(null);
   }
+
+  startCheckSessionAndValidation() {}
 }

--- a/projects/angular-auth-oidc-client/src/lib/check-auth.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/check-auth.service.ts
@@ -112,7 +112,7 @@ export class CheckAuthService {
     );
   }
 
-  private startCheckSessionAndValidation() {
+  startCheckSessionAndValidation() {
     if (this.checkSessionService.isCheckSessionConfigured()) {
       this.checkSessionService.start();
     }


### PR DESCRIPTION
Suggested fix for #1107 where silent renew was not being performed as
the session checks are only started when `CheckAuthService::checkAuth`
is called. Making `CheckAuthService::startCheckSessionAndValidation`
public is not ideal but reduces duplication of this logic.