### PR TITLE
docs: loader API moved to Observable

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -106,8 +106,7 @@ export const httpLoaderFactory = (httpClient: HttpClient) => {
           /* Your config mapping here */
         };
       })
-    )
-    .toPromise();
+    );
 
   return new StsConfigHttpLoader(config$);
 };
@@ -144,8 +143,7 @@ export const httpLoaderFactory = (httpClient: HttpClient) => {
           /* Your config mapping here */
         };
       })
-    )
-    .toPromise();
+    );
 
   const config2$ = httpClient
     .get<any>(`https://...`)
@@ -156,8 +154,7 @@ export const httpLoaderFactory = (httpClient: HttpClient) => {
           /* Your config mapping here */
         };
       })
-    )
-    .toPromise();
+    );
 
   return new StsConfigHttpLoader([config1$, config2$]);
 };


### PR DESCRIPTION
#Description

It removes the `toPromise()` part of Http config loader examples as the API moved from Promise to Observable.


related issue: #1345