### PR TITLE
Disable id_token time validation

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auth-state/auth-state.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/auth-state.service.spec.ts
@@ -367,7 +367,7 @@ describe('Auth State Service', () => {
 
       authStateService.hasIdTokenExpiredAndRenewCheckIsEnabled(config);
 
-      expect(spy).toHaveBeenCalledOnceWith('idToken', config, 30);
+      expect(spy).toHaveBeenCalledOnceWith('idToken', config, 30, undefined);
     });
 
     it('fires event if idToken is expired', () => {

--- a/projects/angular-auth-oidc-client/src/lib/auth-state/auth-state.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/auth-state.service.ts
@@ -118,14 +118,14 @@ export class AuthStateService {
   }
 
   hasIdTokenExpiredAndRenewCheckIsEnabled(configuration: OpenIdConfiguration): boolean {
-    const { renewTimeBeforeTokenExpiresInSeconds, enableIdTokenExpiredValidationInRenew } = configuration;
+    const { renewTimeBeforeTokenExpiresInSeconds, enableIdTokenExpiredValidationInRenew, disableIdTokenValidation } = configuration;
 
     if (!enableIdTokenExpiredValidationInRenew) {
       return false;
     }
     const tokenToCheck = this.storagePersistenceService.getIdToken(configuration);
 
-    const idTokenExpired = this.tokenValidationService.hasIdTokenExpired(tokenToCheck, configuration, renewTimeBeforeTokenExpiresInSeconds);
+    const idTokenExpired = this.tokenValidationService.hasIdTokenExpired(tokenToCheck, configuration, renewTimeBeforeTokenExpiresInSeconds, disableIdTokenValidation);
 
     if (idTokenExpired) {
       this.publicEventsService.fireEvent<boolean>(EventTypes.IdTokenExpired, idTokenExpired);

--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -175,4 +175,6 @@ export interface OpenIdConfiguration {
    * The refresh token rotation is optional (rfc6749) but is more safe and hence encouraged.
    */
   allowUnsafeReuseRefreshToken?: boolean;
+  /** Disable validation for id_token expiry time */
+  disableIdTokenValidation?: boolean
 }

--- a/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/state-validation.service.ts
@@ -51,7 +51,7 @@ export class StateValidationService {
     }
 
     if (callbackContext.authResult.id_token) {
-      const { clientId, issValidationOff, maxIdTokenIatOffsetAllowedInSeconds, disableIatOffsetValidation, ignoreNonceAfterRefresh } =
+      const { clientId, issValidationOff, maxIdTokenIatOffsetAllowedInSeconds, disableIatOffsetValidation, ignoreNonceAfterRefresh, disableIdTokenValidation } =
         configuration;
 
       toReturn.idToken = callbackContext.authResult.id_token;
@@ -164,7 +164,7 @@ export class StateValidationService {
             return of(toReturn);
           }
 
-          if (!this.tokenValidationService.validateIdTokenExpNotExpired(toReturn.decodedIdToken, configuration)) {
+          if (!this.tokenValidationService.validateIdTokenExpNotExpired(toReturn.decodedIdToken, configuration, maxIdTokenIatOffsetAllowedInSeconds, disableIdTokenValidation)) {
             this.loggerService.logWarning(configuration, 'authCallback id token expired');
             toReturn.state = ValidationResult.TokenExpired;
             this.handleUnsuccessfulValidation(configuration);

--- a/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
@@ -68,15 +68,17 @@ export class TokenValidationService {
 
   // id_token C7: The current time MUST be before the time represented by the exp Claim
   // (possibly allowing for some small leeway to account for clock skew).
-  hasIdTokenExpired(token: string, configuration: OpenIdConfiguration, offsetSeconds?: number): boolean {
+  hasIdTokenExpired(token: string, configuration: OpenIdConfiguration, offsetSeconds?: number, disableIdTokenValidation?: boolean): boolean {
     const decoded = this.tokenHelperService.getPayloadFromToken(token, false, configuration);
 
-    return !this.validateIdTokenExpNotExpired(decoded, configuration, offsetSeconds);
+    return !this.validateIdTokenExpNotExpired(decoded, configuration, offsetSeconds, disableIdTokenValidation);
   }
 
   // id_token C7: The current time MUST be before the time represented by the exp Claim
   // (possibly allowing for some small leeway to account for clock skew).
-  validateIdTokenExpNotExpired(decodedIdToken: string, configuration: OpenIdConfiguration, offsetSeconds?: number): boolean {
+  validateIdTokenExpNotExpired(decodedIdToken: string, configuration: OpenIdConfiguration, offsetSeconds?: number, disableIdTokenValidation?: boolean): boolean {
+    if (disableIdTokenValidation) return true;
+
     const tokenExpirationDate = this.tokenHelperService.getTokenExpirationDate(decodedIdToken);
     offsetSeconds = offsetSeconds || 0;
 


### PR DESCRIPTION
Greetings @FabianGosebrink @damienbod

I've tried to disable id_token validation time, mentioned in this issue [1027](https://github.com/damienbod/angular-auth-oidc-client/issues/1027)

I've tested that on my local machine and it works as expected, but I'm not quite sure, that I did it correctly

Could you please check this pull request?