### PR TITLE
Add redirectUrl customization (via AuthOptions)

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auth-options.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-options.ts
@@ -1,4 +1,6 @@
 export interface AuthOptions {
   customParams?: { [key: string]: string | number | boolean };
   urlHandler?(url: string): any;
+  /** overrides redirectUrl from configuration */
+  redirectUrl?: string;
 }

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.ts
@@ -43,9 +43,7 @@ export class PopUpLoginService {
 
     return this.authWellKnownService.queryAndStoreAuthWellKnownEndPoints(configuration).pipe(
       switchMap(() => {
-        const { customParams } = authOptions || {};
-
-        return this.urlService.getAuthorizeUrl(configuration, customParams);
+        return this.urlService.getAuthorizeUrl(configuration, authOptions);
       }),
       tap((authUrl: string) => this.popupService.openPopUp(authUrl, popupOptions)),
       switchMap(() => {

--- a/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.spec.ts
@@ -120,7 +120,7 @@ describe('StandardLoginService', () => {
       standardLoginService.loginStandard(config, { customParams: { to: 'add', as: 'well' } });
       tick();
       expect(redirectSpy).toHaveBeenCalledOnceWith('someUrl');
-      expect(getAuthorizeUrlSpy).toHaveBeenCalledOnceWith(config, { to: 'add', as: 'well' });
+      expect(getAuthorizeUrlSpy).toHaveBeenCalledOnceWith(config, { customParams: { to: 'add', as: 'well' } });
     }));
 
     it('does nothing, logs only if getAuthorizeUrl returns falsy', fakeAsync(() => {

--- a/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/standard/standard-login.service.ts
@@ -27,9 +27,9 @@ export class StandardLoginService {
     this.loggerService.logDebug(configuration, 'BEGIN Authorize OIDC Flow, no auth data');
 
     this.authWellKnownService.queryAndStoreAuthWellKnownEndPoints(configuration).subscribe(() => {
-      const { urlHandler, customParams } = authOptions || {};
+      const { urlHandler } = authOptions || {};
 
-      this.urlService.getAuthorizeUrl(configuration, customParams).subscribe((url: string) => {
+      this.urlService.getAuthorizeUrl(configuration, authOptions).subscribe((url: string) => {
         if (!url) {
           this.loggerService.logError(configuration, 'Could not create URL', url);
 

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -627,7 +627,7 @@ describe('OidcSecurityService', () => {
       const spy = spyOn(urlService, 'getAuthorizeUrl').and.returnValue(of(null));
 
       oidcSecurityService.getAuthorizeUrl({ custom: 'params' }).subscribe(() => {
-        expect(spy).toHaveBeenCalledOnceWith(config, { custom: 'params' });
+        expect(spy).toHaveBeenCalledOnceWith(config, { customParams: { custom: 'params' } });
       });
     });
   });

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
@@ -427,7 +427,7 @@ export class OidcSecurityService {
   getAuthorizeUrl(customParams?: { [p: string]: string | number | boolean }, configId?: string): Observable<string | null> {
     return this.configurationService
       .getOpenIDConfiguration(configId)
-      .pipe(switchMap((config) => this.urlService.getAuthorizeUrl(config, customParams)));
+      .pipe(switchMap((config) => this.urlService.getAuthorizeUrl(config, customParams ? { customParams: customParams } : undefined)));
   }
 
   private finishLoading = (): void => {
@@ -436,7 +436,7 @@ export class OidcSecurityService {
 
   private finishLoadingOnError = (err: any): Observable<never> => {
     this.isLoading.next(false);
-    
+
     return throwError(() => err);
   };
 }

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -773,6 +773,20 @@ describe('UrlService Tests', () => {
     });
   });
 
+  describe('getRedirectUrl', () => {
+    it('returns configured redirectUrl', () => {
+      let config = { configId: 'configId1', redirectUrl: 'one-url' };
+      let url = (service as any).getRedirectUrl(config);
+      expect(url).toEqual('one-url');
+    });
+
+    it('returns redefined redirectUrl in AuthOptions', () => {
+      let config = { configId: 'configId1', redirectUrl: 'one-url' };
+      let url = (service as any).getRedirectUrl(config, { redirectUrl: 'other-url' });
+      expect(url).toEqual('other-url');
+    });
+  });
+
   describe('getAuthorizeUrl', () => {
     it('calls createUrlCodeFlowAuthorize if current flow is code flow', () => {
       spyOn(flowHelper, 'isCurrentFlowCodeFlow').and.returnValue(true);
@@ -1330,7 +1344,7 @@ describe('UrlService Tests', () => {
 
       const serviceAsAny = service as any;
 
-      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config, { to: 'add', as: 'well' });
+      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config, { customParams: { to: 'add', as: 'well' } });
       resultObs$.subscribe((result) => {
         expect(result).toBe(
           `authorizationEndpoint?client_id=clientId&redirect_uri=http%3A%2F%2Fany-url.com` +

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -2,6 +2,7 @@ import { HttpParams } from '@angular/common/http';
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { map } from 'rxjs/operators';
+import { AuthOptions } from '../../auth-options';
 import { OpenIdConfiguration } from '../../config/openid-configuration';
 import { FlowsDataService } from '../../flows/flows-data.service';
 import { LoggerService } from '../../logging/logger.service';
@@ -93,12 +94,12 @@ export class UrlService {
     return `${authorizationUrl}?${params}`;
   }
 
-  getAuthorizeUrl(config: OpenIdConfiguration, customParams?: { [key: string]: string | number | boolean }): Observable<string> {
+  getAuthorizeUrl(config: OpenIdConfiguration, authOptions?: AuthOptions): Observable<string> {
     if (this.flowHelper.isCurrentFlowCodeFlow(config)) {
-      return this.createUrlCodeFlowAuthorize(config, customParams);
+      return this.createUrlCodeFlowAuthorize(config, authOptions);
     }
 
-    return of(this.createUrlImplicitFlowAuthorize(config, customParams) || '');
+    return of(this.createUrlImplicitFlowAuthorize(config, authOptions) || '');
   }
 
   createEndSessionUrl(
@@ -434,15 +435,12 @@ export class UrlService {
     );
   }
 
-  private createUrlImplicitFlowAuthorize(
-    configuration: OpenIdConfiguration,
-    customParams?: { [key: string]: string | number | boolean }
-  ): string {
+  private createUrlImplicitFlowAuthorize(configuration: OpenIdConfiguration, authOptions?: AuthOptions): string {
     const state = this.flowsDataService.getExistingOrCreateAuthStateControl(configuration);
     const nonce = this.flowsDataService.createNonce(configuration);
     this.loggerService.logDebug(configuration, 'Authorize created. adding myautostate: ' + state);
 
-    const redirectUrl = this.getRedirectUrl(configuration);
+    const redirectUrl = this.getRedirectUrl(configuration, authOptions);
 
     if (!redirectUrl) {
       return null;
@@ -450,6 +448,8 @@ export class UrlService {
 
     const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints', configuration);
     if (authWellKnownEndPoints) {
+      const { customParams } = authOptions || {};
+
       return this.createAuthorizeUrl('', redirectUrl, nonce, state, configuration, null, customParams);
     }
 
@@ -458,15 +458,12 @@ export class UrlService {
     return null;
   }
 
-  private createUrlCodeFlowAuthorize(
-    config: OpenIdConfiguration,
-    customParams?: { [key: string]: string | number | boolean }
-  ): Observable<string> {
+  private createUrlCodeFlowAuthorize(config: OpenIdConfiguration, authOptions?: AuthOptions): Observable<string> {
     const state = this.flowsDataService.getExistingOrCreateAuthStateControl(config);
     const nonce = this.flowsDataService.createNonce(config);
     this.loggerService.logDebug(config, 'Authorize created. adding myautostate: ' + state);
 
-    const redirectUrl = this.getRedirectUrl(config);
+    const redirectUrl = this.getRedirectUrl(config, authOptions);
 
     if (!redirectUrl) {
       return of(null);
@@ -479,6 +476,8 @@ export class UrlService {
       map((codeChallenge: string) => {
         const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints', config);
         if (authWellKnownEndPoints) {
+          const { customParams } = authOptions || {};
+
           return this.createAuthorizeUrl(codeChallenge, redirectUrl, nonce, state, config, null, customParams);
         }
 
@@ -489,8 +488,13 @@ export class UrlService {
     );
   }
 
-  private getRedirectUrl(configuration: OpenIdConfiguration): string {
-    const { redirectUrl } = configuration;
+  private getRedirectUrl(configuration: OpenIdConfiguration, authOptions?: AuthOptions): string {
+    let { redirectUrl } = configuration;
+
+    if (authOptions && authOptions.redirectUrl) {
+      // override by redirectUrl from authOptions
+      redirectUrl = authOptions.redirectUrl;
+    }
 
     if (!redirectUrl) {
       this.loggerService.logError(configuration, `could not get redirectUrl, was: `, redirectUrl);


### PR DESCRIPTION
I've tried to implement my feature request: **Optimisation for popup login** #1361.

The implementation is more generic (and also simpler) and enables to customize the redirect URL (via AuthOptions) for not only authorizeWithPopUp() but also for authorize().

related issue: #1361
