### PR TITLE
Added a test to `getUrlParameter` for square brackets

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -132,6 +132,19 @@ describe('UrlService Tests', () => {
       expect(tokenType).toBe('example');
       expect(expiresIn).toBe('3600');
     });
+
+    it('gets correct params when square brackets are present', () => {
+      const urlToCheck = 'http://example.com/cb#state=abc[&code=abc&arr[]=1&some_param=abc]&arr[]=2&arr[]=3';
+      const state = service.getUrlParameter(urlToCheck, 'state');
+      const code = service.getUrlParameter(urlToCheck, 'code');
+      const someParam = service.getUrlParameter(urlToCheck, 'some_param');
+      const array = service.getUrlParameter(urlToCheck, 'arr[]');
+
+      expect(state).toBe('abc[');
+      expect(code).toBe('abc');
+      expect(someParam).toBe('abc]');
+      expect(['1', '2', '3']).toContain(array);
+    });
   });
 
   describe('createAuthorizeUrl', () => {


### PR DESCRIPTION
This test seems justified since it is a special case that is currently well-supported by the current implementation but should always be upheld.