### PR TITLE
⌛isLoading observable in OidcSecurityService

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/public-api.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/public-api.md
@@ -148,6 +148,20 @@ this.isAuthenticated$ = this.oidcSecurityService.isAuthenticated$;
 }
 ```
 
+## isLoading$
+
+The `isLoading$` property returns an `Observable<boolean>`. Emits false when the observable, returned by either of the `checkAuth()` methods, emits a value, or errors. Initial value: true.
+
+### Example
+
+```ts
+this.isLoading$ = this.oidcSecurityService.isLoading$;
+```
+
+#### Example use case
+
+An auth guard subscribes to `isAuthenticated$` before the observable, returned by `checkAuth()`, emits a value. The `isAuthenticated$` emits false, and prompts an `authorize`, causing an infinite redirect loop. Use the `isLoading$` in combination with the `isAuthenticated$` to ensure that there is no race condition.
+
 ## checkSessionChanged$
 
 The `checkSessionChanged$` observable emits values every time the server comes back with a check session and the value `changed`. If you want to get information about when the `CheckSession` Event has been received, please take a look at the [public events](public-events.md).

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -633,127 +633,142 @@ describe('OidcSecurityService', () => {
   });
 
   describe('test isLoading$', () => {
-    it('should emit true', () => {
-      oidcSecurityService.isLoading$.subscribe((x) => {
-        expect(x).toBeTrue();
-      });
-    });
+    it(
+      'should emit true',
+      waitForAsync(() => {
+        oidcSecurityService.isLoading$.subscribe((x) => {
+          expect(x).toBeTrue();
+        });
+      })
+    );
 
-    it('isloading should emit false after checkauth is called', (done) => {
-      const config = { configId: 'configId1' };
-      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      spyOn(checkAuthService, 'checkAuth').and.returnValue(of(null));
+    it(
+      'isloading should emit false after checkauth is called',
+      waitForAsync(() => {
+        const config = { configId: 'configId1' };
+        spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+        spyOn(checkAuthService, 'checkAuth').and.returnValue(of(null));
 
-      oidcSecurityService
-        .checkAuth()
-        .pipe(
-          switchMap(() =>
-            oidcSecurityService.isLoading$.pipe(
-              tap((x) => {
-                expect(x).toBeFalse();
-                done();
-              })
+        oidcSecurityService
+          .checkAuth()
+          .pipe(
+            switchMap(() =>
+              oidcSecurityService.isLoading$.pipe(
+                tap((x) => {
+                  expect(x).toBeFalse();
+                })
+              )
             )
           )
-        )
-        .subscribe();
-    });
+          .subscribe();
+      })
+    );
 
-    it('isloading should emit false on error in checkauth', (done) => {
-      const config = { configId: 'configId1' };
-      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      spyOn(checkAuthService, 'checkAuth').and.returnValue(throwError(() => new Error('Error')));
-      oidcSecurityService
-        .checkAuth()
-        .pipe(
-          catchError(() =>
-            oidcSecurityService.isLoading$.pipe(
-              tap((x) => {
-                expect(x).toBeFalse();
-                done();
-              })
+    it(
+      'isloading should emit false on error in checkauth',
+      waitForAsync(() => {
+        const config = { configId: 'configId1' };
+        spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+        spyOn(checkAuthService, 'checkAuth').and.returnValue(throwError(() => new Error('Error')));
+        oidcSecurityService
+          .checkAuth()
+          .pipe(
+            catchError(() =>
+              oidcSecurityService.isLoading$.pipe(
+                tap((x) => {
+                  expect(x).toBeFalse();
+                })
+              )
             )
           )
-        )
-        .subscribe();
-    });
+          .subscribe();
+      })
+    );
 
-    it('isloading should emit false after checkauthMultiple is called', (done) => {
-      const config = { configId: 'configId1' };
-      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(of(null));
+    it(
+      'isloading should emit false after checkauthMultiple is called',
+      waitForAsync(() => {
+        const config = { configId: 'configId1' };
+        spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+        spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(of(null));
 
-      oidcSecurityService
-        .checkAuthMultiple()
-        .pipe(
-          switchMap(() =>
-            oidcSecurityService.isLoading$.pipe(
-              tap((x) => {
-                expect(x).toBeFalse();
-                done();
-              })
+        oidcSecurityService
+          .checkAuthMultiple()
+          .pipe(
+            switchMap(() =>
+              oidcSecurityService.isLoading$.pipe(
+                tap((x) => {
+                  expect(x).toBeFalse();
+                })
+              )
             )
           )
-        )
-        .subscribe();
-    });
+          .subscribe();
+      })
+    );
 
-    it('isloading should emit false on error in checkauthMultiple', (done) => {
-      const config = { configId: 'configId1' };
-      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(throwError(() => new Error('Error')));
-      oidcSecurityService
-        .checkAuthMultiple()
-        .pipe(
-          catchError(() =>
-            oidcSecurityService.isLoading$.pipe(
-              tap((x) => {
-                expect(x).toBeFalse();
-                done();
-              })
+    it(
+      'isloading should emit false on error in checkauthMultiple',
+      waitForAsync(() => {
+        const config = { configId: 'configId1' };
+        spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+        spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(throwError(() => new Error('Error')));
+        oidcSecurityService
+          .checkAuthMultiple()
+          .pipe(
+            catchError(() =>
+              oidcSecurityService.isLoading$.pipe(
+                tap((x) => {
+                  expect(x).toBeFalse();
+                })
+              )
             )
           )
-        )
-        .subscribe();
-    });
+          .subscribe();
+      })
+    );
 
-    it('isloading should emit false after checkAuthIncludingServer is called', (done) => {
-      const config = { configId: 'configId1' };
-      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      spyOn(checkAuthService, 'checkAuthIncludingServer').and.returnValue(of(null));
+    it(
+      'isloading should emit false after checkAuthIncludingServer is called',
+      waitForAsync(() => {
+        const config = { configId: 'configId1' };
+        spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+        spyOn(checkAuthService, 'checkAuthIncludingServer').and.returnValue(of(null));
 
-      oidcSecurityService
-        .checkAuthIncludingServer()
-        .pipe(
-          switchMap(() =>
-            oidcSecurityService.isLoading$.pipe(
-              tap((x) => {
-                expect(x).toBeFalse();
-                done();
-              })
+        oidcSecurityService
+          .checkAuthIncludingServer()
+          .pipe(
+            switchMap(() =>
+              oidcSecurityService.isLoading$.pipe(
+                tap((x) => {
+                  expect(x).toBeFalse();
+                })
+              )
             )
           )
-        )
-        .subscribe();
-    });
+          .subscribe();
+      })
+    );
 
-    it('isloading should emit false on error in checkAuthIncludingServer', (done) => {
-      const config = { configId: 'configId1' };
-      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      spyOn(checkAuthService, 'checkAuthIncludingServer').and.returnValue(throwError(() => new Error('Error')));
-      oidcSecurityService
-        .checkAuthIncludingServer()
-        .pipe(
-          catchError(() =>
-            oidcSecurityService.isLoading$.pipe(
-              tap((x) => {
-                expect(x).toBeFalse();
-                done();
-              })
+    it(
+      'isloading should emit false on error in checkAuthIncludingServer',
+      waitForAsync(() => {
+        const config = { configId: 'configId1' };
+        spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+        spyOn(checkAuthService, 'checkAuthIncludingServer').and.returnValue(throwError(() => new Error('Error')));
+        oidcSecurityService
+          .checkAuthIncludingServer()
+          .pipe(
+            catchError(() =>
+              oidcSecurityService.isLoading$.pipe(
+                tap((x) => {
+                  expect(x).toBeFalse();
+                })
+              )
             )
           )
-        )
-        .subscribe();
-    });
+          .subscribe();
+      })
+    );
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { Observable, of } from 'rxjs';
+import { catchError, Observable, of, switchMap, tap, throwError } from 'rxjs';
 import { mockClass } from '../test/auto-mock';
 import { AuthStateService } from './auth-state/auth-state.service';
 import { CheckAuthService } from './auth-state/check-auth.service';
@@ -629,6 +629,131 @@ describe('OidcSecurityService', () => {
       oidcSecurityService.getAuthorizeUrl({ custom: 'params' }).subscribe(() => {
         expect(spy).toHaveBeenCalledOnceWith(config, { custom: 'params' });
       });
+    });
+  });
+
+  describe('test isLoading$', () => {
+    it('should emit true', () => {
+      oidcSecurityService.isLoading$.subscribe((x) => {
+        expect(x).toBeTrue();
+      });
+    });
+
+    it('isloading should emit false after checkauth is called', (done) => {
+      const config = { configId: 'configId1' };
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+      spyOn(checkAuthService, 'checkAuth').and.returnValue(of(null));
+
+      oidcSecurityService
+        .checkAuth()
+        .pipe(
+          switchMap(() =>
+            oidcSecurityService.isLoading$.pipe(
+              tap((x) => {
+                expect(x).toBeFalse();
+                done();
+              })
+            )
+          )
+        )
+        .subscribe();
+    });
+
+    it('isloading should emit false on error in checkauth', (done) => {
+      const config = { configId: 'configId1' };
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+      const spy = spyOn(checkAuthService, 'checkAuth').and.returnValue(throwError(() => new Error('Error')));
+      oidcSecurityService
+        .checkAuth()
+        .pipe(
+          catchError((err) =>
+            oidcSecurityService.isLoading$.pipe(
+              tap((x) => {
+                expect(x).toBeFalse();
+                done();
+              })
+            )
+          )
+        )
+        .subscribe();
+    });
+
+    it('isloading should emit false after checkauthMultiple is called', (done) => {
+      const config = { configId: 'configId1' };
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+      spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(of(null));
+
+      oidcSecurityService
+        .checkAuthMultiple()
+        .pipe(
+          switchMap(() =>
+            oidcSecurityService.isLoading$.pipe(
+              tap((x) => {
+                expect(x).toBeFalse();
+                done();
+              })
+            )
+          )
+        )
+        .subscribe();
+    });
+
+    it('isloading should emit false on error in checkauthMultiple', (done) => {
+      const config = { configId: 'configId1' };
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+      const spy = spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(throwError(() => new Error('Error')));
+      oidcSecurityService
+        .checkAuthMultiple()
+        .pipe(
+          catchError((err) =>
+            oidcSecurityService.isLoading$.pipe(
+              tap((x) => {
+                expect(x).toBeFalse();
+                done();
+              })
+            )
+          )
+        )
+        .subscribe();
+    });
+
+    it('isloading should emit false after checkAuthIncludingServer is called', (done) => {
+      const config = { configId: 'configId1' };
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+      spyOn(checkAuthService, 'checkAuthIncludingServer').and.returnValue(of(null));
+
+      oidcSecurityService
+        .checkAuthIncludingServer()
+        .pipe(
+          switchMap(() =>
+            oidcSecurityService.isLoading$.pipe(
+              tap((x) => {
+                expect(x).toBeFalse();
+                done();
+              })
+            )
+          )
+        )
+        .subscribe();
+    });
+
+    it('isloading should emit false on error in checkAuthIncludingServer', (done) => {
+      const config = { configId: 'configId1' };
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
+      spyOn(checkAuthService, 'checkAuthIncludingServer').and.returnValue(throwError(() => new Error('Error')));
+      oidcSecurityService
+        .checkAuthIncludingServer()
+        .pipe(
+          catchError((err) =>
+            oidcSecurityService.isLoading$.pipe(
+              tap((x) => {
+                expect(x).toBeFalse();
+                done();
+              })
+            )
+          )
+        )
+        .subscribe();
     });
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -662,11 +662,11 @@ describe('OidcSecurityService', () => {
     it('isloading should emit false on error in checkauth', (done) => {
       const config = { configId: 'configId1' };
       spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      const spy = spyOn(checkAuthService, 'checkAuth').and.returnValue(throwError(() => new Error('Error')));
+      spyOn(checkAuthService, 'checkAuth').and.returnValue(throwError(() => new Error('Error')));
       oidcSecurityService
         .checkAuth()
         .pipe(
-          catchError((err) =>
+          catchError(() =>
             oidcSecurityService.isLoading$.pipe(
               tap((x) => {
                 expect(x).toBeFalse();
@@ -701,11 +701,11 @@ describe('OidcSecurityService', () => {
     it('isloading should emit false on error in checkauthMultiple', (done) => {
       const config = { configId: 'configId1' };
       spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
-      const spy = spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(throwError(() => new Error('Error')));
+      spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(throwError(() => new Error('Error')));
       oidcSecurityService
         .checkAuthMultiple()
         .pipe(
-          catchError((err) =>
+          catchError(() =>
             oidcSecurityService.isLoading$.pipe(
               tap((x) => {
                 expect(x).toBeFalse();
@@ -744,7 +744,7 @@ describe('OidcSecurityService', () => {
       oidcSecurityService
         .checkAuthIncludingServer()
         .pipe(
-          catchError((err) =>
+          catchError(() =>
             oidcSecurityService.isLoading$.pipe(
               tap((x) => {
                 expect(x).toBeFalse();

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -632,7 +632,7 @@ describe('OidcSecurityService', () => {
     });
   });
 
-  describe('test isLoading$', () => {
+  describe('isLoading$', () => {
     it(
       'should emit true',
       waitForAsync(() => {
@@ -643,7 +643,7 @@ describe('OidcSecurityService', () => {
     );
 
     it(
-      'isloading should emit false after checkauth is called',
+      'should emit false after checkauth is called',
       waitForAsync(() => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
@@ -665,7 +665,7 @@ describe('OidcSecurityService', () => {
     );
 
     it(
-      'isloading should emit false on error in checkauth',
+      'should emit false on error in checkauth',
       waitForAsync(() => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
@@ -686,7 +686,7 @@ describe('OidcSecurityService', () => {
     );
 
     it(
-      'isloading should emit false after checkauthMultiple is called',
+      'should emit false after checkauthMultiple is called',
       waitForAsync(() => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
@@ -708,7 +708,7 @@ describe('OidcSecurityService', () => {
     );
 
     it(
-      'isloading should emit false on error in checkauthMultiple',
+      'should emit false on error in checkauthMultiple',
       waitForAsync(() => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
@@ -729,7 +729,7 @@ describe('OidcSecurityService', () => {
     );
 
     it(
-      'isloading should emit false after checkAuthIncludingServer is called',
+      'should emit false after checkAuthIncludingServer is called',
       waitForAsync(() => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
@@ -751,7 +751,7 @@ describe('OidcSecurityService', () => {
     );
 
     it(
-      'isloading should emit false on error in checkAuthIncludingServer',
+      'should emit false on error in checkAuthIncludingServer',
       waitForAsync(() => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
-import { catchError, Observable, of, switchMap, tap, throwError } from 'rxjs';
+import { catchError, Observable, of, switchMap, throwError } from 'rxjs';
 import { mockClass } from '../test/auto-mock';
 import { AuthStateService } from './auth-state/auth-state.service';
 import { CheckAuthService } from './auth-state/check-auth.service';
@@ -636,9 +636,7 @@ describe('OidcSecurityService', () => {
     it(
       'should emit true',
       waitForAsync(() => {
-        oidcSecurityService.isLoading$.subscribe((x) => {
-          expect(x).toBeTrue();
-        });
+        oidcSecurityService.isLoading$.subscribe((x) => expect(x).toBeTrue());
       })
     );
 
@@ -651,16 +649,8 @@ describe('OidcSecurityService', () => {
 
         oidcSecurityService
           .checkAuth()
-          .pipe(
-            switchMap(() =>
-              oidcSecurityService.isLoading$.pipe(
-                tap((x) => {
-                  expect(x).toBeFalse();
-                })
-              )
-            )
-          )
-          .subscribe();
+          .pipe(switchMap(() => oidcSecurityService.isLoading$))
+          .subscribe((x) => expect(x).toBeFalse());
       })
     );
 
@@ -670,18 +660,11 @@ describe('OidcSecurityService', () => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
         spyOn(checkAuthService, 'checkAuth').and.returnValue(throwError(() => new Error('Error')));
+
         oidcSecurityService
           .checkAuth()
-          .pipe(
-            catchError(() =>
-              oidcSecurityService.isLoading$.pipe(
-                tap((x) => {
-                  expect(x).toBeFalse();
-                })
-              )
-            )
-          )
-          .subscribe();
+          .pipe(catchError(() => oidcSecurityService.isLoading$))
+          .subscribe((x) => expect(x).toBeFalse());
       })
     );
 
@@ -694,16 +677,8 @@ describe('OidcSecurityService', () => {
 
         oidcSecurityService
           .checkAuthMultiple()
-          .pipe(
-            switchMap(() =>
-              oidcSecurityService.isLoading$.pipe(
-                tap((x) => {
-                  expect(x).toBeFalse();
-                })
-              )
-            )
-          )
-          .subscribe();
+          .pipe(switchMap(() => oidcSecurityService.isLoading$))
+          .subscribe((x) => expect(x).toBeFalse());
       })
     );
 
@@ -713,18 +688,11 @@ describe('OidcSecurityService', () => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
         spyOn(checkAuthService, 'checkAuthMultiple').and.returnValue(throwError(() => new Error('Error')));
+
         oidcSecurityService
           .checkAuthMultiple()
-          .pipe(
-            catchError(() =>
-              oidcSecurityService.isLoading$.pipe(
-                tap((x) => {
-                  expect(x).toBeFalse();
-                })
-              )
-            )
-          )
-          .subscribe();
+          .pipe(catchError(() => oidcSecurityService.isLoading$))
+          .subscribe((x) => expect(x).toBeFalse());
       })
     );
 
@@ -737,16 +705,8 @@ describe('OidcSecurityService', () => {
 
         oidcSecurityService
           .checkAuthIncludingServer()
-          .pipe(
-            switchMap(() =>
-              oidcSecurityService.isLoading$.pipe(
-                tap((x) => {
-                  expect(x).toBeFalse();
-                })
-              )
-            )
-          )
-          .subscribe();
+          .pipe(switchMap(() => oidcSecurityService.isLoading$))
+          .subscribe((x) => expect(x).toBeFalse());
       })
     );
 
@@ -756,18 +716,11 @@ describe('OidcSecurityService', () => {
         const config = { configId: 'configId1' };
         spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(of({ allConfigs: [config], currentConfig: config }));
         spyOn(checkAuthService, 'checkAuthIncludingServer').and.returnValue(throwError(() => new Error('Error')));
+
         oidcSecurityService
           .checkAuthIncludingServer()
-          .pipe(
-            catchError(() =>
-              oidcSecurityService.isLoading$.pipe(
-                tap((x) => {
-                  expect(x).toBeFalse();
-                })
-              )
-            )
-          )
-          .subscribe();
+          .pipe(catchError(() => oidcSecurityService.isLoading$))
+          .subscribe((x) => expect(x).toBeFalse());
       })
     );
   });

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
@@ -62,13 +62,13 @@ export class OidcSecurityService {
   }
 
   /**
-   * Emits false when checkAuth observable emits a value, or errors. Initial value: true.
+   * Emits false when the observable, returned by one of the checkAuth() methods, emits a value, or errors. Initial value: true.
    */
   get isLoading$(): Observable<boolean> {
-    return this.isLoadingBehaviorSubject.asObservable();
+    return this.isLoading.asObservable();
   }
 
-  private readonly isLoadingBehaviorSubject: BehaviorSubject<boolean> = new BehaviorSubject(true);
+  private readonly isLoading: BehaviorSubject<boolean> = new BehaviorSubject(true);
 
   constructor(
     private checkSessionService: CheckSessionService,
@@ -431,11 +431,12 @@ export class OidcSecurityService {
   }
 
   private finishLoading = (): void => {
-    this.isLoadingBehaviorSubject.next(false);
+    this.isLoading.next(false);
   };
 
   private finishLoadingOnError = (err: any): Observable<never> => {
-    this.isLoadingBehaviorSubject.next(false);
+    this.isLoading.next(false);
+    
     return throwError(() => err);
   };
 }


### PR DESCRIPTION
Hi, I made the pull request to add an isLoading observable to the oidc security service. 

**Reason** 

I came accross the problem when all routes are protected by an Auth guard. The Auth guard subscribes to the isAuthenticated observable in the oidc security service. If emission is true return true, otherwise call the authorize method. Since the initial emission of isAuthenticated is false, this would cause an infinite redirect loop. In these situations it could be convenient to have an isLoading observable, which is implemented to emit false when the checkAuth methods have either emitted, or errored.

**Use case**

Combine isLoading with isAuthenticated to avoid timing issues, isAuthenticated will only emit its first value after isLoading has emitted false.

Ps: It is the best auth library I have used.<3

