### PR TITLE
docs: update the example function name

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
@@ -127,7 +127,7 @@ logout() {
 `logoff()` also accepts a `configId` paramater to select a specific config:
 
 ```ts
-login() {
+logout() {
   this.oidcSecurityService.logoff('configId')
     .subscribe(({ isAuthenticated, userData, idToken, accessToken, errorMessage }) => {
       /* ... */


### PR DESCRIPTION
The example is showing the _logout_ process but the function mane is "_login_"