### PR TITLE
fix(ng-add): remove double quotes in info messages

### DIFF
--- a/projects/schematics/src/ng-add/actions/copy-module-file.ts
+++ b/projects/schematics/src/ng-add/actions/copy-module-file.ts
@@ -24,13 +24,13 @@ export function copyModuleFile(options: NgAddOptions): Rule {
 
     const filePath = `${project.sourceRoot}/app/auth/${moduleFileName}.ts`;
     if (host.exists(filePath)) {
-      context.logger.info(`✅️ '${filePath}'' already existing - skipping file create`);
+      context.logger.info(`✅️ '${filePath}' already existing - skipping file create`);
       return host;
     }
 
     const templateConfig = getTemplateConfig(options);
 
-    context.logger.info(`✅️ '${filePath}''will be created`);
+    context.logger.info(`✅️ '${filePath}' will be created`);
 
     const templateSource = apply(url(`./files/${moduleFolder}`), [
       template(templateConfig),

--- a/projects/schematics/src/ng-add/files/auth-http-config/auth-http-config.module.__ts__
+++ b/projects/schematics/src/ng-add/files/auth-http-config/auth-http-config.module.__ts__
@@ -27,8 +27,7 @@ export const httpLoaderFactory = (httpClient: HttpClient) => {
           // autoUserInfo: false,
         };
       })
-    )
-    .toPromise();
+    );
 
   return new StsConfigHttpLoader(config$);
 };


### PR DESCRIPTION
I couldn't get enough, so I installed the package in another project.
In the process I saw that the info messages from the ng-add command included two double quotes.
