### PR TITLE
docs: clean up documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ import { AuthModule, LogLevel } from 'angular-auth-oidc-client';
 export class AppModule {}
 ```
 
-And call the method `checkAuth()` from your `app.component.ts`. The method `checkAuth()` is needed to process the redirect from your secure token server and set the correct states. This method must be used to ensure the correct functioning of the library.
+And call the method `checkAuth()` from your `app.component.ts`. The method `checkAuth()` is needed to process the redirect from your Security Token Service and set the correct states. This method must be used to ensure the correct functioning of the library.
 
 ```ts
 import { Component, OnInit } from '@angular/core';

--- a/docs/site/angular-auth-oidc-client/docs/documentation/auto-login.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/auto-login.md
@@ -5,20 +5,20 @@ sidebar_position: 8
 
 # Auto Login
 
-If you want to have your app being redirected to the secure token server automatically without the user clicking any login button only by accessing a specific route, you can use the `AutoLoginPartialRoutesGuard` or the `AutoLoginAllRoutesGuard` provided by the lib. In case you are using multiple configs the guard currently uses the first config fix to perform a login! The guard handles `canActivate` and `canLoad` for you. It also saves the route you wanted to visit before the login and redirects you to that route after the successful login.
+If you want to have your app being redirected to the Security Token Service automatically without the user clicking any login button only by accessing a specific route, you can use the `AutoLoginPartialRoutesGuard` or the `AutoLoginAllRoutesGuard` provided by the lib. In case you are using multiple configs the guard currently uses the first config fix to perform a login! The guard handles `canActivate` and `canLoad` for you. It also saves the route you wanted to visit before the login and redirects you to that route after the successful login.
 
-Here are two use cases to distinguish:
+Here are two use cases to distinguish: with and without a guarded default route.
 
 ### Auto Login when default route is not guarded
 
 You have this case when you have some routes in your configuration publicly accessible and some routes should be protected by a login. The login should start when the user enters the route.
 
-For example
+#### Example
 
 ```ts
 import { AutoLoginPartialRoutesGuard } from 'angular-auth-oidc-client';
 
-const appRoutes: Routes = [
+const routes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'home' },
   { path: 'home', component: HomeComponent },
   { path: 'protected', component: ProtectedComponent, canActivate: [AutoLoginPartialRoutesGuard] },
@@ -31,9 +31,8 @@ const appRoutes: Routes = [
 ];
 ```
 
-In this case the `/home` and the `/unauthorized` are not protected and accessible without a login.
-
-Please make sure to call `checkAuth()` like normal in your `app.component.ts`
+In this case the `/home` and `/unauthorized` routes are not protected and hence are accessible without a login.
+Please make sure to call `checkAuth()` like normal in your `app.component.ts`.
 
 ```ts
 export class AppComponent implements OnInit {
@@ -49,7 +48,7 @@ export class AppComponent implements OnInit {
 
 ### Auto Login when all routes are guarded
 
-If all your routes are guarded please use the `AutoLoginAllRoutesGuard` instead of the `AutoLoginPartialRoutesGuard`. This guard ensures that `checkAuth` is being called for you and you do not have to call it in your `app.component.ts` then.
+If all your routes are guarded please use the `AutoLoginAllRoutesGuard` instead of the `AutoLoginPartialRoutesGuard`. This guard ensures that `checkAuth()` is being called for you and you do not have to call it in your `app.component.ts` then.
 
 ```ts
 export class AppComponent implements OnInit {
@@ -78,4 +77,4 @@ const appRoutes: Routes = [
 ];
 ```
 
-[src code](../projects/sample-code-flow-auto-login)
+[Source Code](../projects/sample-code-flow-auto-login)

--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -71,7 +71,6 @@ export class ConfigService {
 
 const authFactory = (configService: ConfigService) => {
   const config = configService.getConfig();
-
   return new StsConfigStaticLoader(config);
 };
 
@@ -90,9 +89,9 @@ const authFactory = (configService: ConfigService) => {
 export class AuthConfigModule {}
 ```
 
-## Load config from HTTP / Async
+## Load config from HTTP (async)
 
-If you want to load the config from HTTP and then map it to the interface the library provides you can use the `StsConfigHttpLoader` and pass it with the `loader` property
+If you want to load the config from HTTP and then map it to the interface the library provides you can use the `StsConfigHttpLoader` and pass it with the `loader` property.
 
 ```ts
 import { AuthModule, StsConfigHttpLoader, StsConfigLoader } from 'angular-auth-oidc-client';
@@ -128,9 +127,9 @@ export const httpLoaderFactory = (httpClient: HttpClient) => {
 export class AuthConfigModule {}
 ```
 
-### Using multiple http configs
+### Using multiple HTTP configs
 
-Also the http loader supports multiple configs.
+The HTTP loader also supports multiple configs.
 
 ```ts
 import { AuthModule, StsConfigHttpLoader, StsConfigLoader } from 'angular-auth-oidc-client';
@@ -182,287 +181,286 @@ export class AuthConfigModule {}
 
 ### `configId`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-To identify a configuration a new parameter called `configId` was introduced. If you do not explicitly set this value, the library will generate and assign the value for you. If set, the configured value is used. The value is optional.
+To identify a configuration the `configId` parameter was introduced. If you do not explicitly set this value, the library will generate and assign the value for you. If set, the configured value is used. The value is optional.
 
 ### `authority`
 
-- Type: string
-- Required: true
+- Type: `string`
+- Required: `true`
 
-This is the authority or the secure token server (URL). This must be set.
+This is the authority or the Security Token Service URL. This must be set.
 
 ### `authWellknownEndpointUrl`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-A different well known endpoint can be defined instead of the authority domain, with the standard well known endpoints postfix. This is only required if the well known endpoint URL is not implemented in a standard way on the secure token service.
+A different well-known endpoint can be defined instead of the authority domain with the standard well-known endpoints postfix. This is only required if the well-known endpoint URL is not implemented in a standard way on the Security Token Service (STS).
 
 ### `authWellknownEndpoints`
 
-- Type: object
-- Required: false
+- Type: `object`
+- Required: `false`
 
 TBD
 
 ### `redirectUrl`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-This is the redirect_url which was configured on the security token service (STS)
+This is the `redirect_url` which was configured on the Security Token Service (STS).
 
 ### `clientId`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-The client MUST validate that the aud (audience) claim contains its client_id value registered at the Issuer identified by the iss (issuer) Claim as an audience. The id token MUST be rejected if the id token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
+The client MUST validate that the aud (audience) claim contains its `client_id` value registered at the Issuer identified by the iss (issuer) Claim as an audience. The id token MUST be rejected if the id token does not list the Client as a valid audience, or if it contains additional audiences not trusted by the Client.
 
 ### `responseType`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-'code', 'id_token token' or 'id_token' Name of the flow which can be configured. <br/> You must use the 'id_token token' flow, if you want to access an API or get user data from the server. <br/> The `access_token` is required for this, and only returned with this flow.
+`code`, `id_token token` or `id_token`. Name of the flow which can be configured. <br/> You must use the `id_token token` flow, if you want to access an API or get user data from the server. <br/> The `access_token` is required for this, and only returned with this flow.
 
 ### `scope`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-This is this scopes which are requested from the server from this client. This must match the secure token server configuration for the client you use.
+List of scopes which are requested from the server from this client. This must match the Security Token Service configuration for the client you use.
 
 ### `hdParam`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
 Optional hd parameter for Google Auth with particular G Suite domain, see https://developers.google.com/identity/protocols/OpenIDConnect#hd-param
 
 ### `postLogoutRedirectUri`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-URL after a server logout if using the end session API.
+URL to redirect to after a server logout if using the end session API.
 
 ### `startCheckSession`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
 Starts the OpenID session management for this client.
 
 ### `silentRenew`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-Renews the client tokens, once the token_id expires. Can use the iframes, or the refresh tokens.
+Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens.
 
 ### `silentRenewUrl`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
 URL which can be used for a lightweight renew callback. See silent renew.
 
 ### `silentRenewTimeoutInSeconds`
 
-- Type: number
-- Required: false
+- Type: `number`
+- Required: `false`
 
-Sets the maximum waiting time for silent renew process. If this time is exceeded, the silent renew state will be reset. Default = <em>20</em>
+Sets the maximum waiting time for silent renew process. If this time is exceeded, the silent renew state will be reset. Default = _20_
 
 ### `renewTimeBeforeTokenExpiresInSeconds`
 
-- Type: number
-- Required: false
+- Type: `number`
+- Required: `false`
 
-Makes it possible to add an offset to the silent renew check in seconds. By entering a value, you can renew the tokens, before the tokens expire.
+Makes it possible to add an offset to the silent renew check in seconds. By entering a value, you can renew the tokens before the tokens expire.
 
 ### `useRefreshToken`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
 Default set to false. Standard silent renew mode used per default. Refresh tokens can be activated.
 
 ### `ignoreNonceAfterRefresh`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However some oidc endpoint implementations do send one. Setting ignoreNonceAfterRefresh to true disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is false.
+A token obtained by using a refresh token normally doesn't contain a nonce value. The library checks it is not there. However, some OIDC endpoint implementations do send one. Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present. Please note that the nonce value, if present, will not be verified. Default is `false`.
 
 ### `postLoginRoute`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
 The default Angular route which is used after a successful login, if not using the `triggerAuthorizationResultEvent`.
 
 ### `forbiddenRoute`
 
-- Type: string
-- Required: false
+- Type: `string`
+- Required: `false`
 
-Route, if the server returns a 403. This is an Angular route. HTTP 403.
+Route to redirect to if the server returns a 403 error. This has to be an Angular route. HTTP 403.
 
 ### `unauthorizedRoute`
 
 - Type: string
 - Required: false
 
-Route, if the server returns a 401. This is an Angular route. HTTP 401.
+Route to redirect to if the server returns a 401 error. This has to be an Angular route. HTTP 401.
 
 ### `autoUserInfo`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
 
 Automatically get user info after authentication.
 
 ### `renewUserInfoAfterTokenRenew`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
 Automatically get user info after token renew.
 
 ### `autoCleanStateAfterAuthentication`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-Can be used for custom state logic handling, the state is not automatically reset, when set to false.
+Can be used for custom state logic handling, the state is not automatically reset when set to `false`.
 
 ### `triggerAuthorizationResultEvent`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-This can be set to `true` which emits an event instead of an angular route change. Instead of forcing the application consuming this library to automatically redirect to one of the 3 hard-configured routes (start, unauthorized, forbidden), this modification will add an extra configuration option to override such behavior and trigger an event that will allow to subscribe to it and let the application perform other actions. This would be useful to allow the application to save an initial return url so that the user is redirected to it after a successful login on the secure token server (ie: saving the return url previously on sessionStorage and then retrieving it during the triggering of the event).
+This can be set to `true` which emits an event instead of an Angular route change. Instead of forcing the application consuming this library to automatically redirect to one of the 3 hard-configured routes (start, unauthorized, forbidden), this modification will add an extra configuration option to override such behavior and trigger an event that will allow to subscribe to it and let the application perform other actions. This would be useful to allow the application to save an initial return URL so that the user is redirected to it after a successful login on the Security Token Service (i.e. saving the return URL previously on sessionStorage and then retrieving it during the triggering of the event).
 
 ### `logLevel`
 
 - Type: `LogLevel`
-- Required: false
+- Required: `false`
 
 Can be used to set the log level displayed in the console.
 
 ### `issValidationOff`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-Make it possible to turn the iss validation off per configuration. You should not turn this off!
+Make it possible to turn off the iss validation per configuration. **You should not turn this off!**
 
 ### `historyCleanupOff`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-If this is active, the history is not cleaned up at an authorize callback. This can be used, when the application needs to preserve the history.
+If this is active, the history is not cleaned up at an authorize callback. This can be used when the application needs to preserve the history.
 
 ### `maxIdTokenIatOffsetAllowedInSeconds`
 
-- Type: number
-- Required: false
+- Type: `number`
+- Required: `false`
 
-Amount of offset allowed between the server creating the token, and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
+Amount of offset allowed between the server creating the token and the client app receiving the id_token. The diff in time between the server time and client time is also important in validating this value. All times are in UTC.
 
 ### `disableIatOffsetValidation`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
 This allows the application to disable the iat offset validation check. The iat Claim can be used to reject tokens that were issued too far away from the current time, limiting the amount of time that nonces need to be stored to prevent attacks.The acceptable range is client specific.
 
 ### `customParamsAuthRequest`
 
-- Type: Object
-- Required: false
+- Type: `Object`
+- Required: `false`
 
-Extra parameters can be added to the authorization URL request.
+Extra parameters to add to the authorization URL request.
 
 ### `customParamsRefreshTokenRequest`
 
-- Type: Object
-- Required: false
+- Type: `Object`
+- Required: `false`
 
 Extra parameters to add to the refresh token request body.
 
 ### `customParamsEndSessionRequest`
 
-- Type: Object
-- Required: false
+- Type: `Object`
+- Required: `false`
 
 Extra parameters to add to the end session request body.
 
 ### `customParamsCodeRequest`
 
-- Type: Object
-- Required: false
+- Type: `Object`
+- Required: `false`
 
-Extra parameters can be added to the token URL request.
+Extra parameters to add to the token URL request.
 
 ### `disableRefreshIdTokenAuthTimeValidation`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-disables the auth_time validation for id_tokens in a refresh due to Azure incorrect implementation
+Disables the auth_time validation for id_tokens in a refresh due to Azure's incorrect implementation.
 
 ### `enableIdTokenExpiredValidationInRenew`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-enables the id_token validation, default value is true. You can disable this validation if you would like to ignore the expired value in the renew process. If no id_token is returned in using refresh tokens, set this to false.
+Enables the id_token validation, default value is `true`. You can disable this validation if you like to ignore the expired value in the renew process. If no id_token is returned in using refresh tokens, set this to `false`.
 
 ### `eagerLoadAuthWellKnownEndpoints`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-Tells if the AuthWellKnownEndpoints should be loaded on start or when the user calls the `authorize` method
+Tells if the `AuthWellKnownEndpoints` should be loaded on start or when the user calls the `authorize` method.
 
 ### `tokenRefreshInSeconds`
 
-- Type: number
-- Required: false
+- Type: `number`
+- Required: `false`
 
-Controls the periodic check time interval in seconds, default = 3
+Controls the periodic check time interval in seconds. Default = _3_
 
 ### `secureRoutes`
 
 - Type: `string[]`
-- Required: false
+- Required: `false`
 
-Array of secure urls on which the token should be send if the interceptor is added to the HTTP_INTERCEPTORS see [Http Interceptor](./using-access-tokens.md/#http-interceptor)
+Array of secure URLs for which the token should be sent if the interceptor is added to the `HTTP_INTERCEPTORS`, see [HTTP Interceptor](./using-access-tokens.md/#http-interceptor).
 
 ### `usePushedAuthorisationRequests`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-activates Pushed Authorisation Requests for login and popup login (Iframe renew not supported)
+Activates Pushed Authorisation Requests for login and popup login (iframe renew not supported)
 
 ### `refreshTokenRetryInSeconds`
 
-- Type: number
-- Required: false
+- Type: `number`
+- Required: `false`
 
-Controls the periodic retry time interval for retrieving new tokens in seconds, default = 3. `silentRenewTimeoutInSeconds` and `tokenRefreshInSeconds` are upper bounds for this value.
+Controls the periodic retry time interval for retrieving new tokens in seconds, default = _3_. `silentRenewTimeoutInSeconds` and `tokenRefreshInSeconds` are upper bounds for this value.
 
 ### `ngswBypass`
 
-- Type: boolean
-- Required: false
+- Type: `boolean`
+- Required: `false`
 
-Adds the `ngsw-bypass` param to all requests ([Angular Docu](https://angular.io/guide/service-worker-devops#bypassing-the-service-worker)).
+Adds the `ngsw-bypass` param to all requests ([Angular Docs](https://angular.io/guide/service-worker-devops#bypassing-the-service-worker)).

--- a/docs/site/angular-auth-oidc-client/docs/documentation/custom-parameters.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/custom-parameters.md
@@ -3,7 +3,7 @@ sidebar_label: Custom Parameters
 sidebar_position: 9
 ---
 
-# Custom parameters
+# Custom Parameters
 
 Custom parameters can be added to the auth request by adding them to the config. They are provided by
 
@@ -17,25 +17,25 @@ so you can pass them as an object like this:
 
 ```ts
 AuthModule.forRoot({
-      config: {
-        authority: '<your authority address here>',
-        customParamsAuthRequest: {
-          response_mode: 'fragment',
-          prompt: 'consent',
-        },
-      },
-    }),
+  config: {
+    authority: '<your authority address here>',
+    customParamsAuthRequest: {
+      response_mode: 'fragment',
+      prompt: 'consent',
+    },
+  },
+}),
 ```
 
 ## Dynamic custom parameters
 
-If you want to pass dynamic custom parameters with the request url to the secure token server, you can do this by passing the parameters into the `authorize` method.
+If you want to pass dynamic custom parameters with the request URL to the Security Token Service, you can do this by passing the parameters into the `authorize` method:
 
 ```ts
 login() {
-    this.oidcSecurityService.authorize(null, { customParams: { ui_locales: 'de-CH' }});
+  this.oidcSecurityService.authorize(null, { customParams: { ui_locales: 'de-CH' }});
 }
 
 ```
 
-> If you want to pass static parameters to the secure token server every time please use the custom parameters in the [Configuration](configuration.md) instead!
+> If you want to pass static parameters to the Security Token Service every time please use the custom parameters in the [Configuration](configuration.md) instead!

--- a/docs/site/angular-auth-oidc-client/docs/documentation/custom-storage.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/custom-storage.md
@@ -5,9 +5,9 @@ sidebar_position: 7
 
 # Custom Storage
 
-The lib uses the `sessionStorage` as default. If you need, you can create a custom storage (for example to use cookies).
-
-Implement `AbstractSecurityStorage` and the `read`, `write` and `remove` methods:
+The lib uses the `sessionStorage` as default. If needed, you can create a custom storage implementation, e.g. to use `localStorage` or cookies.
+A storage is implemented as a class with the `AbstractSecurityStorage` interface and the `read`, `write` and `remove` methods.
+The following example shows a custom storage that uses `localStorage`:
 
 ```ts
 import { AbstractSecurityStorage } from 'angular-auth-oidc-client';
@@ -33,10 +33,10 @@ Then provide the class in the module:
 
 ```ts
 @NgModule({
-    imports: [
-        ...
-        AuthModule.forRoot({ config: { storage: new CustomStorage() } })
-    ],
-    ...
+  imports: [
+      // ...
+      AuthModule.forRoot({ config: { storage: new CustomStorage() } })
+  ],
+  // ...
 })
 ```

--- a/docs/site/angular-auth-oidc-client/docs/documentation/delay-or-pass-authwellknown.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/delay-or-pass-authwellknown.md
@@ -5,20 +5,20 @@ sidebar_position: 11
 
 # Delay the loading or pass an existing .well-known/openid-configuration
 
-The secure token server `.well-known/openid-configuration` configuration can be requested via an HTTPS call when starting the application. This HTTPS call may affect your first page loading time. You can disable this and configure the loading of the `.well-known/openid-configuration` later, just before you start the authentication process. You as a user, can decide when you want to request the well known endpoints.
+The Security Token Service `.well-known/openid-configuration` configuration can be requested via an HTTPS call when starting the application. This HTTPS call may affect your first page loading time. You can disable this and configure the loading of the `.well-known/openid-configuration` later, just before you start the authentication process. You as a user, can decide when you want to request the well known endpoints.
 
 The property `eagerLoadAuthWellKnownEndpoints` in the configuration sets exactly this. The default is set to `true`, so the `.well-known/openid-configuration` is loaded at the start as in previous versions. Setting this to `false` the `.well-known/openid-configuration` will be loaded when the user starts the authentication.
 
 You also have the option to pass the already existing `.well-known/openid-configuration` into the module as a second parameter. In this case no HTTPS call to load the `.well-known/openid-configuration` will be made.
 
 ```ts
- AuthModule.forRoot({
-    config: {
+AuthModule.forRoot({
+  config: {
+    // ...
+    eagerLoadAuthWellKnownEndpoints: true | false,
+    authWellknownEndpoints: {
       // ...
-      eagerLoadAuthWellKnownEndpoints: true | false,
-      authWellknownEndpoints: {
-        // ...
-      }
-    },
-  }),
+    }
+  },
+}),
 ```

--- a/docs/site/angular-auth-oidc-client/docs/documentation/deploy-to-different-domains.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/deploy-to-different-domains.md
@@ -5,7 +5,7 @@ sidebar_position: 5
 
 # Deploying to different domains
 
-If deploying the client application and the Secure token server application with 2 different domains,
+If deploying the client application and the Security Token Service application with 2 different domains,
 the X-Frame-Options HTTPS header needs to allow all iframes. Then use the CSP HTTPS header to only allow the required domains.
 **The silent renew requires this.**
 
@@ -15,9 +15,9 @@ Add this header to responses from the server that serves your SPA:
 Content-Security-Policy: script-src 'self' 'unsafe-inline';style-src 'self' 'unsafe-inline';img-src 'self' data:;font-src 'self';frame-ancestors 'self' https://localhost:44318;block-all-mixed-content
 ```
 
-where `https://localhost:44318` is the address of your secure token secure server, ie the authority which issues tokens.
+where `https://localhost:44318` is the address of your secure token secure server, i.e. the authority which issues tokens.
 
-e.g. if you use NginX to serve your Angular application, it would be
+E.g. if you use nginx to serve your Angular application, you can configure the server as follows:
 
 ```
 http {

--- a/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
@@ -5,29 +5,30 @@ sidebar_position: 3
 
 # Login & Logout
 
-In this section the Login and Logout mechanisms should be briefly described.
-
 ## Login
 
-For logging in a user you can call the `authorize()` method.
+For logging in a user you can call the `authorize()` method:
 
 ```ts
+constructor(private oidcSecurityService: OidcSecurityService) {}
+
+// ...
 this.oidcSecurityService.authorize();
 ```
 
-You configuration will be used and you will be redirected to the Security Token Server to log into your app.
+The supplied configuration will be used and the user will be redirected to the Security Token Service to log into your app.
 
-> The configuration on server _and_ client side has to be correct to finish the login successful!
+> The configuration on server _and_ client side has to be valid to finish the login successfully!
 
 ### `ConfigId` Parameter
 
-In case you have multiple configs you can pass the `configId` parameter as the first argument.
+In case you have multiple configs you can pass the `configId` parameter as the first argument to select a specific config:
 
 ```ts
 login() {
   this.oidcSecurityService.authorizeWithPopUp('configId')
     .subscribe(({ isAuthenticated, userData, idToken, accessToken, errorMessage }) => {
-    /* ... */
+      // ...
     });
 }
 ```
@@ -40,44 +41,42 @@ You can pass options to manipulate the behavior of the login with a custom `urlH
 login() {
   const authOptions = {
     customParams: {
-    some: 'params',
-  },
-  urlHandler: () => {
-    /* ... */
+      some: 'params',
+    },
+    urlHandler: () => {
+      // ...
     },
   };
 
-  const configIdOrNull = /* ... */
+  const configIdOrNull = // ...
 
   this.oidcSecurityService.authorizeWithPopUp(configIdOrNull, authOptions)
     .subscribe(({ isAuthenticated, userData, idToken, accessToken, errorMessage }) => {
-    /* ... */
-  });
+      // ...
+    });
 }
 
 ```
 
 ## Login using a Popup
 
-You can authenticate with any Open ID Connect identity provider using a popup.
+You can authenticate with any OpenID Connect identity provider using a popup.
 
 This allows you to have the provider's consent prompt display in a popup window to avoid unloading and reloading the app.
 
 ### Sample
 
 ```ts
-  constructor(public oidcSecurityService: OidcSecurityService) {}
-
-  loginWithPopup() {
-    this.oidcSecurityService.authorizeWithPopUp().subscribe(({ isAuthenticated, userData, accessToken, errorMessage }) => {
-      /* use data */
-    });
-  }
+loginWithPopup() {
+  this.oidcSecurityService.authorizeWithPopUp().subscribe(({ isAuthenticated, userData, accessToken, errorMessage }) => {
+    /* use data */
+  });
+}
 ```
 
 ### AuthOptions & PopupOptions
 
-You can pass options to control the dimension of the popup with the `PopupOptions` interface as a second parameter
+You can pass options to control the dimension of the popup with the `PopupOptions` interface as a second parameter.
 
 ```ts
 loginWithPopup() {
@@ -115,23 +114,23 @@ loginWithPopup() {
 
 ## Logout
 
-The `logoff()` function sends an end session request to the OIDC server, if it is available, or the check session has not sent a changed event.
+The `logoff()` method sends an end session request to the OIDC server, if it is available, or the check session has not sent a changed event.
 
 ```ts
 logout() {
-   this.oidcSecurityService.logoff();
+  this.oidcSecurityService.logoff();
 }
 ```
 
 ### `ConfigId` Parameter
 
-In case you have multiple configs you can pass the `configId` parameter as the first argument.
+`logoff()` also accepts a `configId` paramater to select a specific config:
 
 ```ts
 login() {
   this.oidcSecurityService.logoff('configId')
     .subscribe(({ isAuthenticated, userData, idToken, accessToken, errorMessage }) => {
-    /* ... */
+      /* ... */
     });
 }
 ```
@@ -157,23 +156,23 @@ logout() {
 
 ### `logoffAndRevokeTokens()`
 
-The `logoffAndRevokeTokens()` function revokes the access token and the refresh token if using a refresh flow, and then logoff like above.
+The `logoffAndRevokeTokens()` method revokes the access token and the refresh token if using a refresh flow, and then logoff like above.
 
 ```ts
 logoffAndRevokeTokens() {
-   this.oidcSecurityService.logoffAndRevokeTokens()
-      .subscribe((result) => console.log(result));
+  this.oidcSecurityService.logoffAndRevokeTokens()
+    .subscribe((result) => console.log(result));
 }
 ```
 
-The method also takes a `configId` and a `authOptions` in case you want to pass this.
+The method also takes `configId` and `authOptions` parameters if needed.
 
 ### `logoffLocal()`
 
-The `logoffLocal()` function is used to reset you local session in the browser, but not sending anything to the server. It also supports the `configId` parameter.
+The `logoffLocal()` method is used to reset your local session in the browser, but does not send anything to the server. It also accepts the `configId` parameter.
 
 ```ts
-logoutLocal() {
-   this.oidcSecurityService.logoffLocal();
+logoffLocal() {
+  this.oidcSecurityService.logoffLocal();
 }
 ```

--- a/docs/site/angular-auth-oidc-client/docs/documentation/public-api.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/public-api.md
@@ -9,7 +9,7 @@ The most public accessible observables, properties and methods are placed in the
 
 ## userData$
 
-The `userData$` observable provides the information about the user after he has logged in. It returns an `UserDataResult` in the following form.
+The `userData$` observable provides the information about the user after they have logged in. It returns an `UserDataResult` in the following form:
 
 ```ts
 export interface UserDataResult {
@@ -23,17 +23,17 @@ export interface ConfigUserDataResult {
 }
 ```
 
-In case you are running with one configuration the `ConfigUserDataResult` contains the user data in the `userData` property and the `ConfigUserData[]` returns the same user data with the `configId` filled in case you need it.
+In case you are running with one configuration, the `ConfigUserDataResult` contains the user data in the `userData` property and the `ConfigUserData[]` returns the same user data with the `configId` filled in case you need it.
 
-In case you are running with multiple configs the `ConfigUserDataResult`s `userData` property is set to `null` and you find your user data per config in the `ConfigUserData[]`.
+In case you are running with multiple configs, the `userData` property of `ConfigUserDataResult` is set to `null` and you find your user data per config in the `ConfigUserData[]`.
 
-Example:
+### Example
 
 ```ts
 this.userData$ = this.oidcSecurityService.userData$;
 ```
 
-Single Config:
+#### Single Config
 
 ```json
 {
@@ -65,7 +65,7 @@ Single Config:
 }
 ```
 
-Multiple Configs:
+#### Multiple Configs
 
 ```json
 {
@@ -103,12 +103,11 @@ Multiple Configs:
 
 ## isAuthenticated$
 
-This property returns an `Observable<AuthenticatedResult>`. This object is filled depending on with how many configurations you run. The `AuthenticatedResult` is built as following:
+The `isAuthenticated$` property returns an `Observable<AuthenticatedResult>`. This object is filled depending on with how many configurations you run. The `AuthenticatedResult` is structured as follows:
 
 ```ts
 export interface AuthenticatedResult {
   isAuthenticated: boolean;
-
   allConfigsAuthenticated: ConfigAuthenticatedResult[];
 }
 
@@ -118,15 +117,17 @@ export interface ConfigAuthenticatedResult {
 }
 ```
 
-In case you have a single config the `isAuthenticated` on the `AuthenticatedResult` tells you if you are authenticated or not. The `ConfigAuthenticatedResult[]` contains the single config result with it's `configId` and again if this config is authenticated or not.
+In case you have a single config, the `isAuthenticated` on the `AuthenticatedResult` tells you if the user is authenticated or not. The `ConfigAuthenticatedResult[]` contains the single config result with its `configId` and again if this config is authenticated or not.
 
-In case you have multiple configs the `isAuthenticated` on the `AuthenticatedResult` tells you if all configs are authenticated (`true`) or not (`false`). The `ConfigAuthenticatedResult[]` contains the single config results with it's `configId` and again if this config is authenticated or not.
+In case you have multiple configs, the `isAuthenticated` on the `AuthenticatedResult` tells you if all configs are authenticated (`true`) or not (`false`). The `ConfigAuthenticatedResult[]` contains the single config results with their `configId` and again if this config is authenticated or not.
+
+### Example
 
 ```ts
 this.isAuthenticated$ = this.oidcSecurityService.isAuthenticated$;
 ```
 
-Single Config
+#### Single Config
 
 ```json
 {
@@ -135,7 +136,7 @@ Single Config
 }
 ```
 
-Multiple Configs
+#### Multiple Configs
 
 ```json
 {
@@ -149,9 +150,7 @@ Multiple Configs
 
 ## checkSessionChanged$
 
-The `checkSessionChanged$` observable gets emitted values every time the server comes back with a check session and the value `changed`. If you want to get an information about when the CheckSession Event has been received generally take a look at the [public events](public-events.md).
-
-Example:
+The `checkSessionChanged$` observable emits values every time the server comes back with a check session and the value `changed`. If you want to get information about when the `CheckSession` Event has been received, please take a look at the [public events](public-events.md).
 
 ```ts
 this.checkSessionChanged$ = this.oidcSecurityService.checkSessionChanged$;
@@ -159,9 +158,7 @@ this.checkSessionChanged$ = this.oidcSecurityService.checkSessionChanged$;
 
 ## stsCallback$
 
-The `stsCallback$` observable gets emitted _after_ the library has handled the possible secure token server callback. You can perform initial setups and custom workflows inside your application when the secure token server redirects you back to your app.
-
-Example:
+The `stsCallback$` observable emits _after_ the library has handled the possible Security Token Service callback. You can perform initial setups and custom workflows inside your application when the Security Token Service redirects you back to your app.
 
 ```ts
 this.stsCallback$ = this.oidcSecurityService.stsCallback$;
@@ -178,7 +175,7 @@ const allConfigs = this.oidcSecurityService.getConfigurations();
 ## getConfiguration(configId?: string)
 
 This method returns one single configuration.
-If you are running with multiple configs and pass the `configId` the configuration or `null` is returned. If you are running with multiple configs and do not pass the `configId` the first one is returned. If you are running with a single config this config is returned.
+If you are running with multiple configs and pass a `configId`, the configuration or `null` is returned. If you are running with multiple configs and do not pass the `configId`, the first one is returned. If you are running with a single config, then this config is returned.
 
 ```ts
 // one config or the first one in case of multiple or null
@@ -191,7 +188,7 @@ const singleConfig = this.oidcSecurityService.getConfiguration('configId');
 ## getUserData(configId?: string)
 
 This method returns the user data.
-If you are running with multiple configs and pass the `configId` the user data for this config or `null` is returned. If you are running with multiple configs and do not pass the `configId` the user data for the first config is returned. If you are running with a single config the user data for this is returned.
+If you are running with multiple configs and pass a `configId`, the user data for this config or `null` is returned. If you are running with multiple configs and do not pass the `configId`, the user data for the first config is returned. If you are running with a single config, the user data for this config is returned.
 
 ```ts
 // one config or the first one in case of multiple or null
@@ -205,7 +202,7 @@ const userData = this.oidcSecurityService.getUserData('configId');
 
 This method starts the complete authentication flow. Use this method if you are running with a single config or want to check a single config.
 
-This method parses the url when redirected back from the secure token server (STS) and sets all values.
+This method parses the URL when redirected back from the Security Token Service (STS) and sets all values.
 
 It returns an `Observable<LoginResponse>` containing all information you need in one object.
 
@@ -226,7 +223,7 @@ this.oidcSecurityService.checkAuth().subscribe(({ isAuthenticated, userData, acc
 });
 ```
 
-You can also pass a `configId` to check for as well as a url in case you want to overwrite the one in the address bar from the browser. This is useful for mobile or desktop cases like Electron or Cordova/Ionic.
+You can also pass a `configId` to check for as well as a URL in case you want to overwrite the current one in the address bar from the browser. This is useful for mobile or desktop cases like Electron or Cordova/Ionic.
 
 ```ts
 const url = '...';
@@ -241,7 +238,7 @@ this.oidcSecurityService.checkAuth(url, configId).subscribe(({ isAuthenticated, 
 
 This method starts the complete authentication flow for multiple configs. Use this method if you are running with multiple configs to check which one is authenticated or not.
 
-This method parses the url when you come back from the secure token server (STS) and sets all values.
+This method parses the URL when you come back from the Security Token Service (STS) and sets all values.
 
 It returns an `Observable<LoginResponse[]>` containing all information you need in the `LoginResponse` object as array so that you can see which config has which values.
 
@@ -264,7 +261,7 @@ this.oidcSecurityService.checkAuthMultiple().subscribe(({ isAuthenticated, userD
 });
 ```
 
-You can also pass a `configId` to check for as well as a url in case you want to overwrite the one in the address bar from the browser. This is useful for mobile or desktop cases like Electron or Cordova/Ionic.
+You can also pass a `configId` to check for as well as a URL in case you want to overwrite the one in the address bar from the browser. This is useful for mobile or desktop cases like Electron or Cordova/Ionic.
 
 ```ts
 const url = '...';
@@ -343,8 +340,8 @@ const idToken = this.oidcSecurityService.getIdToken('configId');
 
 ## getRefreshToken(configId?: string)
 
-Returns the refresh token for you login scenario if there is one.
-If you are running with multiple configs and pass the `configId` the refresh token for this config is returned. If you are running with multiple configs and do not pass the `configId` the refresh token for the first config is returned. If you are running with a single config the refresh token for this config returned.
+Returns the refresh token for your login scenario if there is one.
+If you are running with multiple configs and pass a `configId`, the refresh token for this config is returned. If you are running with multiple configs and do not pass the `configId`, the refresh token for the first config is returned. If you are running with a single config, the refresh token for this config is returned.
 
 ```ts
 const refreshToken = this.oidcSecurityService.getRefreshToken();
@@ -356,7 +353,7 @@ const refreshToken = this.oidcSecurityService.getRefreshToken('configId');
 
 ## getAuthenticationResult(configId?: string)
 
-Returns the authentication result, if present, for the sign-in. The `configId` parameter is used to check define which configuration to use, this is only required when using multiple configurations. If not passed, the first config will be taken. A object with the authentication result is returned.
+Returns the authentication result, if present, for the sign-in. The `configId` parameter is used to define which configuration to use. This is only required when using multiple configurations. If not passed, the first config will be taken. An object with the authentication result is returned.
 
 ```ts
 const authnResult = this.oidcSecurityService.getAuthenticationResult();
@@ -369,7 +366,7 @@ const authnResult = this.oidcSecurityService.getAuthenticationResult('configId')
 ## getPayloadFromIdToken(encode = false, configId?: string)
 
 Returns the payload from the id_token. This can be used to get claims from the token.
-If you are running with multiple configs and pass the `configId` the payload for this config is returned. If you are running with multiple configs and do not pass the `configId` the refresh token for the first config is returned. If you are running with a single config the refresh token for this config returned.
+If you are running with multiple configs and pass a `configId`, the payload for this config is returned. If you are running with multiple configs and do not pass a `configId`, the payload for the first config is returned. If you are running with a single config, the payload for this config returned.
 
 The `encode` param has to be set to `true` if the payload is base64 encoded.
 
@@ -383,8 +380,8 @@ const payload = this.oidcSecurityService.getPayloadFromIdToken(true, 'configId')
 
 ## setState(state: string, configId?: string)
 
-You can set the state value used for the authorize request, if you have the `autoCleanStateAfterAuthentication` in the configuration set to `false`. Can be used for custom state logic handling, the state is not automatically reset when set to `false`.
-If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+You can set the state value used for the authorize request, if you have `autoCleanStateAfterAuthentication` in the configuration set to `false`. This can be used for custom state logic handling, the state is not automatically reset when set to `false`.
+If you are running with multiple configs and pass a `configId`, the passed config is taken. If you are running with multiple configs and do not pass a `configId`, the first config is taken. If you are running with a single config, then this config is taken.
 
 ```ts
 this.oidcSecurityService.setState('some-state');
@@ -397,7 +394,7 @@ this.oidcSecurityService.setState('some-state', 'configId');
 ## getState(configId?: string)
 
 Returns the state value used for the authorize request.
-If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+If you are running with multiple configs and pass a `configId`, the passed config is taken. If you are running with multiple configs and do not pass a `configId`, the first config is taken. If you are running with a single config, then this config is taken.
 
 ```ts
 const state = this.oidcSecurityService.getState();
@@ -409,9 +406,10 @@ const state = this.oidcSecurityService.getState('configId');
 
 ## authorize(configId?: string, authOptions?: AuthOptions)
 
-This method is being called when you want to redirect to the authority and sign in the identity. This method takes a `configId` as parameter if you want to use a specific config and it also takes `authOptions` adding `customParams` which can change every time you want to login and an `urlHandler` which is getting called instead of the redirect.
+This method must be called when you want to redirect to the authority and sign in the identity. This method takes a `configId` as parameter if you want to use a specific config and it also takes `authOptions` adding `customParams` which can change every time you want to login.
+It also accepts an `urlHandler` which is getting called instead of the redirect.
 
-See also [Custom parameters](custom-parameters.md)
+See also: [Custom parameters](custom-parameters.md).
 
 ```ts
 export interface AuthOptions {
@@ -438,7 +436,8 @@ this.oidcSecurityService.authorize('configId', authOptions);
 
 ## authorizeWithPopUp(authOptions?: AuthOptions, popupOptions?: PopupOptions, configId?: string)
 
-This method is being called when you want to redirect to the secure token server in a popup and login your user. This method takes a `configId` as parameter if you want to use a specific config and it also takes `authOptions` adding `customParams` which can change every time you want to login and an `urlHandler` which is getting called instead of the redirect. You can also pass `PopupOptions` to define where and how the popup should open.
+This method must be called when you want to redirect to the Security Token Service in a popup and login your user. This method takes a `configId` as parameter if you want to use a specific config and it also takes `authOptions` adding `customParams` which can change every time you want to login.
+It also accepts an `urlHandler` which is getting called instead of the redirect. You can pass additional `PopupOptions` to define where and how the popup should open.
 
 The method returns an `Observable<LoginResponse>` containing
 
@@ -469,7 +468,7 @@ export interface AuthOptions {
 }
 ```
 
-Examples:
+### Examples
 
 ```ts
 this.oidcSecurityService.authorizeWithPopUp().subscribe(({ isAuthenticated, userData, accessToken, idToken, configId }) => {
@@ -498,9 +497,9 @@ this.oidcSecurityService
 
 This method provides the functionality to manually refresh the session at any time you require. If a current process is running this method will do nothing. After the run is finished the method forces to refresh again.
 
-This method takes `customParams` for this request as well as a `configId` as parameter if you want to use a specific config. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+This method takes `customParams` for this request as well as a `configId` as parameter if you want to use a specific config. If you are running with multiple configs and pass a `configId`, the passed config is taken. If you are running with multiple configs and do not pass a `configId`, the first config is taken. If you are running with a single config, then this config is taken.
 
-See also [Custom parameters](custom-parameters.md)
+See also: [Custom parameters](custom-parameters.md)
 
 The method returns an `Observable<LoginResponse>` containing
 
@@ -515,7 +514,7 @@ The method returns an `Observable<LoginResponse>` containing
 }
 ```
 
-Examples:
+### Examples
 
 ```ts
 this.oidcSecurityService.forceRefreshSession().subscribe(({ isAuthenticated, userData, accessToken, idToken, configId }) => {
@@ -581,7 +580,7 @@ this.oidcSecurityService.logoff('configId', authOptions);
 
 ## logoffLocal(configId?: string)
 
-This method is used to reset your local session in the browser, but not sending anything to the server. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+This method is used to reset your local session in the browser, but not sending anything to the server. If you are running with multiple configs and pass a `configId`, the passed config is taken. If you are running with multiple configs and do not pass a `configId`, the first config is taken. If you are running with a single config, then this config is taken.
 
 ```ts
 this.oidcSecurityService.logoffLocal();
@@ -601,7 +600,7 @@ this.oidcSecurityService.logoffLocalMultiple();
 
 ## revokeAccessToken(accessToken?: any, configId?: string)
 
-This method revokes an access token on the Security Token Service. This is only required in the code flow with refresh tokens. If no token is provided, then the token from the storage is revoked. You can pass any token to revoke. This makes it possible to manage your own tokens.
+This method revokes an access token on the Security Token Service (STS). This is only required in the code flow with refresh tokens. If no token is provided, then the token from the storage is revoked. You can pass any token to revoke. This makes it possible to manage your own tokens.
 
 This method also takes a `configId`. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
 
@@ -617,9 +616,9 @@ More info: [https://tools.ietf.org/html/rfc7009](https://tools.ietf.org/html/rfc
 
 ## revokeRefreshToken(refreshToken?: any, configId?: string)
 
-This method revokes a refresh token on the secure token server. This is only required in the code flow with refresh tokens. If no token is provided, then the token from the storage is revoked. You can pass any token to revoke. This makes it possible to manage your own tokens.
+This method revokes a refresh token on the Security Token Service (STS). This is only required in the code flow with refresh tokens. If no token is provided, then the token from the storage is revoked. You can pass any token to revoke. This makes it possible to manage your own tokens.
 
-This method also takes a `configId`. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+This method also takes a `configId`. If you are running with multiple configs and pass a `configId`, the passed config is taken. If you are running with multiple configs and do not pass a `configId`, the first config is taken. If you are running with a single config, then this config is taken.
 
 ```ts
 this.oidcSecurityService.revokeRefreshToken().subscribe(/* ... */);
@@ -633,15 +632,15 @@ More info: [https://tools.ietf.org/html/rfc7009](https://tools.ietf.org/html/rfc
 
 ## getEndSessionUrl(customParams?: { ... }, configId?: string)
 
-Creates the end session URL which can be used to implement your own custom server logout. You can pass custom params directly into the method. This method also takes a `configId`. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+Creates the end session URL which can be used to implement your own custom server logout. You can pass custom params directly into the method. This method also takes a `configId`. If you are running with multiple configs and pass a `configId`, the passed config is taken. If you are running with multiple configs and do not pass a `configId`, the first config is taken. If you are running with a single config, then this config is taken.
 
 ```ts
 const endSessionUrl = this.oidcSecurityService.getEndSessionUrl();
 ```
 
 ```ts
-const customParams: {
-  some: 'params';
+const customParams = {
+  some: 'params',
 };
 
 const endSessionUrl = this.oidcSecurityService.getEndSessionUrl(customParams, 'configId');
@@ -649,15 +648,15 @@ const endSessionUrl = this.oidcSecurityService.getEndSessionUrl(customParams, 'c
 
 ## getAuthorizeUrl(customParams?: { ... }, configId?: string)
 
-Creates the authorize URL which can be used to get the url for the authentication the lib uses internally. You can pass custom params directly into the method. This method also takes a `configId`. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+Creates the authorize URL which can be used to get the URL for the authentication the lib uses internally. You can pass custom params directly into the method. This method also takes a `configId`. If you are running with multiple configs and pass a `configId`, the passed config is taken. If you are running with multiple configs and do not pass a `configId`, the first config is taken. If you are running with a single config this config is taken.
 
 ```ts
 const authorizeUrl = this.oidcSecurityService.getAuthorizeUrl();
 ```
 
 ```ts
-const customParams: {
-  some: 'params';
+const customParams = {
+  some: 'params',
 };
 
 const authorizeUrl = this.oidcSecurityService.getAuthorizeUrl(customParams, 'configId');

--- a/docs/site/angular-auth-oidc-client/docs/documentation/public-events.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/public-events.md
@@ -7,7 +7,7 @@ sidebar_position: 6
 
 The library exposes several events which are happening during the runtime. You can subscribe to those events by using the `PublicEventsService`.
 
-Currently the events
+Currently the following events are supported:
 
 ```ts
 {
@@ -22,20 +22,19 @@ Currently the events
 }
 ```
 
-are supported.
+> Notice that the `ConfigLoaded` event only runs inside the constructor of the `AppModule` as the config is loaded with the `APP_INITIALIZER` of Angular inside of the lib.
 
-> Notice that the `ConfigLoaded` event only runs inside the `AppModule`s constructor as the config is loaded with the `APP_INITIALIZER` of Angular inside of the lib.
-
-You can inject the service and use the events like this:
+You can inject the service and use the events like this.
+Using the `filter` operator from RxJS you can decide which events you are interested in and subscribe to them.
 
 ```ts
 import { PublicEventsService } from 'angular-auth-oidc-client';
 
 constructor(private eventService: PublicEventsService) {
-    this.eventService
-            .registerForEvents()
-            .pipe(filter((notification) => notification.type === EventTypes.CheckSessionReceived))
-            .subscribe((value) => console.log('CheckSessionChanged with value ', value));
+  this.eventService
+    .registerForEvents()
+    .pipe(filter((notification) => notification.type === EventTypes.CheckSessionReceived))
+    .subscribe((value) => console.log('CheckSessionChanged with value', value));
 }
 ```
 
@@ -47,5 +46,3 @@ export interface OidcClientNotification<T> {
   value?: T;
 }
 ```
-
-Pass inside the `filter` the type of event you are interested in and subscribe to it.

--- a/docs/site/angular-auth-oidc-client/docs/documentation/silent-renew.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/silent-renew.md
@@ -3,17 +3,24 @@ sidebar_label: Working with Silent Renew
 sidebar_position: 9
 ---
 
-# Renewing the session
+# Working with Silent Renew
 
-The tokens can be renewed in two ways. Using silent renew with refresh tokens or using silent renew with iframes. Both of these have problems and are not perfect. The security best practices for the renew process should be applied as much as possible. See the latest OAuth specs, drafts, recommendations.
+The tokens can be renewed in two ways:
+
+1. Using silent renew with refresh tokens or
+2. Using silent renew with iframes.
+
+Both of these approaches are not perfect and bring some disadvantages. The security best practices for the renew process should be applied as much as possible. See the latest OAuth specs, drafts and recommendations for further information.
 
 ## Silent Renew Code Flow with PKCE using refresh tokens
 
-No iframes are used for this flow, the renew needs only to be configured in the app module. Some servers require the `offline_access` scope for this to work which is defined in the OIDC specifications. Other servers do not require this. Refresh tokens should be rotated and the refresh token should be revoked on a logout using the revocation endpoint.
+For session renewal with the PKCE flow, no iframes are used by default. Instead, a refresh token is used to obtain a new access token from the auth server. Thus, the renewal only needs to be configured in the app module. Some servers require the `offline_access` scope for this to work which is defined in the OIDC specifications. Other servers do not require this.
+
+Refresh tokens should be rotated and the refresh token should be revoked on a logout using the revocation endpoint.
 
 ## Silent Renew (iframe)
 
-When silent renew is enabled, a DOM event will be automatically installed in the application's host window. The event `oidc-silent-renew-message` accepts a `CustomEvent` instance with the token returned from the OAuth server in its `detail` field. The event handler will send this token to the authorization callback and complete the validation.
+When silent renew is enabled, a DOM event will automatically be installed in the application's host window. The event `oidc-silent-renew-message` accepts a `CustomEvent` instance with the token returned from the OAuth server in its `detail` field. The event handler will send this token to the authorization callback and complete the validation.
 
 Point the `silent_renew_url` property to an HTML file which contains the following script element to enable authorization.
 
@@ -25,41 +32,41 @@ Both the access token and the id_token are used to start this process.
 
 ```javascript
 <script>
-    window.onload = function () {
-    /* The parent window hosts the Angular application */
-    var parent = window.parent;
-    /* Send the id_token information to the oidc message handler */
-    var event = new CustomEvent('oidc-silent-renew-message', { detail: window.location });
-    parent.dispatchEvent(event);
-  };
+window.onload = function () {
+  /* The parent window hosts the Angular application */
+  const parent = window.parent;
+  /* Send the id_token information to the oidc message handler */
+  const event = new CustomEvent('oidc-silent-renew-message', { detail: window.location });
+  parent.dispatchEvent(event);
+};
 </script>
 ```
 
-If you are working with the (AngularCLI)[https://angular.io/cli] make sure you add the `silent-renew.html` file to the `angular.json` assets configuration. This has already been done for you if you used the schematics to set up the library.
+If you are working with the [Angular CLI](https://angular.io/cli) make sure you add the `silent-renew.html` file to the assets configuration in your `angular.json`. This has already been done for you if you used the `ng add` schematics to install and setup the library.
 
 ```json
-  "assets": [
-    "projects/<your-project-here>/src/silent-renew.html",
-  ],
+"assets": [
+  "projects/<your-project-here>/src/silent-renew.html",
+],
 ```
 
 ### Silent Renew Implicit Flow (iframe)
 
 ```javascript
 <script>
-    window.onload = function () {
-    /* The parent window hosts the Angular application */
-    var parent = window.parent;
-    /* Send the id_token information to the oidc message handler */
-    var event = new CustomEvent('oidc-silent-renew-message', {detail: window.location.hash.substr(1) });
-    parent.dispatchEvent(event);
+window.onload = function () {
+  /* The parent window hosts the Angular application */
+  const parent = window.parent;
+  /* Send the id_token information to the oidc message handler */
+  const event = new CustomEvent('oidc-silent-renew-message', { detail: window.location.hash.substr(1) });
+  parent.dispatchEvent(event);
 };
 </script>
 ```
 
-## Secure Token Server CSP and CORS
+## Security Token Service CSP and CORS
 
 When silent renew is enabled, the lib will attempt to perform a renew before returning the authorization state.
-This allows the application to authorize a user, that is already authenticated, without redirects.
+This allows the application to authorize a user, that is already authenticated, without performing redirects.
 
-Silent renew requires CSP configuration on the server to allow iframes and also CORS
+Silent renew requires CSP configuration on the server to allow iframes and also CORS.

--- a/docs/site/angular-auth-oidc-client/docs/documentation/usage-in-module-or-lib.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/usage-in-module-or-lib.md
@@ -11,10 +11,10 @@ This example shows how you could set the configuration when loading a child modu
 
 ```ts
 import { NgModule } from '@angular/core';
-import { AuthModule, LogLevel } from 'angular-auth-oidc-client';
 import { HttpClientModule } from '@angular/common/http';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
+import { AuthModule, LogLevel } from 'angular-auth-oidc-client';
 
 @NgModule({
   declarations: [

--- a/docs/site/angular-auth-oidc-client/docs/documentation/using-access-tokens.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/using-access-tokens.md
@@ -5,7 +5,7 @@ sidebar_position: 8
 
 # Using Access Tokens
 
-The access token can be used by calling the `getAccessToken()` function.
+The access token can be used by calling the `getAccessToken()` method.
 
 ## Accessing the access token
 
@@ -15,13 +15,13 @@ You can get the access token by calling the method `getAccessToken()` on the `Oi
 const token = this.oidcSecurityService.getAccessToken();
 ```
 
-or
+or for a specific config:
 
 ```ts
 const token = this.oidcSecurityService.getAccessToken('configId');
 ```
 
-And then you can use it in the HttpHeaders
+You can then manually use the token within `HttpHeaders` when performing an HTTP request with Angular's `HttpClient`:
 
 ```ts
 import { HttpHeaders } from '@angular/common/http';
@@ -37,11 +37,11 @@ const httpOptions = {
 
 ## Http Interceptor
 
-The `HttpClient` allows you to write [interceptors](https://angular.io/guide/http#intercepting-requests-and-responses). A common use case would be to intercept any outgoing HTTP request and add an authorization header.
+The `HttpClient` allows you to implement [HTTP interceptors](https://angular.io/guide/http#intercepting-requests-and-responses) to tap into requests and responses. A common use case would be to intercept any outgoing HTTP request and add an authorization header.
 
-**Note** Do not send the access token with requests for which the access token is not intended!
+**Note:** Do not send the access token with requests for which the access token is not intended!
 
-You can configure the routes you want to send a token with in the configuration
+You can configure the routes you want to send a token with in the configuration:
 
 ```ts
 AuthModule.forRoot({
@@ -52,40 +52,40 @@ AuthModule.forRoot({
 }),
 ```
 
+The lib provides an own interceptor implementation which you can register like any other HTTP interceptor:
 and use the interceptor the lib provides you
 
 ```ts
-import { AuthInterceptor /*, ... */ } from 'angular-auth-oidc-client';
+import { AuthInterceptor, AuthModule } from 'angular-auth-oidc-client';
 
 @NgModule({
-    declarations: [...],
-    imports: [
-        //...
-        AuthModule.forRoot(...),
-        HttpClientModule,
-    ],
-    providers: [
-        // ...
-        { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
-    ],
-    bootstrap: [AppComponent],
+  // ...
+  imports: [
+    // ...
+    AuthModule.forRoot(),
+    HttpClientModule,
+  ],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
+    // ...
+  ],
 })
-export class AppModule { }
+export class AppModule {}
 ```
 
-If you configured a route to be protected, every child route underneath is protected, too. So if you configure `https://first-route.com/` the token is also added to a request to the route `https://first-route.com/param...`.
+If you configured a route to be protected, every child route underneath is protected, too. So if you configure `https://example.org/api` the token is also added to a request to the route `https://example.org/api/users`.
 
-In case you are running multiple configurations all the configured routes over all configurations are collected and compared against the currently requested route. If a fit is made, the token for the configuration you added the secure route to is being taken and applied in the Authorization header.
+In case you are running multiple configurations all the configured routes over all configurations are collected and compared against the currently requested route. If a match is made, the token for the configuration you added the secure route to is being taken and applied in the Authorization header.
 
-Keep in mind that you always can implement your own interceptor according to the Angular documentation.
+Keep in mind that you always can implement your own interceptor as [described in the Angular documentation](https://angular.io/guide/http#intercepting-requests-and-responses).
 
 ## Revoke the access token
 
-Access tokens can be revoked using the `revokeAccessToken()` function. If you provide the access token in the param, any access token from the same secure token server can be revoked, if the secure token server supports the revocation endpoint.
+Access tokens can be revoked using the `revokeAccessToken()` method. If you provide the access token as a parameter, any access token from the same Security Token Service can be revoked, if the Security Token Service supports the revocation endpoint.
 
 ```ts
 revokeAccessToken() {
-    this.oidcSecurityService.revokeAccessToken()
-        .subscribe((result) => console.log(result));
+  this.oidcSecurityService.revokeAccessToken()
+      .subscribe((result) => console.log(result));
 }
 ```

--- a/docs/site/angular-auth-oidc-client/docs/migrations/v11-to-v12.md
+++ b/docs/site/angular-auth-oidc-client/docs/migrations/v11-to-v12.md
@@ -172,7 +172,7 @@ export interface OpenIdConfiguration {
 
 ### AuthWellKnownEndpoints are now part of the config
 
-In the previous version, `authWellKnownEndpoints` was a separate parameter you could provide alongside the config in `withConfig` to configure your secure token server's Well-Known Endpoints. This parameter still exists, and it is of the same type, but it's now a parameter on the config object rather than being a separate parameter on `withConfig(..., authwellKonwn)`
+In the previous version, `authWellKnownEndpoints` was a separate parameter you could provide alongside the config in `withConfig` to configure your Security Token Service's Well-Known Endpoints. This parameter still exists, and it is of the same type, but it's now a parameter on the config object rather than being a separate parameter on `withConfig(..., authwellKonwn)`
 
 Old:
 

--- a/docs/site/angular-auth-oidc-client/docs/samples/samples.md
+++ b/docs/site/angular-auth-oidc-client/docs/samples/samples.md
@@ -82,7 +82,7 @@ The is a multiple configurations sample using code flow with PKCE and iframe ren
 
 ## Azure B2C code flow PKCE with Silent renew
 
-The sample uses the code flow PKCE and iframe renew with Azure B2C as the secure token server.
+The sample uses the code flow PKCE and iframe renew with Azure B2C as the Security Token Service.
 
 [Code](https://github.com/damienbod/angular-auth-oidc-client/tree/main/projects/sample-code-flow-azure-b2c)
 

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.ts
@@ -18,23 +18,23 @@ export class AutoLoginService {
   }
 
   /**
-   * Saves the redirect url to storage.
+   * Saves the redirect URL to storage.
    *
-   * @param url The redirect url to save.
+   * @param url The redirect URL to save.
    */
   saveRedirectRoute(configId: string, url: string): void {
     this.storageService.write(STORAGE_KEY, url, configId);
   }
 
   /**
-   * Gets the stored redirect route from storage.
+   * Gets the stored redirect URL from storage.
    */
   private getStoredRedirectRoute(configId: string): string {
     return this.storageService.read(STORAGE_KEY, configId);
   }
 
   /**
-   * Removes the redirect url from storage.
+   * Removes the redirect URL from storage.
    */
   private deleteStoredRedirectRoute(configId: string): void {
     this.storageService.remove(STORAGE_KEY, configId);

--- a/projects/angular-auth-oidc-client/src/lib/check-auth.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/check-auth.service.spec.ts
@@ -225,7 +225,7 @@ describe('CheckAuthService', () => {
     );
 
     it(
-      'does fire the auth and user data events when it is not a callback from the secure token server and is authenticated',
+      'does fire the auth and user data events when it is not a callback from the security token service and is authenticated',
       waitForAsync(() => {
         spyOn(configurationProvider, 'hasAsLeastOneConfig').and.returnValue(true);
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ authority: 'authority', configId: 'configId' });
@@ -244,7 +244,7 @@ describe('CheckAuthService', () => {
     );
 
     it(
-      'does NOT fire the auth and user data events when it is not a callback from the secure token server and is NOT authenticated',
+      'does NOT fire the auth and user data events when it is not a callback from the security token service and is NOT authenticated',
       waitForAsync(() => {
         spyOn(configurationProvider, 'hasAsLeastOneConfig').and.returnValue(true);
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ authority: 'authority', configId: 'configId' });

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
@@ -37,7 +37,7 @@ describe('AuthWellKnownDataService', () => {
 
   describe('getWellKnownDocument', () => {
     it(
-      'should add suffix if it does not exist on current url',
+      'should add suffix if it does not exist on current URL',
       waitForAsync(() => {
         const dataServiceSpy = spyOn(dataService, 'get').and.callFake((url) => {
           return of(null);

--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -2,36 +2,44 @@ import { LogLevel } from '../logging/log-level';
 import { AuthWellKnownEndpoints } from './auth-well-known/auth-well-known-endpoints';
 
 export interface OpenIdConfiguration {
+  /**
+   * To identify a configuration the `configId` parameter was introduced.
+   * If you do not explicitly set this value, the library will generate
+   * and assign the value for you. If set, the configured value is used.
+   * The value is optional.
+   */
   configId?: string;
   /**
-   * The url to the secure token server (STS) server. The authority issues tokens
+   * The url to the Security Token Service (STS). The authority issues tokens.
    * This field is required.
    */
   authority?: string;
-  /** Override the default secure token server wellknown endpoint postfix. */
+  /** Override the default Security Token Service wellknown endpoint postfix. */
   authWellknownEndpointUrl?: string;
   authWellknownEndpoints?: AuthWellKnownEndpoints;
 
-  /** The redirect URL defined on the secure token server. */
+  /** The redirect URL defined on the Security Token Service. */
   redirectUrl?: string;
   /**
-   * The Client MUST validate that the aud (audience) Claim contains its client_id value
+   * The Client MUST validate that the aud (audience) Claim contains its `client_id` value
    * registered at the Issuer identified by the iss (issuer) Claim as an audience.
    * The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience,
    * or if it contains additional audiences not trusted by the Client.
    */
   clientId?: string;
   /**
-   * 'code', 'id_token token' or 'id_token' Name of the flow which can be configured.
-   * You must use the 'id_token token' flow, if you want to access an API or get user data from the server.
-   * The access_token is required for this, and only returned with this flow.
+   * `code`, `id_token token` or `id_token`.
+   * Name of the flow which can be configured.
+   * You must use the `id_token token` flow, if you want to access an API
+   * or get user data from the server. The `access_token` is required for this,
+   * and only returned with this flow.
    */
   responseType?: string;
   /**
-   * This is this scopes which are requested from the server from this client.
-   * This must match the secure token server configuration.
-   * The 'openid' scope is required. The 'offline_access' scope can be requested when using refresh tokens
-   * but this is optional and some secure token server do not support this or recommend not requesting this even when using
+   * List of scopes which are requested from the server from this client.
+   * This must match the Security Token Service configuration for the client you use.
+   * The `openid` scope is required. The `offline_access` scope can be requested when using refresh tokens
+   * but this is optional and some Security Token Service do not support this or recommend not requesting this even when using
    * refresh tokens in the browser.
    */
   scope?: string;
@@ -40,11 +48,11 @@ export interface OpenIdConfiguration {
    * see https://developers.google.com/identity/protocols/OpenIDConnect#hd-param
    */
   hdParam?: string;
-  /** URL after a server logout if using the end session API. */
+  /** URL to redirect to after a server logout if using the end session API. */
   postLogoutRedirectUri?: string;
   /**	Starts the OpenID session management for this client. */
   startCheckSession?: boolean;
-  /** Renews the client tokens, once the token_id expires. Can use the iframes, or the refresh tokens */
+  /** Renews the client tokens, once the id_token expires. Can use iframes or refresh tokens. */
   silentRenew?: boolean;
   /** An optional URL to handle silent renew callbacks */
   silentRenewUrl?: string;
@@ -55,7 +63,7 @@ export interface OpenIdConfiguration {
   silentRenewTimeoutInSeconds?: number;
   /**
    * Makes it possible to add an offset to the silent renew check in seconds.
-   * By entering a value, you can renew the tokens, before the tokens expire.
+   * By entering a value, you can renew the tokens before the tokens expire.
    */
   renewTimeBeforeTokenExpiresInSeconds?: number;
   /**
@@ -66,53 +74,52 @@ export interface OpenIdConfiguration {
   useRefreshToken?: boolean;
   /**
    * Activates Pushed Authorisation Requests for login and popup login.
-   * Not compatible with Iframe renew.
+   * Not compatible with iframe renew.
    */
   usePushedAuthorisationRequests?: boolean;
   /**
    * A token obtained by using a refresh token normally doesn't contain a nonce value.
-   * However, some OIDC endpoint implementations do send one. The library checks to see if the nonce is present.
-   * Note that if the nonce value is present, it will not be verified.
-   * This is not recommended, if the secure token server returns a nonce in the refresh.
-   * Default value is false
+   * The library checks it is not there. However, some OIDC endpoint implementations do send one.
+   * Setting `ignoreNonceAfterRefresh` to `true` disables the check if a nonce is present.
+   * Please note that the nonce value, if present, will not be verified. Default is `false`.
    */
   ignoreNonceAfterRefresh?: boolean;
   /**
    * The default Angular route which is used after a successful login, if not using the
-   * trigger_authorization_result_event
+   * `triggerAuthorizationResultEvent`
    */
   postLoginRoute?: string;
-  /** Route, if the server returns a 403. This is an Angular route. HTTP 403 */
+  /** Route to redirect to if the server returns a 403 error. This has to be an Angular route. HTTP 403. */
   forbiddenRoute?: string;
-  /** Route, if the server returns a 401. This is an Angular route. HTTP 401 */
+  /** Route to redirect to if the server returns a 401 error. This has to be an Angular route. HTTP 401. */
   unauthorizedRoute?: string;
-  /** When set to true, library automatically gets user info after authentication */
+  /** When set to true, the library automatically gets user info after authentication */
   autoUserInfo?: boolean;
-  /** When set to true, library automatically gets user info after token renew */
+  /** When set to true, the library automatically gets user info after token renew */
   renewUserInfoAfterTokenRenew?: boolean;
   /** Used for custom state logic handling. The state is not automatically reset when set to false */
   autoCleanStateAfterAuthentication?: boolean;
   /**
-   * This can be set to true which emits an event instead of an angular route change.
+   * This can be set to true which emits an event instead of an Angular route change.
    * Instead of forcing the application consuming this library to automatically redirect to one of the 3
    * hard-configured routes (start, unauthorized, forbidden), this modification will add an extra
    * configuration option to override such behavior and trigger an event that will allow to subscribe to
    * it and let the application perform other actions. This would be useful to allow the application to
-   * save an initial return url so that the user is redirected to it after a successful login on the secure token server
-   * (ie: saving the return url previously on sessionStorage and then retrieving it during the triggering of the event).
+   * save an initial return URL so that the user is redirected to it after a successful login on the Security Token Service
+   * (i.e. saving the return URL previously on sessionStorage and then retrieving it during the triggering of the event).
    */
   triggerAuthorizationResultEvent?: boolean;
   /** 0, 1, 2 can be used to set the log level displayed in the console. */
   logLevel?: LogLevel;
-  /** 	Make it possible to turn the iss validation off per configuration. You should not turn this off! */
+  /** Make it possible to turn off the iss validation per configuration. **You should not turn this off!** */
   issValidationOff?: boolean;
   /**
    * If this is active, the history is not cleaned up on an authorize callback.
-   * This can be used, when the application needs to preserve the history.
+   * This can be used when the application needs to preserve the history.
    */
   historyCleanupOff?: boolean;
   /**
-   * Amount of offset allowed between the server creating the token, and the client app receiving the id_token.
+   * Amount of offset allowed between the server creating the token and the client app receiving the id_token.
    * The diff in time between the server time and client time is also important in validating this value.
    * All times are in UTC.
    */
@@ -138,27 +145,31 @@ export interface OpenIdConfiguration {
   /** Extra parameters to add to the token URL request */
   customParamsCodeRequest?: { [key: string]: string | number | boolean };
 
-  /** Denotes if the AuthWellKnownEndpoints should be loaded at startup or when the user calls the authorize method. */
+  /** Tells if the `AuthWellKnownEndpoints` should be loaded at startup or when the user calls the authorize method. */
   eagerLoadAuthWellKnownEndpoints?: boolean;
 
   // Azure B2C have implemented this incorrectly. Add support for to disable this until fixed.
-  /** disables the auth_time validation for id_tokens in a refresh due to Azure's incorrect implementation */
+  /** Disables the auth_time validation for id_tokens in a refresh due to Azure's incorrect implementation. */
   disableRefreshIdTokenAuthTimeValidation?: boolean;
 
-  /** enables the id_token validation, default value is true. You can disable this validation if you would like to ignore the expired value in the renew process. If no id_token is returned in using refresh tokens, set this to false. */
+  /**
+   * Enables the id_token validation, default value is `true`.
+   * You can disable this validation if you like to ignore the expired value in the renew process.
+   * If no id_token is returned in using refresh tokens, set this to `false`.
+   */
   enableIdTokenExpiredValidationInRenew?: boolean;
 
   /** Controls the periodic check time interval in sections.
-   * Default value is 3
+   * Default value is 3.
    */
   tokenRefreshInSeconds?: number;
   /**
-   * Array of secure urls on which the token should be send if the interceptor is added to the HTTP_INTERCEPTORS
+   * Array of secure URLs on which the token should be sent if the interceptor is added to the `HTTP_INTERCEPTORS`.
    */
   secureRoutes?: string[];
   /**
-   * Controls the periodic retry time interval for retrieving new tokens in seconds..
-   * silentRenewTimeoutInSeconds and tokenRefreshInSeconds are upper bounds for this value.
+   * Controls the periodic retry time interval for retrieving new tokens in seconds.
+   * `silentRenewTimeoutInSeconds` and `tokenRefreshInSeconds` are upper bounds for this value.
    * Default value is 3
    */
   refreshTokenRetryInSeconds?: number;

--- a/projects/angular-auth-oidc-client/src/lib/config/validation/config-validation.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/validation/config-validation.service.spec.ts
@@ -66,7 +66,7 @@ describe('Config Validation Service', () => {
   });
 
   describe('ensure-authority-server.rule', () => {
-    it('return false when no secure token server is set', () => {
+    it('return false when no security token service is set', () => {
       const config = { ...VALID_CONFIG, authority: null };
       const result = configValidationService.validateConfig(config);
       expect(result).toBeFalse();

--- a/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.spec.ts
@@ -206,7 +206,7 @@ describe('ParLoginService', () => {
     );
 
     it(
-      'calls urlHandler when url is passed',
+      'calls urlHandler when URL is passed',
       waitForAsync(() => {
         spyOn(responseTypeValidationService, 'hasConfigValidResponseType').and.returnValue(true);
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
@@ -280,7 +280,7 @@ describe('ParLoginService', () => {
         service.loginWithPopUpPar('configId').subscribe({
           error: (err) => {
             expect(spy).toHaveBeenCalled();
-            expect(err).toBe("Could not create url with param requestUri: 'url'");
+            expect(err).toBe("Could not create URL with param requestUri: 'url'");
           },
         });
       })
@@ -302,14 +302,14 @@ describe('ParLoginService', () => {
         service.loginWithPopUpPar('configId', { customParams: { some: 'thing' } }).subscribe({
           error: (err) => {
             expect(spy).toHaveBeenCalledOnceWith('configId', { some: 'thing' });
-            expect(err).toBe("Could not create url with param requestUri: 'url'");
+            expect(err).toBe("Could not create URL with param requestUri: 'url'");
           },
         });
       })
     );
 
     it(
-      'returns undefined and logs error when no url could be created',
+      'returns undefined and logs error when no URL could be created',
       waitForAsync(() => {
         spyOn(responseTypeValidationService, 'hasConfigValidResponseType').and.returnValue(true);
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
@@ -325,7 +325,7 @@ describe('ParLoginService', () => {
 
         service.loginWithPopUpPar('configId', { customParams: { some: 'thing' } }).subscribe({
           error: (err) => {
-            expect(err).toBe("Could not create url with param requestUri: 'url'");
+            expect(err).toBe("Could not create URL with param requestUri: 'url'");
             expect(spy).toHaveBeenCalledTimes(1);
           },
         });
@@ -333,7 +333,7 @@ describe('ParLoginService', () => {
     );
 
     it(
-      'calls popupService openPopUp when url could be created',
+      'calls popupService openPopUp when URL could be created',
       waitForAsync(() => {
         spyOn(responseTypeValidationService, 'hasConfigValidResponseType').and.returnValue(true);
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
@@ -355,7 +355,7 @@ describe('ParLoginService', () => {
     );
 
     it(
-      'returns correct properties if url is received',
+      'returns correct properties if URL is received',
       waitForAsync(() => {
         spyOn(responseTypeValidationService, 'hasConfigValidResponseType').and.returnValue(true);
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({

--- a/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/par/par-login.service.ts
@@ -60,7 +60,7 @@ export class ParLoginService {
         this.loggerService.logDebug(configId, 'par request url: ', url);
 
         if (!url) {
-          this.loggerService.logError(configId, `Could not create url with param ${response.requestUri}: '${url}'`);
+          this.loggerService.logError(configId, `Could not create URL with param ${response.requestUri}: '${url}'`);
 
           return;
         }
@@ -104,7 +104,7 @@ export class ParLoginService {
         this.loggerService.logDebug(configId, 'par request url: ', url);
 
         if (!url) {
-          const errorMessage = `Could not create url with param ${response.requestUri}: 'url'`;
+          const errorMessage = `Could not create URL with param ${response.requestUri}: 'url'`;
           this.loggerService.logError(configId, errorMessage);
 
           return throwError(errorMessage);

--- a/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.spec.ts
@@ -99,7 +99,7 @@ describe('StandardLoginService', () => {
     );
 
     it(
-      'redirects to url with no url handler',
+      'redirects to URL with no URL handler',
       waitForAsync(() => {
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
           authWellknownEndpointUrl: 'authWellknownEndpoint',
@@ -118,7 +118,7 @@ describe('StandardLoginService', () => {
     );
 
     it(
-      'redirects to url with url handler when urlHandler is given',
+      'redirects to URL with URL handler when urlHandler is given',
       waitForAsync(() => {
         spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
           authWellknownEndpointUrl: 'authWellknownEndpoint',

--- a/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.ts
@@ -41,7 +41,7 @@ export class StandardLoginService {
       const url = this.urlService.getAuthorizeUrl(configId, customParams);
 
       if (!url) {
-        this.loggerService.logError(configId, 'Could not create url', url);
+        this.loggerService.logError(configId, 'Could not create URL', url);
 
         return;
       }

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
@@ -53,7 +53,7 @@ export class OidcSecurityService {
   }
 
   /**
-   * Emits on a secure token server callback. The observable will never contain a value.
+   * Emits on a Security Token Service callback. The observable will never contain a value.
    */
   get stsCallback$(): Observable<any> {
     return this.callbackService.stsCallback$;
@@ -110,7 +110,7 @@ export class OidcSecurityService {
    * will denote whether the user was successfully authenticated including the user data, the access token, the configId and
    * an error message in case an error happened
    *
-   * @param url The url to perform the authorization on the behalf of.
+   * @param url The URL to perform the authorization on the behalf of.
    * @param configId The configId to perform the authorization on the behalf of. If not passed, the first configs will be taken
    *
    * @returns An object `LoginResponse` containing all information about the login
@@ -125,7 +125,7 @@ export class OidcSecurityService {
    * will denote whether the user was successfully authenticated including the user data, the access token, the configId and
    * an error message in case an error happened in an array for each config which was provided
    *
-   * @param url The url to perform the authorization on the behalf of.
+   * @param url The URL to perform the authorization on the behalf of.
    * @param configId The configId to perform the authorization on the behalf of. If not passed, all of the current
    * configured ones will be used to check.
    *
@@ -250,7 +250,7 @@ export class OidcSecurityService {
   }
 
   /**
-   * Redirects the user to the secure token server to begin the authentication process.
+   * Redirects the user to the Security Token Service to begin the authentication process.
    *
    * @param configId The configId to perform the action in behalf of. If not passed, the first configs will be taken
    * @param authOptions The custom options for the the authentication request.
@@ -262,7 +262,7 @@ export class OidcSecurityService {
   }
 
   /**
-   * Opens the secure token server in a new window to begin the authentication process.
+   * Opens the Security Token Service in a new window to begin the authentication process.
    *
    * @param authOptions The custom options for the authentication request.
    * @param popupOptions The configuration for the popup window.
@@ -340,7 +340,7 @@ export class OidcSecurityService {
   }
 
   /**
-   * Revokes an access token on the secure token server. This is only required in the code flow with refresh tokens. If no token is
+   * Revokes an access token on the Security Token Service. This is only required in the code flow with refresh tokens. If no token is
    * provided, then the token from the storage is revoked. You can pass any token to revoke.
    * https://tools.ietf.org/html/rfc7009
    *
@@ -356,7 +356,7 @@ export class OidcSecurityService {
   }
 
   /**
-   * Revokes a refresh token on the secure token server. This is only required in the code flow with refresh tokens. If no token is
+   * Revokes a refresh token on the Security Token Service. This is only required in the code flow with refresh tokens. If no token is
    * provided, then the token from the storage is revoked. You can pass any token to revoke.
    * https://tools.ietf.org/html/rfc7009
    *
@@ -386,12 +386,12 @@ export class OidcSecurityService {
   }
 
   /**
-   * Creates the authorize url basd on your flow
+   * Creates the authorize URL based on your flow
    *
    * @param customParams
    * @param configId The configId to perform the action in behalf of. If not passed, the first configs will be taken
    *
-   * @returns A string with the authorize url or null
+   * @returns A string with the authorize URL or null
    */
   getAuthorizeUrl(customParams?: { [p: string]: string | number | boolean }, configId?: string): string | null {
     configId = configId ?? this.configurationProvider.getOpenIDConfiguration(configId).configId;

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/current-url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/current-url.service.spec.ts
@@ -28,7 +28,7 @@ describe('CurrentUrlService', () => {
   });
 
   describe('getCurrentUrl', () => {
-    it('returns the current url', () => {
+    it('returns the current URL', () => {
       const currentUrl = service.getCurrentUrl();
 
       expect(currentUrl).toBe('http://my-url.com?state=my-state');
@@ -36,7 +36,7 @@ describe('CurrentUrlService', () => {
   });
 
   describe('currentUrlHasStateParam', () => {
-    it('returns true for the given url', () => {
+    it('returns true for the given URL', () => {
       const hasStateParam = service.currentUrlHasStateParam();
 
       expect(hasStateParam).toBe(true);
@@ -44,7 +44,7 @@ describe('CurrentUrlService', () => {
   });
 
   describe('currentUrlHasStateParam', () => {
-    it('returns the state param for the given url', () => {
+    it('returns the state param for the given URL', () => {
       const stateParam = service.getStateParamFromCurrentUrl();
 
       expect(stateParam).toBe('my-state');

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -439,7 +439,7 @@ describe('UrlService Tests', () => {
       expect(value).toEqual(expectValue);
     });
 
-    it('createAuthorizeUrl creates url with with custom values and dynamic custom values', () => {
+    it('createAuthorizeUrl creates URL with with custom values and dynamic custom values', () => {
       const config = {
         authority: 'https://localhost:5001',
         redirectUrl: 'https://localhost:44386',
@@ -483,7 +483,7 @@ describe('UrlService Tests', () => {
       expect(value).toEqual(expectValue);
     });
 
-    it('createAuthorizeUrl creates url with custom values equals null and dynamic custom values', () => {
+    it('createAuthorizeUrl creates URL with custom values equals null and dynamic custom values', () => {
       const config = {
         authority: 'https://localhost:5001',
         redirectUrl: 'https://localhost:44386',
@@ -521,7 +521,7 @@ describe('UrlService Tests', () => {
       expect(value).toEqual(expectValue);
     });
 
-    it('createAuthorizeUrl creates url with custom values not given and dynamic custom values', () => {
+    it('createAuthorizeUrl creates URL with custom values not given and dynamic custom values', () => {
       const config = {
         authority: 'https://localhost:5001',
         redirectUrl: 'https://localhost:44386',
@@ -559,7 +559,7 @@ describe('UrlService Tests', () => {
     });
 
     // https://docs.microsoft.com/en-us/azure/active-directory-b2c/active-directory-b2c-reference-oidc
-    it('createAuthorizeUrl with custom url like active-directory-b2c', () => {
+    it('createAuthorizeUrl with custom URL like active-directory-b2c', () => {
       const config = { authority: 'https://localhost:5001' } as OpenIdConfiguration;
       config.redirectUrl = 'https://localhost:44386';
       config.clientId = 'myid';
@@ -921,7 +921,7 @@ describe('UrlService Tests', () => {
   });
 
   describe('createBodyForCodeFlowRefreshTokensRequest', () => {
-    it('returns correct url', () => {
+    it('returns correct URL', () => {
       const clientId = 'clientId';
       const refreshToken = 'refreshToken';
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ clientId });
@@ -929,7 +929,7 @@ describe('UrlService Tests', () => {
       expect(result).toBe(`grant_type=refresh_token&client_id=${clientId}&refresh_token=${refreshToken}`);
     });
 
-    it('returns correct url with custom params if custom params are passed', () => {
+    it('returns correct URL with custom params if custom params are passed', () => {
       const clientId = 'clientId';
       const refreshToken = 'refreshToken';
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({ clientId });
@@ -953,7 +953,7 @@ describe('UrlService Tests', () => {
       expect(result).toBe(null);
     });
 
-    it('returns basic url with no extras if properties are given', () => {
+    it('returns basic URL with no extras if properties are given', () => {
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         clientId: 'testClientId',
         responseType: 'testResponseType',
@@ -973,7 +973,7 @@ describe('UrlService Tests', () => {
       );
     });
 
-    it('returns basic url with hdParam if properties are given', () => {
+    it('returns basic URL with hdParam if properties are given', () => {
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         clientId: 'testClientId',
         responseType: 'testResponseType',
@@ -993,7 +993,7 @@ describe('UrlService Tests', () => {
       );
     });
 
-    it('returns basic url with hdParam and custom params if properties are given', () => {
+    it('returns basic URL with hdParam and custom params if properties are given', () => {
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         clientId: 'testClientId',
         responseType: 'testResponseType',
@@ -1013,7 +1013,7 @@ describe('UrlService Tests', () => {
       );
     });
 
-    it('returns basic url with hdParam and custom params and passed cutom params if properties are given', () => {
+    it('returns basic URL with hdParam and custom params and passed cutom params if properties are given', () => {
       spyOn(configurationProvider, 'getOpenIDConfiguration').and.returnValue({
         clientId: 'testClientId',
         responseType: 'testResponseType',
@@ -1053,7 +1053,7 @@ describe('UrlService Tests', () => {
       expect(result).toBeNull();
     });
 
-    it('returns correct url if wellknownendpoints are given', () => {
+    it('returns correct URL if wellknownendpoints are given', () => {
       const state = 'testState';
       const nonce = 'testNonce';
       const silentRenewUrl = 'http://any-url.com';
@@ -1133,7 +1133,7 @@ describe('UrlService Tests', () => {
       expect(result).toBeNull();
     });
 
-    it('returns correct url if wellknownendpoints are given', () => {
+    it('returns correct URL if wellknownendpoints are given', () => {
       const state = 'testState';
       const nonce = 'testNonce';
       const silentRenewUrl = 'http://any-url.com';
@@ -1192,7 +1192,7 @@ describe('UrlService Tests', () => {
   });
 
   describe('createUrlImplicitFlowAuthorize', () => {
-    it('returns correct url if wellknownendpoints are given', () => {
+    it('returns correct URL if wellknownendpoints are given', () => {
       const state = 'testState';
       const nonce = 'testNonce';
       const redirectUrl = 'http://any-url.com';
@@ -1278,7 +1278,7 @@ describe('UrlService Tests', () => {
       expect(result).toBeNull();
     });
 
-    it('returns correct url if wellknownendpoints are given', () => {
+    it('returns correct URL if wellknownendpoints are given', () => {
       const state = 'testState';
       const nonce = 'testNonce';
       const scope = 'testScope';
@@ -1310,7 +1310,7 @@ describe('UrlService Tests', () => {
       );
     });
 
-    it('returns correct url if wellknownendpoints and custom params are given', () => {
+    it('returns correct URL if wellknownendpoints and custom params are given', () => {
       const state = 'testState';
       const nonce = 'testNonce';
       const scope = 'testScope';
@@ -1370,7 +1370,7 @@ describe('UrlService Tests', () => {
   });
 
   describe('createEndSessionUrl', () => {
-    it('create url when all parameters given', () => {
+    it('create URL when all parameters given', () => {
       const config = {
         authority: 'https://localhost:5001',
         redirectUrl: 'https://localhost:44386',
@@ -1392,7 +1392,7 @@ describe('UrlService Tests', () => {
       expect(value).toEqual(expectValue);
     });
 
-    it('create url when all parameters and customParamsEndSession given', () => {
+    it('create URL when all parameters and customParamsEndSession given', () => {
       const config = {
         authority: 'https://localhost:5001',
         redirectUrl: 'https://localhost:44386',
@@ -1438,7 +1438,7 @@ describe('UrlService Tests', () => {
       expect(value).toEqual(expectValue);
     });
 
-    it('create url without postLogoutRedirectUri when not given', () => {
+    it('create URL without postLogoutRedirectUri when not given', () => {
       const config = {
         authority: 'https://localhost:5001',
         redirectUrl: 'https://localhost:44386',
@@ -1483,7 +1483,7 @@ describe('UrlService Tests', () => {
       expect(value).toEqual(expectValue);
     });
 
-    it('returns auth0 format url if authority ends with .auth0', () => {
+    it('returns auth0 format URL if authority ends with .auth0', () => {
       configurationProvider.setConfig({
         authority: 'something.auth0.com',
         clientId: 'someClientId',
@@ -1528,7 +1528,7 @@ describe('UrlService Tests', () => {
       expect(result).toBe(null);
     });
 
-    it('returns correct url when everything is given', () => {
+    it('returns correct URL when everything is given', () => {
       spyOn(storagePersistenceService, 'read').withArgs('authWellKnownEndPoints', 'configId').and.returnValue({
         authorizationEndpoint: 'anything',
       });

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -62,7 +62,7 @@ export class UrlService {
     const authorizationEndpoint = authWellKnownEndPoints.authorizationEndpoint;
 
     if (!authorizationEndpoint) {
-      this.loggerService.logError(configId, `Can not create an authorize url when authorizationEndpoint is '${authorizationEndpoint}'`);
+      this.loggerService.logError(configId, `Can not create an authorize URL when authorizationEndpoint is '${authorizationEndpoint}'`);
 
       return null;
     }
@@ -295,7 +295,7 @@ export class UrlService {
     const authorizationEndpoint = authWellKnownEndPoints?.authorizationEndpoint;
 
     if (!authorizationEndpoint) {
-      this.loggerService.logError(configId, `Can not create an authorize url when authorizationEndpoint is '${authorizationEndpoint}'`);
+      this.loggerService.logError(configId, `Can not create an authorize URL when authorizationEndpoint is '${authorizationEndpoint}'`);
 
       return null;
     }

--- a/projects/sample-code-flow-auto-login-all-routes/src/app/customers/customers.component.ts
+++ b/projects/sample-code-flow-auto-login-all-routes/src/app/customers/customers.component.ts
@@ -8,5 +8,5 @@ import { Component, OnInit } from '@angular/core';
 export class CustomersComponent implements OnInit {
   constructor() {}
 
-  ngOnInit(): void {}
+  ngOnInit() {}
 }

--- a/projects/sample-code-flow-par/node-oidc-provider-docs/lib/helpers/defaults.js
+++ b/projects/sample-code-flow-par/node-oidc-provider-docs/lib/helpers/defaults.js
@@ -2293,7 +2293,7 @@ function getDefaults() {
     /*
      * interactions
      *
-     * description: Holds the configuration for interaction policy and url to send end-users to
+     * description: Holds the configuration for interaction policy and URL to send end-users to
      *   when the policy decides to require interaction.
      *
      * @nodefault


### PR DESCRIPTION
- consistent capitalized `URL`
- consistent `Security Token Service` (not `secure token server`)
- tried to make exmplanations clearer

Might interfere with #1145 – didn't see this before...
- You could merge the other one first and I can take care of aligning my PR accordingly.
- I could also include the other PR in mine