### PR TITLE
fix: include query params in return url with canLoad guards

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-all-routes.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-all-routes.guard.ts
@@ -1,14 +1,5 @@
 import { Injectable } from '@angular/core';
-import {
-  ActivatedRouteSnapshot,
-  CanActivate,
-  CanActivateChild,
-  CanLoad,
-  Route,
-  RouterStateSnapshot,
-  UrlSegment,
-  UrlTree,
-} from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, CanLoad, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map, switchMap, take } from 'rxjs/operators';
 import { CheckAuthService } from '../auth-state/check-auth.service';
@@ -22,13 +13,12 @@ export class AutoLoginAllRoutesGuard implements CanActivate, CanActivateChild, C
     private autoLoginService: AutoLoginService,
     private checkAuthService: CheckAuthService,
     private loginService: LoginService,
-    private configurationService: ConfigurationService
+    private configurationService: ConfigurationService,
+    private router: Router
   ) {}
 
-  canLoad(route: Route, segments: UrlSegment[]): Observable<boolean | UrlTree> {
-    const routeToRedirect = segments.join('/');
-
-    return this.checkAuth(routeToRedirect);
+  canLoad(): Observable<boolean | UrlTree> {
+    return this.checkAuth(this.router.getCurrentNavigation()?.extractedUrl.toString().substring(1) ?? '');
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, CanLoad, Route, RouterStateSnapshot, UrlSegment } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, CanActivateChild, CanLoad, Router, RouterStateSnapshot } from '@angular/router';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { AuthStateService } from '../auth-state/auth-state.service';
@@ -13,13 +13,12 @@ export class AutoLoginPartialRoutesGuard implements CanActivate, CanActivateChil
     private autoLoginService: AutoLoginService,
     private authStateService: AuthStateService,
     private loginService: LoginService,
-    private configurationService: ConfigurationService
+    private configurationService: ConfigurationService,
+    private router: Router
   ) {}
 
-  canLoad(route: Route, segments: UrlSegment[]): Observable<boolean> {
-    const routeToRedirect = segments.join('/');
-
-    return this.checkAuth(routeToRedirect);
+  canLoad(): Observable<boolean> {
+    return this.checkAuth(this.router.getCurrentNavigation()?.extractedUrl.toString().substring(1) ?? '');
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {


### PR DESCRIPTION
I tried the fix in the project that I'm working on, and also in the `start-sample-code-flow-auto-login` example in this repo.

![yes](https://user-images.githubusercontent.com/28659384/160122899-a3de8c01-53f1-4918-b2c3-252b914ab3b1.gif)

Resolves #1409 