### PR TITLE
refresh token rotation should be optional (fixes #1338)

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -465,3 +465,13 @@ Default = _3_. <br/>
 - Required: `false`
 
 Adds the `ngsw-bypass` param to all requests ([Angular Documentation](https://angular.io/guide/service-worker-devops#bypassing-the-service-worker)).
+
+### `allowUnsafeReuseRefreshToken`
+
+- Type: `boolean`
+- Required: `false`
+
+Allows the refresh token reuse. Refresh tokens are typically longer-lived and RFC6749 allows their reuse nevertheless this is strongly discourage.
+Activate this property only if your OIDC provider cannot be configured to rotate refresh tokens.
+
+Default = _false_

--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -172,4 +172,8 @@ export interface OpenIdConfiguration {
   refreshTokenRetryInSeconds?: number;
   /** Adds the ngsw-bypass param to all requests */
   ngswBypass?: boolean;
+  /** Allow refresh token reuse (refresh without rotation), default value is false.
+   * The refresh token rotation is optional (rfc6749) but is more safe and hence encouraged.
+   */
+  allowUnsafeReuseRefreshToken?: boolean;
 }

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-context.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-context.ts
@@ -18,6 +18,8 @@ export interface AuthResult {
   id_token?: string;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   access_token?: string;
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  refresh_token?: string;
   error?: any;
   // eslint-disable-next-line @typescript-eslint/naming-convention
   session_state?: any;

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.spec.ts
@@ -87,6 +87,35 @@ describe('HistoryJwtKeysCallbackHandlerService', () => {
     );
 
     it(
+      'writes refresh_token into the storage',
+      waitForAsync(() => {
+        const DUMMY_AUTH_RESULT = {
+          refresh_token: 'dummy_refresh_token',
+        };
+
+        const storagePersistenceServiceSpy = spyOn(storagePersistenceService, 'write');
+        const callbackContext = { authResult: DUMMY_AUTH_RESULT } as unknown as CallbackContext;
+        const allconfigs = [
+          {
+            configId: 'configId1',
+            historyCleanupOff: true,
+          },
+        ];
+
+        spyOn(signInKeyDataService, 'getSigningKeys').and.returnValue(of({ keys: [] } as JwtKeys));
+        service.callbackHistoryAndResetJwtKeys(callbackContext, allconfigs[0], allconfigs).subscribe(() => {
+          expect(storagePersistenceServiceSpy.calls.allArgs()).toEqual([
+            ['authnResult', DUMMY_AUTH_RESULT, allconfigs[0]],
+            ['refresh_token', 'dummy_refresh_token', allconfigs[0]],
+            ['jwtKeys', { keys: [] }, allconfigs[0]],
+          ]);
+          // write authnResult & refresh_token & jwtKeys
+          expect(storagePersistenceServiceSpy).toHaveBeenCalledTimes(3);
+        });
+      })
+    );
+
+    it(
       'resetBrowserHistory if historyCleanup is turned on and is not in a renewProcess',
       waitForAsync(() => {
         const callbackContext = { isRenewProcess: false, authResult: 'authResult' } as unknown as CallbackContext;

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
@@ -35,6 +35,10 @@ export class HistoryJwtKeysCallbackHandlerService {
   ): Observable<CallbackContext> {
     this.storagePersistenceService.write('authnResult', callbackContext.authResult, config);
 
+    if (callbackContext.authResult.refresh_token) {
+      this.storagePersistenceService.write('refresh_token', callbackContext.authResult.refresh_token, config);
+    }
+
     if (this.historyCleanUpTurnedOn(config) && !callbackContext.isRenewProcess) {
       this.resetBrowserHistory();
     } else {

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
@@ -35,8 +35,8 @@ export class HistoryJwtKeysCallbackHandlerService {
   ): Observable<CallbackContext> {
     this.storagePersistenceService.write('authnResult', callbackContext.authResult, config);
 
-    if (callbackContext.authResult.refresh_token) {
-      this.storagePersistenceService.write('refresh_token', callbackContext.authResult.refresh_token, config);
+    if (config.allowUnsafeReuseRefreshToken && callbackContext.authResult.refresh_token) {
+      this.storagePersistenceService.write('reusable_refresh_token', callbackContext.authResult.refresh_token, config);
     }
 
     if (this.historyCleanUpTurnedOn(config) && !callbackContext.isRenewProcess) {

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.spec.ts
@@ -101,7 +101,7 @@ describe('Storage Persistence Service', () => {
       expect(spy.calls.argsFor(5)).toEqual(['access_token_expires_at', config]);
       expect(spy.calls.argsFor(6)).toEqual(['storageCustomParamsRefresh', config]);
       expect(spy.calls.argsFor(7)).toEqual(['storageCustomParamsEndSession', config]);
-      expect(spy.calls.argsFor(8)).toEqual(['refresh_token', config]);
+      expect(spy.calls.argsFor(8)).toEqual(['reusable_refresh_token', config]);
     });
   });
 
@@ -113,7 +113,7 @@ describe('Storage Persistence Service', () => {
       service.resetAuthStateInStorage(config);
 
       expect(spy.calls.argsFor(0)).toEqual(['authzData', config]);
-      expect(spy.calls.argsFor(1)).toEqual(['refresh_token', config]);
+      expect(spy.calls.argsFor(1)).toEqual(['reusable_refresh_token', config]);
       expect(spy.calls.argsFor(2)).toEqual(['authnResult', config]);
     });
   });
@@ -182,14 +182,28 @@ describe('Storage Persistence Service', () => {
   });
 
   describe('getRefreshToken', () => {
-    it('get calls oidcSecurityStorage.read with correct key and returns the value', () => {
-      const returnValue = { refresh_token: 'someValue' };
+    it('get calls oidcSecurityStorage.read with correct key and returns the value (refresh token with mandatory rotation - default)', () => {
+      const returnValue = { authnResult: { refresh_token: 'someValue' } };
       const spy = spyOn(securityStorage, 'read').and.returnValue(returnValue);
       const config = { configId: 'configId1' };
       const result = service.getRefreshToken(config);
 
       expect(result).toBe('someValue');
-      expect(spy).toHaveBeenCalledOnceWith('refresh_token', config);
+      expect(spy).toHaveBeenCalledOnceWith('authnResult', config);
+    });
+
+    it('get calls oidcSecurityStorage.read with correct key and returns the value (refresh token without rotation)', () => {
+      const returnValue = { reusable_refresh_token: 'test_refresh_token' };
+      const config = { configId: 'configId1', allowUnsafeReuseRefreshToken: true };
+      let spy = spyOn(securityStorage, 'read');
+      spy.withArgs('reusable_refresh_token', config).and.returnValue(returnValue);
+      spy.withArgs('authnResult', config).and.returnValue(undefined);
+      const result = service.getRefreshToken(config);
+
+      expect(result).toBe(returnValue.reusable_refresh_token);
+      expect(spy).toHaveBeenCalledTimes(2);
+      expect(spy).toHaveBeenCalledWith('authnResult', config);
+      expect(spy).toHaveBeenCalledWith('reusable_refresh_token', config);
     });
 
     it('get calls oidcSecurityStorage.read with correct key and returns null', () => {
@@ -199,7 +213,7 @@ describe('Storage Persistence Service', () => {
       const result = service.getRefreshToken(config);
 
       expect(result).toBeUndefined();
-      expect(spy).toHaveBeenCalledOnceWith('refresh_token', config);
+      expect(spy).toHaveBeenCalledOnceWith('authnResult', config);
     });
 
     it('get calls oidcSecurityStorage.read with correct key and returns null', () => {
@@ -208,7 +222,7 @@ describe('Storage Persistence Service', () => {
       const result = service.getRefreshToken(config);
 
       expect(result).toBeUndefined();
-      expect(spy).toHaveBeenCalledOnceWith('refresh_token', config);
+      expect(spy).toHaveBeenCalledOnceWith('authnResult', config);
     });
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.spec.ts
@@ -92,7 +92,7 @@ describe('Storage Persistence Service', () => {
 
       service.resetStorageFlowData(config);
 
-      expect(spy).toHaveBeenCalledTimes(8);
+      expect(spy).toHaveBeenCalledTimes(9);
       expect(spy.calls.argsFor(0)).toEqual(['session_state', config]);
       expect(spy.calls.argsFor(1)).toEqual(['storageSilentRenewRunning', config]);
       expect(spy.calls.argsFor(2)).toEqual(['codeVerifier', config]);
@@ -101,6 +101,7 @@ describe('Storage Persistence Service', () => {
       expect(spy.calls.argsFor(5)).toEqual(['access_token_expires_at', config]);
       expect(spy.calls.argsFor(6)).toEqual(['storageCustomParamsRefresh', config]);
       expect(spy.calls.argsFor(7)).toEqual(['storageCustomParamsEndSession', config]);
+      expect(spy.calls.argsFor(8)).toEqual(['refresh_token', config]);
     });
   });
 
@@ -112,7 +113,8 @@ describe('Storage Persistence Service', () => {
       service.resetAuthStateInStorage(config);
 
       expect(spy.calls.argsFor(0)).toEqual(['authzData', config]);
-      expect(spy.calls.argsFor(1)).toEqual(['authnResult', config]);
+      expect(spy.calls.argsFor(1)).toEqual(['refresh_token', config]);
+      expect(spy.calls.argsFor(2)).toEqual(['authnResult', config]);
     });
   });
 
@@ -181,13 +183,13 @@ describe('Storage Persistence Service', () => {
 
   describe('getRefreshToken', () => {
     it('get calls oidcSecurityStorage.read with correct key and returns the value', () => {
-      const returnValue = { authnResult: { refresh_token: 'someValue' } };
+      const returnValue = { refresh_token: 'someValue' };
       const spy = spyOn(securityStorage, 'read').and.returnValue(returnValue);
       const config = { configId: 'configId1' };
       const result = service.getRefreshToken(config);
 
       expect(result).toBe('someValue');
-      expect(spy).toHaveBeenCalledOnceWith('authnResult', config);
+      expect(spy).toHaveBeenCalledOnceWith('refresh_token', config);
     });
 
     it('get calls oidcSecurityStorage.read with correct key and returns null', () => {
@@ -197,7 +199,7 @@ describe('Storage Persistence Service', () => {
       const result = service.getRefreshToken(config);
 
       expect(result).toBeUndefined();
-      expect(spy).toHaveBeenCalledOnceWith('authnResult', config);
+      expect(spy).toHaveBeenCalledOnceWith('refresh_token', config);
     });
 
     it('get calls oidcSecurityStorage.read with correct key and returns null', () => {
@@ -206,7 +208,7 @@ describe('Storage Persistence Service', () => {
       const result = service.getRefreshToken(config);
 
       expect(result).toBeUndefined();
-      expect(spy).toHaveBeenCalledOnceWith('authnResult', config);
+      expect(spy).toHaveBeenCalledOnceWith('refresh_token', config);
     });
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
@@ -11,6 +11,7 @@ export type StorageKeys =
   | 'authNonce'
   | 'codeVerifier'
   | 'authStateControl'
+  | 'refresh_token'
   | 'session_state'
   | 'storageSilentRenewRunning'
   | 'storageCustomParamsAuthRequest'
@@ -59,10 +60,12 @@ export class StoragePersistenceService {
     this.remove('access_token_expires_at', config);
     this.remove('storageCustomParamsRefresh', config);
     this.remove('storageCustomParamsEndSession', config);
+    this.remove('refresh_token', config);
   }
 
   resetAuthStateInStorage(config: OpenIdConfiguration): void {
     this.remove('authzData', config);
+    this.remove('refresh_token', config);
     this.remove('authnResult', config);
   }
 
@@ -75,7 +78,7 @@ export class StoragePersistenceService {
   }
 
   getRefreshToken(config: OpenIdConfiguration): string {
-    return this.read('authnResult', config)?.refresh_token;
+    return this.read('refresh_token', config);
   }
 
   getAuthenticationResult(config: OpenIdConfiguration): any {

--- a/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/storage-persistence.service.ts
@@ -11,7 +11,7 @@ export type StorageKeys =
   | 'authNonce'
   | 'codeVerifier'
   | 'authStateControl'
-  | 'refresh_token'
+  | 'reusable_refresh_token'
   | 'session_state'
   | 'storageSilentRenewRunning'
   | 'storageCustomParamsAuthRequest'
@@ -60,12 +60,12 @@ export class StoragePersistenceService {
     this.remove('access_token_expires_at', config);
     this.remove('storageCustomParamsRefresh', config);
     this.remove('storageCustomParamsEndSession', config);
-    this.remove('refresh_token', config);
+    this.remove('reusable_refresh_token', config);
   }
 
   resetAuthStateInStorage(config: OpenIdConfiguration): void {
     this.remove('authzData', config);
-    this.remove('refresh_token', config);
+    this.remove('reusable_refresh_token', config);
     this.remove('authnResult', config);
   }
 
@@ -78,7 +78,12 @@ export class StoragePersistenceService {
   }
 
   getRefreshToken(config: OpenIdConfiguration): string {
-    return this.read('refresh_token', config);
+    let refreshToken = this.read('authnResult', config)?.refresh_token;
+    if (!refreshToken && config.allowUnsafeReuseRefreshToken) {
+      return this.read('reusable_refresh_token', config);
+    }
+
+    return refreshToken;
   }
 
   getAuthenticationResult(config: OpenIdConfiguration): any {


### PR DESCRIPTION
Proposed solution to #1338. The idea is to separate the refresh token from authResult in the storage. 
I have tested the solution and it resolves my problem.

Of course more refactoring and more tests could be needed.