### PR TITLE
Fix regression in the check session service

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -184,7 +184,7 @@ export class CheckSessionService {
 
   private bindMessageEventToIframe(configId: string): void {
     const iframeMessageEvent = this.messageHandler.bind(this, configId);
-    this.document.addEventListener('message', iframeMessageEvent, false);
+    this.document.defaultView.addEventListener('message', iframeMessageEvent, false);
   }
 
   private getOrCreateIframe(configuration: OpenIdConfiguration): HTMLIFrameElement {


### PR DESCRIPTION
In this commit: [5c57084900237245e0fe3b7db58cc188f4f5fe75](https://github.com/damienbod/angular-auth-oidc-client/commit/5c57084900237245e0fe3b7db58cc188f4f5fe75) the code was refactored in order to retrieve the reference to the browser's global variables via Angular's dependency injection.

In this line: https://github.com/damienbod/angular-auth-oidc-client/commit/5c57084900237245e0fe3b7db58cc188f4f5fe75#diff-dec315070d26d82195b08309ea5550cfd8d36e230b58ab9ddb59a401fe9ff3a4L185, `window` was replaced with `this.document` which is wrong because the events of type [`message`](https://developer.mozilla.org/fr/docs/Web/API/Window/message_event) are being emitted by `window`, not `document`.

That prevents the library from receiving response [`message` ](https://developer.mozilla.org/fr/docs/Web/API/Window/message_event) events from the `iframe`, which causes these errors in the console:

> [ERROR] 0-app- CheckSession - OidcSecurityCheckSession not receiving check session response messages. Outstanding messages: '12'. Server unreachable?

It also very probably prevents the check session mechanism from working at all.

My pull request fixes this by replacing `this.document` with `this.document.defaultView`, an actual reference to `window`.
It fixes #1428 