### PR TITLE
fix: RxJS imports to be compatible with RxJS 6

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { catchError, Observable, of, tap, throwError } from 'rxjs';
+import { Observable, of,  throwError } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
 import { EventTypes } from '../../public-events/event-types';
 import { PublicEventsService } from '../../public-events/public-events.service';
 import { StoragePersistenceService } from '../../storage/storage-persistence.service';

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, catchError, map, Observable, switchMap, tap, throwError } from 'rxjs';
+import { BehaviorSubject, Observable, throwError } from 'rxjs';
+import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { AuthOptions } from './auth-options';
 import { AuthenticatedResult } from './auth-state/auth-result';
 import { AuthStateService } from './auth-state/auth-state.service';


### PR DESCRIPTION
Move `operators` from `rxjs` to `rxjs/imports`
Closes #1490 