### PR TITLE
Move and export PASSED_CONFIG, PassedInitialConfig

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/angular-auth-oidc-client.ts
+++ b/projects/angular-auth-oidc-client/src/lib/angular-auth-oidc-client.ts
@@ -10,6 +10,8 @@ export * from './config/auth-well-known/auth-well-known-endpoints';
 export * from './config/config.service';
 export * from './config/loader/config-loader';
 export * from './config/openid-configuration';
+export * from './passed-config/passed-config';
+export * from './passed-config/passed-initial-config';
 export * from './interceptor/auth.interceptor';
 export * from './logging/log-level';
 export * from './logging/logger.service';

--- a/projects/angular-auth-oidc-client/src/lib/auth.module.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth.module.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { AuthModule, PASSED_CONFIG } from './auth.module';
+import { AuthModule } from './auth.module';
+import { PASSED_CONFIG } from './passed-config/passed-config';
 import { OidcConfigService } from './config/config.service';
 import { OidcConfigServiceMock } from './config/config.service.mock';
 import { StsConfigHttpLoader, StsConfigLoader, StsConfigStaticLoader } from './config/loader/config-loader';

--- a/projects/angular-auth-oidc-client/src/lib/auth.module.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { HttpClientModule } from '@angular/common/http';
-import { APP_INITIALIZER, InjectionToken, ModuleWithProviders, NgModule, Provider } from '@angular/core';
+import { APP_INITIALIZER, ModuleWithProviders, NgModule } from '@angular/core';
 import { DataService } from './api/data.service';
 import { HttpBaseService } from './api/http-base.service';
 import { AuthStateService } from './auth-state/auth-state.service';
@@ -39,6 +39,8 @@ import { ResponseTypeValidationService } from './login/response-type-validation/
 import { StandardLoginService } from './login/standard/standard-login.service';
 import { LogoffRevocationService } from './logoff-revoke/logoff-revocation.service';
 import { OidcSecurityService } from './oidc.security.service';
+import { PASSED_CONFIG } from './passed-config/passed-config';
+import { PassedInitialConfig } from './passed-config/passed-initial-config';
 import { PublicEventsService } from './public-events/public-events.service';
 import { AbstractSecurityStorage } from './storage/abstract-security-storage';
 import { BrowserStorageService } from './storage/browser-storage.service';
@@ -54,12 +56,6 @@ import { JsrsAsignReducedService } from './validation/jsrsasign-reduced.service'
 import { StateValidationService } from './validation/state-validation.service';
 import { TokenValidationService } from './validation/token-validation.service';
 
-export interface PassedInitialConfig {
-  config?: OpenIdConfiguration | OpenIdConfiguration[];
-  loader?: Provider;
-  storage?: any;
-}
-
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createStaticLoader(passedConfig: PassedInitialConfig) {
   return new StsConfigStaticLoader(passedConfig.config);
@@ -72,8 +68,6 @@ export function configurationProviderFactory(oidcConfigService: OidcConfigServic
 
   return fn;
 }
-
-export const PASSED_CONFIG = new InjectionToken<PassedInitialConfig>('PASSED_CONFIG');
 
 @NgModule({
   imports: [CommonModule, HttpClientModule],

--- a/projects/angular-auth-oidc-client/src/lib/passed-config/passed-config.ts
+++ b/projects/angular-auth-oidc-client/src/lib/passed-config/passed-config.ts
@@ -1,0 +1,4 @@
+import { InjectionToken } from '@angular/core';
+import { PassedInitialConfig } from './passed-initial-config';
+
+export const PASSED_CONFIG = new InjectionToken<PassedInitialConfig>('PASSED_CONFIG');

--- a/projects/angular-auth-oidc-client/src/lib/passed-config/passed-initial-config.ts
+++ b/projects/angular-auth-oidc-client/src/lib/passed-config/passed-initial-config.ts
@@ -1,0 +1,8 @@
+import { Provider } from '@angular/core';
+import { OpenIdConfiguration } from '../config/openid-configuration';
+
+export interface PassedInitialConfig {
+  config?: OpenIdConfiguration | OpenIdConfiguration[];
+  loader?: Provider;
+  storage?: any;
+}


### PR DESCRIPTION
Move PassedInitialConfig interface to its own file.
Create passed-config folder.

Move PASSED_CONFIG InjectionToken to passed-config folder.

Export PassedInitialConfig interface from Public API file since it's a public interface.
We can can now import it like this:
`import { PassedInitialConfig } from 'angular-auth-oidc-client'`
instead of
`import { PassedInitialConfig } from 'angular-auth-oidc-client/lib/auth.module'`
