### PR TITLE
fix: implicite flow in popup window error (fixes #1385)

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/callback/callback.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/callback.service.ts
@@ -37,7 +37,12 @@ export class CallbackService {
     if (this.flowHelper.isCurrentFlowCodeFlow(config)) {
       callback$ = this.codeFlowCallbackService.authenticatedCallbackWithCode(currentCallbackUrl, config, allConfigs);
     } else if (this.flowHelper.isCurrentFlowAnyImplicitFlow(config)) {
-      callback$ = this.implicitFlowCallbackService.authenticatedImplicitFlowCallback(config, allConfigs);
+      if (currentCallbackUrl?.includes('#')) {
+        let hash = currentCallbackUrl.substring(currentCallbackUrl.indexOf('#') + 1);
+        callback$ = this.implicitFlowCallbackService.authenticatedImplicitFlowCallback(config, allConfigs, hash);
+      } else {
+        callback$ = this.implicitFlowCallbackService.authenticatedImplicitFlowCallback(config, allConfigs);
+      }
     }
 
     return callback$.pipe(tap(() => this.stsCallbackInternal$.next()));


### PR DESCRIPTION
The modification fixes the issue #1385.

I am not sure if calling `authenticatedImplicitFlowCallback` without a hash make any sense and 
maybe we should just throw an error if there's no hash in the current Url (?).
But I preferred less risky way to fix this.