### PR TITLE
Add navigator cookies check for storageSession

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
@@ -30,7 +30,7 @@ export const DEFAULT_CONFIG: OpenIdConfiguration = {
   historyCleanupOff: false,
   maxIdTokenIatOffsetAllowedInSeconds: 120,
   disableIatOffsetValidation: false,
-  storage: typeof Storage !== 'undefined' ? sessionStorage : null,
+  storage: typeof navigator !== 'undefined' && navigator.cookieEnabled && typeof Storage !== 'undefined' ? sessionStorage : null,
   customParamsAuthRequest: {},
   customParamsRefreshTokenRequest: {},
   customParamsEndSessionRequest: {},

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
@@ -20,6 +20,7 @@ export class PopUpService {
 
       return !!window.opener && window.opener !== window && !!popup;
     }
+
     return false;
   }
 
@@ -82,6 +83,7 @@ export class PopUpService {
   }
 
   private canAccessSessionStorage(): boolean {
+    
     return typeof navigator !== 'undefined' && navigator.cookieEnabled && typeof Storage !== 'undefined';
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
@@ -15,9 +15,12 @@ export class PopUpService {
   }
 
   isCurrentlyInPopup(): boolean {
-    const popup = sessionStorage.getItem(this.STORAGE_IDENTIFIER);
+    if (this.canAccessSessionStorage()) {
+      const popup = sessionStorage.getItem(this.STORAGE_IDENTIFIER);
 
-    return !!window.opener && window.opener !== window && !!popup;
+      return !!window.opener && window.opener !== window && !!popup;
+    }
+    return false;
   }
 
   openPopUp(url: string, popupOptions?: PopupOptions): void {
@@ -76,5 +79,9 @@ export class PopUpService {
     return Object.entries(options)
       .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
       .join(',');
+  }
+
+  private canAccessSessionStorage(): boolean {
+    return typeof navigator !== 'undefined' && navigator.cookieEnabled && typeof Storage !== 'undefined';
   }
 }


### PR DESCRIPTION
Hello,
If cookies are disabled on the navigator, the lines I've just changed throw errors (`"DOMException: Failed to real the "sessionStorage' property from 'Window' : Access is denied for this document.`). So we must check the `navigator.cookieEnabled` property before trying to call `sessionStorage`.
So this fix prevent the error from occuring (and frozing our entire website on loading).
If you have any questions, i'm available of course.
Have a nice day,