### PR TITLE
Bugfix/unable to extract jwk without kid

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auth.module.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth.module.ts
@@ -56,6 +56,8 @@ import { UrlService } from './utils/url/url.service';
 import { JwtWindowCryptoService } from './validation/jwt-window-crypto.service';
 import { StateValidationService } from './validation/state-validation.service';
 import { TokenValidationService } from './validation/token-validation.service';
+import { JwkExtractor } from './extractors/jwk.extractor';
+import { JwkWindowCryptoService } from './validation/jwk-window-crypto.service';
 
 export interface PassedInitialConfig {
   config?: OpenIdConfiguration | OpenIdConfiguration[];
@@ -128,6 +130,8 @@ export class AuthModule {
         PopUpLoginService,
         StandardLoginService,
         AutoLoginService,
+        JwkExtractor,
+        JwkWindowCryptoService,
         JwtWindowCryptoService,
         CurrentUrlService,
         ClosestMatchingRouteService,

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
@@ -4,7 +4,67 @@ import { JwkExtractor } from './jwk.extractor';
 
 describe('JwkExtractor', () => {
   let service: JwkExtractor;
-  let keys: JsonWebKey[];
+  const key1 = {
+    "kty": "RSA",
+    "use": "sig",
+    "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
+    "x5t": "VibOao9PX815xmQjRSgsp20zdUg",
+    "e": "AQAB",
+    "n": "uu3-HK4pLRHJHoEBzFhM516RWx6nybG5yQjH4NbKjfGQ8dtKy1BcGjqfMaEKF8KOK44NbAx7rtBKCO9EKNYkeFvcUzBzVeuu4jWG61XYdTekgv-Dh_Fj8245GocEkbvBbFW6cw-_N59JWqUuiCvb-EOfhcuubUcr44a0AQyNccYNpcXGRcMKy7_L1YhO0AMULqLDDVLFj5glh4TcJ2N5VnJedq1-_JKOxPqD1ni26UOQoWrW16G29KZ1_4Xxf2jX8TAq-4RJEHccdzgZVIO4F5B4MucMZGq8_jMCpiTUsUGDOAMA_AmjxIRHOtO5n6Pt0wofrKoAVhGh2sCTtaQf2Q",
+    "x5c": [
+      "MIIDPzCCAiegAwIBAgIQF+HRVxLHII9IlOoQk6BxcjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBzdHMuZGV2LmNlcnQuY29tMB4XDTE5MDIyMDEwMTA0M1oXDTM5MDIyMDEwMTkyOVowGzEZMBcGA1UEAwwQc3RzLmRldi5jZXJ0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALrt/hyuKS0RyR6BAcxYTOdekVsep8mxuckIx+DWyo3xkPHbSstQXBo6nzGhChfCjiuODWwMe67QSgjvRCjWJHhb3FMwc1XrruI1hutV2HU3pIL/g4fxY/NuORqHBJG7wWxVunMPvzefSVqlLogr2/hDn4XLrm1HK+OGtAEMjXHGDaXFxkXDCsu/y9WITtADFC6iww1SxY+YJYeE3CdjeVZyXnatfvySjsT6g9Z4tulDkKFq1tehtvSmdf+F8X9o1/EwKvuESRB3HHc4GVSDuBeQeDLnDGRqvP4zAqYk1LFBgzgDAPwJo8SERzrTuZ+j7dMKH6yqAFYRodrAk7WkH9kCAwEAAaN/MH0wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAtBgNVHREEJjAkghBzdHMuZGV2LmNlcnQuY29tghBzdHMuZGV2LmNlcnQuY29tMB0GA1UdDgQWBBQuyHxWP3je6jGMOmOiY+hz47r36jANBgkqhkiG9w0BAQsFAAOCAQEAKEHG7Ga6nb2XiHXDc69KsIJwbO80+LE8HVJojvITILz3juN6/FmK0HmogjU6cYST7m1MyxsVhQQNwJASZ6haBNuBbNzBXfyyfb4kr62t1oDLNwhctHaHaM4sJSf/xIw+YO+Qf7BtfRAVsbM05+QXIi2LycGrzELiXu7KFM0E1+T8UOZ2Qyv7OlCb/pWkYuDgE4w97ox0MhDpvgluxZLpRanOLUCVGrfFaij7gRAhjYPUY3vAEcD8JcFBz1XijU8ozRO6FaG4qg8/JCe+VgoWsMDj3sKB9g0ob6KCyG9L2bdk99PGgvXDQvMYCpkpZzG3XsxOINPd5p0gc209ZOoxTg=="
+    ],
+    "alg": "RS256"
+  } as JsonWebKey;
+  const key2 = {
+    "kty": "RSA",
+    "kid": "boop",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  const key3 = {
+    "kty": "RSA",
+    "use": "enc",
+    "kid": "boop",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  const key4 = {
+    "kty": "RSA",
+    "use": "sig",
+    "kid": "boop",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  const key5 = {
+    "kty": "RSA",
+    "use": "sig",
+    "kid": "boop",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  const key6 = {
+    "kty": "EC",
+    "use": "sig",
+    "kid": "boop",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  const key7 = {
+    "kty": "EC",
+    "use": "enc",
+    "kid": "boop",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  const key8 = {
+    "kty": "EC",
+    "use": "sig",
+    "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  let keys: JsonWebKey[] = [key1, key2, key3, key4, key5, key6, key7, key8];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -15,35 +75,6 @@ describe('JwkExtractor', () => {
 
   beforeEach(() => {
     service = TestBed.inject(JwkExtractor);
-    keys = [{
-      "kty": "RSA",
-      "use": "sig",
-      "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
-      "x5t": "VibOao9PX815xmQjRSgsp20zdUg",
-      "e": "AQAB",
-      "n": "uu3-HK4pLRHJHoEBzFhM516RWx6nybG5yQjH4NbKjfGQ8dtKy1BcGjqfMaEKF8KOK44NbAx7rtBKCO9EKNYkeFvcUzBzVeuu4jWG61XYdTekgv-Dh_Fj8245GocEkbvBbFW6cw-_N59JWqUuiCvb-EOfhcuubUcr44a0AQyNccYNpcXGRcMKy7_L1YhO0AMULqLDDVLFj5glh4TcJ2N5VnJedq1-_JKOxPqD1ni26UOQoWrW16G29KZ1_4Xxf2jX8TAq-4RJEHccdzgZVIO4F5B4MucMZGq8_jMCpiTUsUGDOAMA_AmjxIRHOtO5n6Pt0wofrKoAVhGh2sCTtaQf2Q",
-      "x5c": [
-        "MIIDPzCCAiegAwIBAgIQF+HRVxLHII9IlOoQk6BxcjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBzdHMuZGV2LmNlcnQuY29tMB4XDTE5MDIyMDEwMTA0M1oXDTM5MDIyMDEwMTkyOVowGzEZMBcGA1UEAwwQc3RzLmRldi5jZXJ0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALrt/hyuKS0RyR6BAcxYTOdekVsep8mxuckIx+DWyo3xkPHbSstQXBo6nzGhChfCjiuODWwMe67QSgjvRCjWJHhb3FMwc1XrruI1hutV2HU3pIL/g4fxY/NuORqHBJG7wWxVunMPvzefSVqlLogr2/hDn4XLrm1HK+OGtAEMjXHGDaXFxkXDCsu/y9WITtADFC6iww1SxY+YJYeE3CdjeVZyXnatfvySjsT6g9Z4tulDkKFq1tehtvSmdf+F8X9o1/EwKvuESRB3HHc4GVSDuBeQeDLnDGRqvP4zAqYk1LFBgzgDAPwJo8SERzrTuZ+j7dMKH6yqAFYRodrAk7WkH9kCAwEAAaN/MH0wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAtBgNVHREEJjAkghBzdHMuZGV2LmNlcnQuY29tghBzdHMuZGV2LmNlcnQuY29tMB0GA1UdDgQWBBQuyHxWP3je6jGMOmOiY+hz47r36jANBgkqhkiG9w0BAQsFAAOCAQEAKEHG7Ga6nb2XiHXDc69KsIJwbO80+LE8HVJojvITILz3juN6/FmK0HmogjU6cYST7m1MyxsVhQQNwJASZ6haBNuBbNzBXfyyfb4kr62t1oDLNwhctHaHaM4sJSf/xIw+YO+Qf7BtfRAVsbM05+QXIi2LycGrzELiXu7KFM0E1+T8UOZ2Qyv7OlCb/pWkYuDgE4w97ox0MhDpvgluxZLpRanOLUCVGrfFaij7gRAhjYPUY3vAEcD8JcFBz1XijU8ozRO6FaG4qg8/JCe+VgoWsMDj3sKB9g0ob6KCyG9L2bdk99PGgvXDQvMYCpkpZzG3XsxOINPd5p0gc209ZOoxTg=="
-      ],
-      "alg": "RS256"
-    } as JsonWebKey, {
-      "kty": "RSA",
-      "kid": "boop",
-      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
-      "e": "AQAB"
-    } as JsonWebKey, {
-      "kty": "RSA",
-      "use": "enc",
-      "kid": "boop",
-      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
-      "e": "AQAB"
-    } as JsonWebKey, {
-      "kty": "RSA",
-      "use": "sig",
-      "kid": "boop",
-      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
-      "e": "AQAB"
-    } as JsonWebKey];
   });
 
   it('should create', () => {
@@ -54,61 +85,87 @@ describe('JwkExtractor', () => {
     it('throws error if no keys are present in array', () => {
         expect(() => {
           service.extractJwk([]);
-        }).toThrowError();
+        }).toThrow(JwkExtractor.InvalidArgumentError);
       }
     );
 
-    it('throws error if keyId is present, but no key was matching', () => {
+    it('throws error if spec.kid is present, but no key was matching', () => {
         expect(() => {
-          service.extractJwk(keys, 'doot');
-        }).toThrowError();
+          service.extractJwk(keys, {kid: 'doot'});
+        }).toThrow(JwkExtractor.NoMatchingKeysError);
       }
     );
 
-    it('throws error if use is present, but no key was matching', () => {
+    it('throws error if spec.use is present, but no key was matching', () => {
         expect(() => {
-          service.extractJwk(keys, null, 'blorp');
-        }).toThrowError();
+          service.extractJwk(keys, {use: 'blorp'});
+        }).toThrow(JwkExtractor.NoMatchingKeysError);
       }
     );
 
-    it('throws error if multiple keys are present, and neither keyId nor use is present', () => {
+    it('throws error if multiple keys are present, and spec is not present', () => {
         expect(() => {
           service.extractJwk(keys);
-        }).toThrowError();
+        }).toThrow(JwkExtractor.SeveralMatchingKeysError);
       }
     );
 
-    it('returns first key matching keyId', () => {
-        const extracted = service.extractJwk(keys.slice(0, 1), '5626CE6A8F4F5FCD79C6642345282CA76D337548RS256');
+    it('returns first key matching spec.kid', () => {
+        const extracted = service.extractJwk(keys.slice(0, 1), {kid: '5626CE6A8F4F5FCD79C6642345282CA76D337548RS256'});
 
-        expect(extracted).toEqual(keys[0]);
+        expect(extracted).toEqual(key1);
 
-        const extracted2 = service.extractJwk(keys, 'boop');
+        const extracted2 = service.extractJwk(keys, {kid: 'boop'});
 
-        expect(extracted2).toEqual(keys[1]);
+        expect(extracted2).toEqual(key2);
       }
     );
 
-    it('returns first key that matches intended use if keyId is not present', () => {
-        const extracted = service.extractJwk(keys, null, 'sig');
+    it('returns first key that matches spec.use if spec.kid is not present', () => {
+        const extracted = service.extractJwk(keys, {use: 'sig'});
 
-        expect(extracted).toEqual(keys[0]);
+        expect(extracted).toEqual(key1);
 
-        const extracted2 = service.extractJwk(keys, null, 'enc');
+        const extracted2 = service.extractJwk(keys, {use: 'enc'});
 
-        expect(extracted2).toEqual(keys[2]);
+        expect(extracted2).toEqual(key3);
       }
     );
 
-    it('returns first key that matches the combination of intended use and keyId', () => {
-        const extracted = service.extractJwk(keys, 'boop', 'sig');
+    it('returns first key that matches the combination of spec.use and spec.kid', () => {
+        const extracted = service.extractJwk(keys, {kid: 'boop', use: 'sig'});
 
-        expect(extracted).toEqual(keys[3]);
+        expect(extracted).toEqual(key4);
 
-        const extracted2 = service.extractJwk(keys, 'boop', 'enc');
+        const extracted2 = service.extractJwk(keys, {kid: 'boop', use: 'enc'});
 
-        expect(extracted2).toEqual(keys[2]);
+        expect(extracted2).toEqual(key3);
+      }
+    );
+
+    it('returns first key that matches spec.kty', () => {
+        const extracted = service.extractJwk(keys, {kty: 'RSA'});
+
+        expect(extracted).toEqual(key1);
+
+        const extracted2 = service.extractJwk(keys, {kty: 'EC'});
+
+        expect(extracted2).toEqual(key6);
+      }
+    );
+
+    it('returns first key that matches the combination of spec.kty and other specs', () => {
+        const extracted = service.extractJwk(keys, {kty: 'RSA', use: 'enc'});
+
+        expect(extracted).toEqual(key3);
+
+        const extracted2 = service.extractJwk(keys, {kty: 'EC', use: 'sig'});
+
+        expect(extracted2).toEqual(key6);
+
+        const extracted3 = service.extractJwk(keys, {kty: 'EC', use: 'enc'});
+
+        expect(extracted3).toEqual(key7);
       }
     );
   });

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
@@ -28,6 +28,19 @@ describe('JwkExtractor', () => {
       "alg": "RS256"
     } as JsonWebKey, {
       "kty": "RSA",
+      "kid": "boop",
+      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+      "e": "AQAB"
+    } as JsonWebKey, {
+      "kty": "RSA",
+      "use": "enc",
+      "kid": "boop",
+      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+      "e": "AQAB"
+    } as JsonWebKey, {
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "boop",
       "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
       "e": "AQAB"
     } as JsonWebKey];
@@ -52,30 +65,50 @@ describe('JwkExtractor', () => {
       }
     );
 
-    it('throws error if multiple keys are present, and more than one match', () => {
-        const keysWithSameKid = [...keys].map((k) => {
-          k['kid'] = 'doot';
-
-          return k;
-        });
-
+    it('throws error if use is present, but no key was matching', () => {
         expect(() => {
-          service.extractJwk(keysWithSameKid, 'doot');
+          service.extractJwk(keys, null, 'blorp');
         }).toThrowError();
       }
     );
 
-    it('returns first key if it\'s the only one present and keyId is null', () => {
-        const extracted = service.extractJwk(keys.slice(0, 1));
-
-        expect(extracted).toEqual(keys[0]);
+    it('throws error if multiple keys are present, and neither keyId nor use is present', () => {
+        expect(() => {
+          service.extractJwk(keys);
+        }).toThrowError();
       }
     );
 
-    it('returns correct key if keyId is specified', () => {
+    it('returns first key matching keyId', () => {
         const extracted = service.extractJwk(keys.slice(0, 1), '5626CE6A8F4F5FCD79C6642345282CA76D337548RS256');
 
         expect(extracted).toEqual(keys[0]);
+
+        const extracted2 = service.extractJwk(keys, 'boop');
+
+        expect(extracted2).toEqual(keys[1]);
+      }
+    );
+
+    it('returns first key that matches intended use if keyId is not present', () => {
+        const extracted = service.extractJwk(keys, null, 'sig');
+
+        expect(extracted).toEqual(keys[0]);
+
+        const extracted2 = service.extractJwk(keys, null, 'enc');
+
+        expect(extracted2).toEqual(keys[2]);
+      }
+    );
+
+    it('returns first key that matches the combination of intended use and keyId', () => {
+        const extracted = service.extractJwk(keys, 'boop', 'sig');
+
+        expect(extracted).toEqual(keys[3]);
+
+        const extracted2 = service.extractJwk(keys, 'boop', 'enc');
+
+        expect(extracted2).toEqual(keys[2]);
       }
     );
   });

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { CryptoService } from '../utils/crypto/crypto-service';
+import { JwkExtractor } from './jwk.extractor';
+
+describe('JwkExtractor', () => {
+  let service: JwkExtractor;
+  let keys: JsonWebKey[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [JwkExtractor, CryptoService],
+    });
+  });
+
+  beforeEach(() => {
+    service = TestBed.inject(JwkExtractor);
+    keys = [{
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
+      "x5t": "VibOao9PX815xmQjRSgsp20zdUg",
+      "e": "AQAB",
+      "n": "uu3-HK4pLRHJHoEBzFhM516RWx6nybG5yQjH4NbKjfGQ8dtKy1BcGjqfMaEKF8KOK44NbAx7rtBKCO9EKNYkeFvcUzBzVeuu4jWG61XYdTekgv-Dh_Fj8245GocEkbvBbFW6cw-_N59JWqUuiCvb-EOfhcuubUcr44a0AQyNccYNpcXGRcMKy7_L1YhO0AMULqLDDVLFj5glh4TcJ2N5VnJedq1-_JKOxPqD1ni26UOQoWrW16G29KZ1_4Xxf2jX8TAq-4RJEHccdzgZVIO4F5B4MucMZGq8_jMCpiTUsUGDOAMA_AmjxIRHOtO5n6Pt0wofrKoAVhGh2sCTtaQf2Q",
+      "x5c": [
+        "MIIDPzCCAiegAwIBAgIQF+HRVxLHII9IlOoQk6BxcjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBzdHMuZGV2LmNlcnQuY29tMB4XDTE5MDIyMDEwMTA0M1oXDTM5MDIyMDEwMTkyOVowGzEZMBcGA1UEAwwQc3RzLmRldi5jZXJ0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALrt/hyuKS0RyR6BAcxYTOdekVsep8mxuckIx+DWyo3xkPHbSstQXBo6nzGhChfCjiuODWwMe67QSgjvRCjWJHhb3FMwc1XrruI1hutV2HU3pIL/g4fxY/NuORqHBJG7wWxVunMPvzefSVqlLogr2/hDn4XLrm1HK+OGtAEMjXHGDaXFxkXDCsu/y9WITtADFC6iww1SxY+YJYeE3CdjeVZyXnatfvySjsT6g9Z4tulDkKFq1tehtvSmdf+F8X9o1/EwKvuESRB3HHc4GVSDuBeQeDLnDGRqvP4zAqYk1LFBgzgDAPwJo8SERzrTuZ+j7dMKH6yqAFYRodrAk7WkH9kCAwEAAaN/MH0wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAtBgNVHREEJjAkghBzdHMuZGV2LmNlcnQuY29tghBzdHMuZGV2LmNlcnQuY29tMB0GA1UdDgQWBBQuyHxWP3je6jGMOmOiY+hz47r36jANBgkqhkiG9w0BAQsFAAOCAQEAKEHG7Ga6nb2XiHXDc69KsIJwbO80+LE8HVJojvITILz3juN6/FmK0HmogjU6cYST7m1MyxsVhQQNwJASZ6haBNuBbNzBXfyyfb4kr62t1oDLNwhctHaHaM4sJSf/xIw+YO+Qf7BtfRAVsbM05+QXIi2LycGrzELiXu7KFM0E1+T8UOZ2Qyv7OlCb/pWkYuDgE4w97ox0MhDpvgluxZLpRanOLUCVGrfFaij7gRAhjYPUY3vAEcD8JcFBz1XijU8ozRO6FaG4qg8/JCe+VgoWsMDj3sKB9g0ob6KCyG9L2bdk99PGgvXDQvMYCpkpZzG3XsxOINPd5p0gc209ZOoxTg=="
+      ],
+      "alg": "RS256"
+    } as JsonWebKey, {
+      "kty": "RSA",
+      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+      "e": "AQAB"
+    } as JsonWebKey];
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('extractJwk', () => {
+    it('throws error if no keys are present in array', () => {
+        expect(() => {
+          service.extractJwk([]);
+        }).toThrowError();
+      }
+    );
+
+    it('throws error if keyId is present, but no key was matching', () => {
+        expect(() => {
+          service.extractJwk(keys, 'doot');
+        }).toThrowError();
+      }
+    );
+
+    it('throws error if multiple keys are present, and more than one match', () => {
+        const keysWithSameKid = [...keys].map((k) => {
+          k['kid'] = 'doot';
+
+          return k;
+        });
+
+        expect(() => {
+          service.extractJwk(keysWithSameKid, 'doot');
+        }).toThrowError();
+      }
+    );
+
+    it('returns first key if it\'s the only one present and keyId is null', () => {
+        const extracted = service.extractJwk(keys.slice(0, 1));
+
+        expect(extracted).toEqual(keys[0]);
+      }
+    );
+
+    it('returns correct key if keyId is specified', () => {
+        const extracted = service.extractJwk(keys.slice(0, 1), '5626CE6A8F4F5FCD79C6642345282CA76D337548RS256');
+
+        expect(extracted).toEqual(keys[0]);
+      }
+    );
+  });
+});

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.spec.ts
@@ -64,7 +64,14 @@ describe('JwkExtractor', () => {
     "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
     "e": "AQAB"
   } as JsonWebKey;
-  let keys: JsonWebKey[] = [key1, key2, key3, key4, key5, key6, key7, key8];
+  const key9 = {
+    "kty": "EC",
+    "use": "sig",
+    "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  let keys: JsonWebKey[] = [key1, key2, key3, key4, key5, key6, key7, key8, key9];
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -103,6 +110,13 @@ describe('JwkExtractor', () => {
       }
     );
 
+    it('does not throw error if no key is matching when throwOnEmpty is false', () => {
+        const result = service.extractJwk(keys, {use: 'blorp'}, false);
+
+        expect(result.length).toEqual(0);
+      }
+    );
+
     it('throws error if multiple keys are present, and spec is not present', () => {
         expect(() => {
           service.extractJwk(keys);
@@ -110,62 +124,98 @@ describe('JwkExtractor', () => {
       }
     );
 
-    it('returns first key matching spec.kid', () => {
-        const extracted = service.extractJwk(keys.slice(0, 1), {kid: '5626CE6A8F4F5FCD79C6642345282CA76D337548RS256'});
+    it('returns array of keys matching spec.kid', () => {
+        const extracted = service.extractJwk(keys, {kid: '5626CE6A8F4F5FCD79C6642345282CA76D337548RS256'});
 
-        expect(extracted).toEqual(key1);
+        expect(extracted.length).toEqual(3);
+        expect(extracted).toContain(key1);
+        expect(extracted).toContain(key8);
+        expect(extracted).toContain(key9);
 
         const extracted2 = service.extractJwk(keys, {kid: 'boop'});
 
-        expect(extracted2).toEqual(key2);
+        expect(extracted2.length).toEqual(6);
+        expect(extracted2).toContain(key2);
+        expect(extracted2).toContain(key3);
+        expect(extracted2).toContain(key4);
+        expect(extracted2).toContain(key5);
+        expect(extracted2).toContain(key6);
+        expect(extracted2).toContain(key7);
       }
     );
 
-    it('returns first key that matches spec.use if spec.kid is not present', () => {
+    it('returns array of keys matching spec.use', () => {
         const extracted = service.extractJwk(keys, {use: 'sig'});
 
-        expect(extracted).toEqual(key1);
+        expect(extracted.length).toEqual(6);
+        expect(extracted).toContain(key1);
+        expect(extracted).toContain(key4);
+        expect(extracted).toContain(key5);
+        expect(extracted).toContain(key6);
+        expect(extracted).toContain(key8);
+        expect(extracted).toContain(key9);
 
         const extracted2 = service.extractJwk(keys, {use: 'enc'});
 
-        expect(extracted2).toEqual(key3);
+        expect(extracted2.length).toEqual(2);
+        expect(extracted2).toContain(key3);
+        expect(extracted2).toContain(key7);
       }
     );
 
-    it('returns first key that matches the combination of spec.use and spec.kid', () => {
+    it('returns array of keys matching the combination of spec.use and spec.kid', () => {
         const extracted = service.extractJwk(keys, {kid: 'boop', use: 'sig'});
 
-        expect(extracted).toEqual(key4);
+        expect(extracted.length).toEqual(3);
+        expect(extracted).toContain(key4);
+        expect(extracted).toContain(key5);
+        expect(extracted).toContain(key6);
 
         const extracted2 = service.extractJwk(keys, {kid: 'boop', use: 'enc'});
 
-        expect(extracted2).toEqual(key3);
+        expect(extracted2.length).toEqual(2);
+        expect(extracted2).toContain(key3);
+        expect(extracted2).toContain(key7);
       }
     );
 
-    it('returns first key that matches spec.kty', () => {
+    it('returns array of keys matching spec.kty', () => {
         const extracted = service.extractJwk(keys, {kty: 'RSA'});
 
-        expect(extracted).toEqual(key1);
+        expect(extracted.length).toEqual(5);
+        expect(extracted).toContain(key1);
+        expect(extracted).toContain(key2);
+        expect(extracted).toContain(key3);
+        expect(extracted).toContain(key4);
+        expect(extracted).toContain(key5);
 
         const extracted2 = service.extractJwk(keys, {kty: 'EC'});
 
-        expect(extracted2).toEqual(key6);
+        expect(extracted2.length).toEqual(4);
+        expect(extracted2).toContain(key6);
+        expect(extracted2).toContain(key7);
+        expect(extracted2).toContain(key8);
+        expect(extracted2).toContain(key9);
       }
     );
 
-    it('returns first key that matches the combination of spec.kty and other specs', () => {
+    it('returns array of keys matching the combination of spec.kty and spec.use', () => {
         const extracted = service.extractJwk(keys, {kty: 'RSA', use: 'enc'});
 
-        expect(extracted).toEqual(key3);
+        expect(extracted.length).toEqual(1);
+        expect(extracted).toContain(key3);
 
         const extracted2 = service.extractJwk(keys, {kty: 'EC', use: 'sig'});
 
-        expect(extracted2).toEqual(key6);
+        expect(extracted2.length).toEqual(3);
+        expect(extracted2).toContain(key6);
+        expect(extracted2).toContain(key8);
+        expect(extracted2).toContain(key9);
 
         const extracted3 = service.extractJwk(keys, {kty: 'EC', use: 'enc'});
 
-        expect(extracted3).toEqual(key7);
+        expect(extracted3.length).toEqual(1);
+        expect(extracted3).toContain(key7);
       }
     );
   });

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
@@ -2,31 +2,41 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class JwkExtractor {
-  extractJwk(keys: JsonWebKey[], keyId?: string, use?: string): JsonWebKey {
-    const isNil = (c: any): boolean => {
-      return null === c || undefined === c;
-    };
+  static InvalidArgumentError = {
+    name: JwkExtractor.buildErrorName('InvalidArgumentError'),
+    message: 'Array of keys was empty. Unable to extract'
+  };
 
+  static NoMatchingKeysError = {
+    name: JwkExtractor.buildErrorName('NoMatchingKeysError'),
+    message: 'No key found matching the spec'
+  };
+
+  static SeveralMatchingKeysError = {
+    name: JwkExtractor.buildErrorName('SeveralMatchingKeysError'),
+    message: 'More than one key found. Please use spec to filter'
+  };
+
+  private static buildErrorName(name: string): string {
+    return JwkExtractor.name + ': ' + name;
+  }
+
+  extractJwk(keys: JsonWebKey[], spec?: {kid?: string, use?: string, kty?: string}): JsonWebKey {
     if (0 === keys.length) {
-      throw new Error('Array of JsonWebKey was empty. Unable to extract');
+      throw JwkExtractor.InvalidArgumentError;
     }
 
-    let foundKeys = [...keys];
-
-    if (!isNil(keyId)) {
-      foundKeys = foundKeys.filter((k) => k['kid'] === keyId);
-    }
-
-    if (!isNil(use)) {
-      foundKeys = foundKeys.filter((k) => k['use'] === use);
-    }
+    let foundKeys = keys
+      .filter((k) => spec?.kid ? k['kid'] === spec.kid : true)
+      .filter((k) => spec?.use ? k['use'] === spec.use : true)
+      .filter((k) => spec?.kty ? k['kty'] === spec.kty : true);
 
     if (foundKeys.length === 0) {
-      throw new Error(`No JsonWebKey found`);
+      throw JwkExtractor.NoMatchingKeysError;
     }
 
-    if (foundKeys.length > 1 && isNil(keyId) && isNil(use)) {
-      throw new Error(`More than one JsonWebKey found`);
+    if (foundKeys.length > 1 && (null === spec || undefined === spec)) {
+      throw JwkExtractor.SeveralMatchingKeysError;
     }
 
     return foundKeys[0];

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@angular/core';
+
+@Injectable()
+export class JwkExtractor {
+  extractJwk(keys: JsonWebKey[], keyId?: string): JsonWebKey {
+    if (0 === keys.length) {
+      throw new Error('Array of JsonWebKey was empty. Unable to extract');
+    }
+
+    if (1 === keys.length && (null === keyId || undefined === keyId)) {
+      return keys[0];
+    }
+
+    const foundKeys = keys.filter((k) => k['kid'] === keyId);
+
+    if (foundKeys.length === 0) {
+      throw new Error(`No JsonWebKey found matching provided kid (${keyId})`);
+    }
+
+    if (foundKeys.length > 1) {
+      throw new Error(`More than one JsonWebKey found matching provided kid (${keyId})`);
+    }
+
+    return foundKeys[0];
+  }
+}

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
@@ -21,7 +21,7 @@ export class JwkExtractor {
     return JwkExtractor.name + ': ' + name;
   }
 
-  extractJwk(keys: JsonWebKey[], spec?: {kid?: string, use?: string, kty?: string}): JsonWebKey {
+  extractJwk(keys: JsonWebKey[], spec?: {kid?: string, use?: string, kty?: string}, throwOnEmpty = true): JsonWebKey[] {
     if (0 === keys.length) {
       throw JwkExtractor.InvalidArgumentError;
     }
@@ -31,7 +31,7 @@ export class JwkExtractor {
       .filter((k) => spec?.use ? k['use'] === spec.use : true)
       .filter((k) => spec?.kty ? k['kty'] === spec.kty : true);
 
-    if (foundKeys.length === 0) {
+    if (foundKeys.length === 0 && throwOnEmpty) {
       throw JwkExtractor.NoMatchingKeysError;
     }
 
@@ -39,6 +39,6 @@ export class JwkExtractor {
       throw JwkExtractor.SeveralMatchingKeysError;
     }
 
-    return foundKeys[0];
+    return foundKeys;
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
+++ b/projects/angular-auth-oidc-client/src/lib/extractors/jwk.extractor.ts
@@ -2,23 +2,31 @@ import { Injectable } from '@angular/core';
 
 @Injectable()
 export class JwkExtractor {
-  extractJwk(keys: JsonWebKey[], keyId?: string): JsonWebKey {
+  extractJwk(keys: JsonWebKey[], keyId?: string, use?: string): JsonWebKey {
+    const isNil = (c: any): boolean => {
+      return null === c || undefined === c;
+    };
+
     if (0 === keys.length) {
       throw new Error('Array of JsonWebKey was empty. Unable to extract');
     }
 
-    if (1 === keys.length && (null === keyId || undefined === keyId)) {
-      return keys[0];
+    let foundKeys = [...keys];
+
+    if (!isNil(keyId)) {
+      foundKeys = foundKeys.filter((k) => k['kid'] === keyId);
     }
 
-    const foundKeys = keys.filter((k) => k['kid'] === keyId);
+    if (!isNil(use)) {
+      foundKeys = foundKeys.filter((k) => k['use'] === use);
+    }
 
     if (foundKeys.length === 0) {
-      throw new Error(`No JsonWebKey found matching provided kid (${keyId})`);
+      throw new Error(`No JsonWebKey found`);
     }
 
-    if (foundKeys.length > 1) {
-      throw new Error(`More than one JsonWebKey found matching provided kid (${keyId})`);
+    if (foundKeys.length > 1 && isNil(keyId) && isNil(use)) {
+      throw new Error(`More than one JsonWebKey found`);
     }
 
     return foundKeys[0];

--- a/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
@@ -44,10 +44,10 @@ describe('JwkWindowCryptoService', () => {
     });
   });
 
-  beforeEach(async () => {
+  beforeEach(waitForAsync(() => {
     service = TestBed.inject(JwkWindowCryptoService);
-    await service.importVerificationKey(key3, alg).then((c) => cryptoKey = c);
-  });
+    service.importVerificationKey(key3, alg).then((c) => cryptoKey = c);
+  }));
 
   it('should create', () => {
     expect(service).toBeTruthy();

--- a/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
@@ -35,7 +35,6 @@ describe('JwkWindowCryptoService', () => {
     "use": "sig"
   } as JsonWebKey;
   const keys: JsonWebKey[] = [key1, key2, key3];
-  let cryptoKey!: CryptoKey;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -46,7 +45,6 @@ describe('JwkWindowCryptoService', () => {
 
   beforeEach(waitForAsync(() => {
     service = TestBed.inject(JwkWindowCryptoService);
-    service.importVerificationKey(key3, alg).then((c) => cryptoKey = c);
   }));
 
   it('should create', () => {
@@ -74,8 +72,12 @@ describe('JwkWindowCryptoService', () => {
         const signatureString = 'NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ';
         const signature: Uint8Array = base64url.parse(signatureString, { loose: true });
 
-        service.verifyKey(alg, cryptoKey, signature, headerAndPayloadString).then((value) => {
-          expect(value).toEqual(true);
+        service.importVerificationKey(key3, alg).then((c) => {
+          waitForAsync(() => {
+            service.verifyKey(alg, c, signature, headerAndPayloadString).then((value) => {
+              expect(value).toEqual(true);
+            });
+          });
         });
       })
     );

--- a/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
@@ -35,7 +35,7 @@ describe('JwkWindowCryptoService', () => {
     "use": "sig"
   } as JsonWebKey;
   const keys: JsonWebKey[] = [key1, key2, key3];
-  let cryptoKey;
+  let cryptoKey!: CryptoKey;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -44,9 +44,9 @@ describe('JwkWindowCryptoService', () => {
     });
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     service = TestBed.inject(JwkWindowCryptoService);
-    service.importVerificationKey(key3, alg).then((c) => cryptoKey = c);
+    await service.importVerificationKey(key3, alg).then((c) => cryptoKey = c);
   });
 
   it('should create', () => {

--- a/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
@@ -1,10 +1,41 @@
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { CryptoService } from '../utils/crypto/crypto-service';
 import { JwkWindowCryptoService } from './jwk-window-crypto.service';
+import { base64url } from 'rfc4648';
 
 describe('JwkWindowCryptoService', () => {
   let service: JwkWindowCryptoService;
-  let keys: JsonWebKey[];
+  const alg = {
+    name: 'RSASSA-PKCS1-v1_5',
+    hash: 'SHA-256',
+  };
+  const key1 = {
+    "kty": "RSA",
+    "use": "sig",
+    "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
+    "x5t": "VibOao9PX815xmQjRSgsp20zdUg",
+    "e": "AQAB",
+    "n": "uu3-HK4pLRHJHoEBzFhM516RWx6nybG5yQjH4NbKjfGQ8dtKy1BcGjqfMaEKF8KOK44NbAx7rtBKCO9EKNYkeFvcUzBzVeuu4jWG61XYdTekgv-Dh_Fj8245GocEkbvBbFW6cw-_N59JWqUuiCvb-EOfhcuubUcr44a0AQyNccYNpcXGRcMKy7_L1YhO0AMULqLDDVLFj5glh4TcJ2N5VnJedq1-_JKOxPqD1ni26UOQoWrW16G29KZ1_4Xxf2jX8TAq-4RJEHccdzgZVIO4F5B4MucMZGq8_jMCpiTUsUGDOAMA_AmjxIRHOtO5n6Pt0wofrKoAVhGh2sCTtaQf2Q",
+    "x5c": [
+      "MIIDPzCCAiegAwIBAgIQF+HRVxLHII9IlOoQk6BxcjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBzdHMuZGV2LmNlcnQuY29tMB4XDTE5MDIyMDEwMTA0M1oXDTM5MDIyMDEwMTkyOVowGzEZMBcGA1UEAwwQc3RzLmRldi5jZXJ0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALrt/hyuKS0RyR6BAcxYTOdekVsep8mxuckIx+DWyo3xkPHbSstQXBo6nzGhChfCjiuODWwMe67QSgjvRCjWJHhb3FMwc1XrruI1hutV2HU3pIL/g4fxY/NuORqHBJG7wWxVunMPvzefSVqlLogr2/hDn4XLrm1HK+OGtAEMjXHGDaXFxkXDCsu/y9WITtADFC6iww1SxY+YJYeE3CdjeVZyXnatfvySjsT6g9Z4tulDkKFq1tehtvSmdf+F8X9o1/EwKvuESRB3HHc4GVSDuBeQeDLnDGRqvP4zAqYk1LFBgzgDAPwJo8SERzrTuZ+j7dMKH6yqAFYRodrAk7WkH9kCAwEAAaN/MH0wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAtBgNVHREEJjAkghBzdHMuZGV2LmNlcnQuY29tghBzdHMuZGV2LmNlcnQuY29tMB0GA1UdDgQWBBQuyHxWP3je6jGMOmOiY+hz47r36jANBgkqhkiG9w0BAQsFAAOCAQEAKEHG7Ga6nb2XiHXDc69KsIJwbO80+LE8HVJojvITILz3juN6/FmK0HmogjU6cYST7m1MyxsVhQQNwJASZ6haBNuBbNzBXfyyfb4kr62t1oDLNwhctHaHaM4sJSf/xIw+YO+Qf7BtfRAVsbM05+QXIi2LycGrzELiXu7KFM0E1+T8UOZ2Qyv7OlCb/pWkYuDgE4w97ox0MhDpvgluxZLpRanOLUCVGrfFaij7gRAhjYPUY3vAEcD8JcFBz1XijU8ozRO6FaG4qg8/JCe+VgoWsMDj3sKB9g0ob6KCyG9L2bdk99PGgvXDQvMYCpkpZzG3XsxOINPd5p0gc209ZOoxTg=="
+    ],
+    "alg": "RS256"
+  } as JsonWebKey;
+  const key2 = {
+    "kty": "RSA",
+    "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+    "e": "AQAB"
+  } as JsonWebKey;
+  const key3 = {
+    "kty": "RSA",
+    "n": "u1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0_IzW7yWR7QkrmBL7jTKEn5u-qKhbwKfBstIs-bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW_VDL5AaWTg0nLVkjRo9z-40RQzuVaE8AkAFmxZzow3x-VJYKdjykkJ0iT9wCS0DRTXu269V264Vf_3jvredZiKRkgwlL9xNAwxXFg0x_XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC-9aGVd-Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmw",
+    "e": "AQAB",
+    "alg": "RS256",
+    "kid": "boop",
+    "use": "sig"
+  } as JsonWebKey;
+  const keys: JsonWebKey[] = [key1, key2, key3];
+  let cryptoKey;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -15,22 +46,7 @@ describe('JwkWindowCryptoService', () => {
 
   beforeEach(() => {
     service = TestBed.inject(JwkWindowCryptoService);
-    keys = [{
-      "kty": "RSA",
-      "use": "sig",
-      "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
-      "x5t": "VibOao9PX815xmQjRSgsp20zdUg",
-      "e": "AQAB",
-      "n": "uu3-HK4pLRHJHoEBzFhM516RWx6nybG5yQjH4NbKjfGQ8dtKy1BcGjqfMaEKF8KOK44NbAx7rtBKCO9EKNYkeFvcUzBzVeuu4jWG61XYdTekgv-Dh_Fj8245GocEkbvBbFW6cw-_N59JWqUuiCvb-EOfhcuubUcr44a0AQyNccYNpcXGRcMKy7_L1YhO0AMULqLDDVLFj5glh4TcJ2N5VnJedq1-_JKOxPqD1ni26UOQoWrW16G29KZ1_4Xxf2jX8TAq-4RJEHccdzgZVIO4F5B4MucMZGq8_jMCpiTUsUGDOAMA_AmjxIRHOtO5n6Pt0wofrKoAVhGh2sCTtaQf2Q",
-      "x5c": [
-        "MIIDPzCCAiegAwIBAgIQF+HRVxLHII9IlOoQk6BxcjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBzdHMuZGV2LmNlcnQuY29tMB4XDTE5MDIyMDEwMTA0M1oXDTM5MDIyMDEwMTkyOVowGzEZMBcGA1UEAwwQc3RzLmRldi5jZXJ0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALrt/hyuKS0RyR6BAcxYTOdekVsep8mxuckIx+DWyo3xkPHbSstQXBo6nzGhChfCjiuODWwMe67QSgjvRCjWJHhb3FMwc1XrruI1hutV2HU3pIL/g4fxY/NuORqHBJG7wWxVunMPvzefSVqlLogr2/hDn4XLrm1HK+OGtAEMjXHGDaXFxkXDCsu/y9WITtADFC6iww1SxY+YJYeE3CdjeVZyXnatfvySjsT6g9Z4tulDkKFq1tehtvSmdf+F8X9o1/EwKvuESRB3HHc4GVSDuBeQeDLnDGRqvP4zAqYk1LFBgzgDAPwJo8SERzrTuZ+j7dMKH6yqAFYRodrAk7WkH9kCAwEAAaN/MH0wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAtBgNVHREEJjAkghBzdHMuZGV2LmNlcnQuY29tghBzdHMuZGV2LmNlcnQuY29tMB0GA1UdDgQWBBQuyHxWP3je6jGMOmOiY+hz47r36jANBgkqhkiG9w0BAQsFAAOCAQEAKEHG7Ga6nb2XiHXDc69KsIJwbO80+LE8HVJojvITILz3juN6/FmK0HmogjU6cYST7m1MyxsVhQQNwJASZ6haBNuBbNzBXfyyfb4kr62t1oDLNwhctHaHaM4sJSf/xIw+YO+Qf7BtfRAVsbM05+QXIi2LycGrzELiXu7KFM0E1+T8UOZ2Qyv7OlCb/pWkYuDgE4w97ox0MhDpvgluxZLpRanOLUCVGrfFaij7gRAhjYPUY3vAEcD8JcFBz1XijU8ozRO6FaG4qg8/JCe+VgoWsMDj3sKB9g0ob6KCyG9L2bdk99PGgvXDQvMYCpkpZzG3XsxOINPd5p0gc209ZOoxTg=="
-      ],
-      "alg": "RS256"
-    } as JsonWebKey, {
-      "kty": "RSA",
-      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
-      "e": "AQAB"
-    } as JsonWebKey];
+    service.importVerificationKey(key3, alg).then((c) => cryptoKey = c);
   });
 
   it('should create', () => {
@@ -40,16 +56,26 @@ describe('JwkWindowCryptoService', () => {
   describe('importVerificationKey', () => {
     it('returns instance of CryptoKey when valid input is provided',
       waitForAsync(() => {
-        const alg = {
-          name: 'RSASSA-PKCS1-v1_5',
-          hash: 'SHA-256',
-        } as RsaHashedImportParams;
         const promises = keys.map((key) => service.importVerificationKey(key, alg));
 
         promises.map((promise) => {
           promise.then((value) => {
             expect(value).toBeInstanceOf(CryptoKey);
           });
+        });
+      })
+    );
+  });
+
+  describe('verifyKey', () => {
+    it('returns true when valid input is provided',
+      waitForAsync(() => {
+        const headerAndPayloadString = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWUsImlhdCI6MTUxNjIzOTAyMn0';
+        const signatureString = 'NHVaYe26MbtOYhSKkoKYdFVomg4i8ZJd8_-RU8VNbftc4TSMb4bXP3l3YlNWACwyXPGffz5aXHc6lty1Y2t4SWRqGteragsVdZufDn5BlnJl9pdR_kdVFUsra2rWKEofkZeIC4yWytE58sMIihvo9H1ScmmVwBcQP6XETqYd0aSHp1gOa9RdUPDvoXQ5oqygTqVtxaDr6wUFKrKItgBMzWIdNZ6y7O9E0DhEPTbE9rfBo6KTFsHAZnMg4k68CDp2woYIaXbmYTWcvbzIuHO7_37GT79XdIwkm95QJ7hYC9RiwrV7mesbY4PAahERJawntho0my942XheVLmGwLMBkQ';
+        const signature: Uint8Array = base64url.parse(signatureString, { loose: true });
+
+        service.verifyKey(alg, cryptoKey, signature, headerAndPayloadString).then((value) => {
+          expect(value).toEqual(true);
         });
       })
     );

--- a/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.spec.ts
@@ -1,0 +1,57 @@
+import { TestBed, waitForAsync } from '@angular/core/testing';
+import { CryptoService } from '../utils/crypto/crypto-service';
+import { JwkWindowCryptoService } from './jwk-window-crypto.service';
+
+describe('JwkWindowCryptoService', () => {
+  let service: JwkWindowCryptoService;
+  let keys: JsonWebKey[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [],
+      providers: [JwkWindowCryptoService, CryptoService],
+    });
+  });
+
+  beforeEach(() => {
+    service = TestBed.inject(JwkWindowCryptoService);
+    keys = [{
+      "kty": "RSA",
+      "use": "sig",
+      "kid": "5626CE6A8F4F5FCD79C6642345282CA76D337548RS256",
+      "x5t": "VibOao9PX815xmQjRSgsp20zdUg",
+      "e": "AQAB",
+      "n": "uu3-HK4pLRHJHoEBzFhM516RWx6nybG5yQjH4NbKjfGQ8dtKy1BcGjqfMaEKF8KOK44NbAx7rtBKCO9EKNYkeFvcUzBzVeuu4jWG61XYdTekgv-Dh_Fj8245GocEkbvBbFW6cw-_N59JWqUuiCvb-EOfhcuubUcr44a0AQyNccYNpcXGRcMKy7_L1YhO0AMULqLDDVLFj5glh4TcJ2N5VnJedq1-_JKOxPqD1ni26UOQoWrW16G29KZ1_4Xxf2jX8TAq-4RJEHccdzgZVIO4F5B4MucMZGq8_jMCpiTUsUGDOAMA_AmjxIRHOtO5n6Pt0wofrKoAVhGh2sCTtaQf2Q",
+      "x5c": [
+        "MIIDPzCCAiegAwIBAgIQF+HRVxLHII9IlOoQk6BxcjANBgkqhkiG9w0BAQsFADAbMRkwFwYDVQQDDBBzdHMuZGV2LmNlcnQuY29tMB4XDTE5MDIyMDEwMTA0M1oXDTM5MDIyMDEwMTkyOVowGzEZMBcGA1UEAwwQc3RzLmRldi5jZXJ0LmNvbTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBALrt/hyuKS0RyR6BAcxYTOdekVsep8mxuckIx+DWyo3xkPHbSstQXBo6nzGhChfCjiuODWwMe67QSgjvRCjWJHhb3FMwc1XrruI1hutV2HU3pIL/g4fxY/NuORqHBJG7wWxVunMPvzefSVqlLogr2/hDn4XLrm1HK+OGtAEMjXHGDaXFxkXDCsu/y9WITtADFC6iww1SxY+YJYeE3CdjeVZyXnatfvySjsT6g9Z4tulDkKFq1tehtvSmdf+F8X9o1/EwKvuESRB3HHc4GVSDuBeQeDLnDGRqvP4zAqYk1LFBgzgDAPwJo8SERzrTuZ+j7dMKH6yqAFYRodrAk7WkH9kCAwEAAaN/MH0wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMCBggrBgEFBQcDATAtBgNVHREEJjAkghBzdHMuZGV2LmNlcnQuY29tghBzdHMuZGV2LmNlcnQuY29tMB0GA1UdDgQWBBQuyHxWP3je6jGMOmOiY+hz47r36jANBgkqhkiG9w0BAQsFAAOCAQEAKEHG7Ga6nb2XiHXDc69KsIJwbO80+LE8HVJojvITILz3juN6/FmK0HmogjU6cYST7m1MyxsVhQQNwJASZ6haBNuBbNzBXfyyfb4kr62t1oDLNwhctHaHaM4sJSf/xIw+YO+Qf7BtfRAVsbM05+QXIi2LycGrzELiXu7KFM0E1+T8UOZ2Qyv7OlCb/pWkYuDgE4w97ox0MhDpvgluxZLpRanOLUCVGrfFaij7gRAhjYPUY3vAEcD8JcFBz1XijU8ozRO6FaG4qg8/JCe+VgoWsMDj3sKB9g0ob6KCyG9L2bdk99PGgvXDQvMYCpkpZzG3XsxOINPd5p0gc209ZOoxTg=="
+      ],
+      "alg": "RS256"
+    } as JsonWebKey, {
+      "kty": "RSA",
+      "n": "wq0vJv4Xl2xSQTN75_N4JeFHlHH80PytypJqyNrhWIp1P9Ur4-5QSiS8BI8PYSh0dQy4NMoj9YMRcyge3y81uCCwxouePiAGc0xPy6QkAOiinvV3KJEMtbppicOvZEzMXb3EqRM-9Twxbp2hhBAPSAhyL79Rwy4JuIQ6imaqL0NIEGv8_BOe_twMPOLGTJhepDO6kDs6O0qlLgPRHQVuKAz3afVby0C2myDLpo5YaI66arU9VXXGQtIp8MhBY9KbsGaYskejSWhSBOcwdtYMEo5rXWGGVnrHiSqq8mm-sVXLQBe5xPFBs4IQ_Gz4nspr05LEEbsHSwFyGq5D77XPxGUPDCq5ZVvON0yBizaHcJ-KA0Lw6uXtOH9-YyVGuaBynkrQEo3pP2iy1uWt-TiQPb8PMsCAdWZP-6R0QKHtjds9HmjIkgFTJSTIeETjNck_bB4ud79gZT-INikjPFTTeyQYk2jqxEJanVe3k0i_1vpskRpknJ7F2vTL45LAQkjWvczjWmHxGA5D4-1msuylXpY8Y4WxnUq6dRTEN29IRVCil9Mfp6JMsquFGTvJO0-Ffl0_suMZZl3uXNt23E9vGreByalWHivYmfpIor5Q5JaFKekRVV-U1KDBaeQQaHp_VqliUKImdUE9-GXNOIaBMjRvfy0nxsRe_q_dD6jc_GU",
+      "e": "AQAB"
+    } as JsonWebKey];
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('importVerificationKey', () => {
+    it('returns instance of CryptoKey when valid input is provided',
+      waitForAsync(() => {
+        const alg = {
+          name: 'RSASSA-PKCS1-v1_5',
+          hash: 'SHA-256',
+        } as RsaHashedImportParams;
+        const promises = keys.map((key) => service.importVerificationKey(key, alg));
+
+        promises.map((promise) => {
+          promise.then((value) => {
+            expect(value).toBeInstanceOf(CryptoKey);
+          });
+        });
+      })
+    );
+  });
+});

--- a/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@angular/core';
+import { CryptoService } from '../utils/crypto/crypto-service';
+
+@Injectable()
+export class JwkWindowCryptoService {
+  constructor(private readonly cryptoService: CryptoService) {}
+
+  importVerificationKey(key: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm): Promise<CryptoKey> {
+    return this.cryptoService.getCrypto().subtle.importKey('jwk', key, algorithm, false, ['verify']);
+  }
+}

--- a/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/jwk-window-crypto.service.ts
@@ -8,4 +8,8 @@ export class JwkWindowCryptoService {
   importVerificationKey(key: JsonWebKey, algorithm: AlgorithmIdentifier | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | AesKeyAlgorithm): Promise<CryptoKey> {
     return this.cryptoService.getCrypto().subtle.importKey('jwk', key, algorithm, false, ['verify']);
   }
+
+  verifyKey(verifyAlgorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams, cryptoKey: CryptoKey, signature: BufferSource, signingInput: string): Promise<boolean> {
+    return this.cryptoService.getCrypto().subtle.verify(verifyAlgorithm, cryptoKey, signature, new TextEncoder().encode(signingInput))
+  }
 }

--- a/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.spec.ts
@@ -6,6 +6,7 @@ import { CryptoService } from '../utils/crypto/crypto-service';
 import { TokenHelperService } from '../utils/tokenHelper/token-helper.service';
 import { JwtWindowCryptoService } from './jwt-window-crypto.service';
 import { TokenValidationService } from './token-validation.service';
+import { JwkExtractor } from '../extractors/jwk.extractor';
 
 describe('TokenValidationService', () => {
   let tokenValidationService: TokenValidationService;
@@ -25,6 +26,7 @@ describe('TokenValidationService', () => {
           provide: TokenHelperService,
           useClass: mockClass(TokenHelperService),
         },
+        JwkExtractor,
         JwtWindowCryptoService,
         CryptoService,
       ],
@@ -441,6 +443,34 @@ describe('TokenValidationService', () => {
         expect(valueFalse).toEqual(false);
       });
     }));
+
+    it('should return true if valid input is provided', () => {
+      const idToken = 'eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJodHRwczovL2V4YW1wbGUuY29tIiwic3ViIjoiMTIzNDU2IiwiYXVkIjoibXlfY2xpZW50X2lkIiwiZXhwIjoxMzExMjgxOTcwLCJpYXQiOjEzMTEyODA5NzAsIm5hbWUiOiJKYW5lIERvZSIsImdpdmVuX25hbWUiOiJKYW5lIiwiZmFtaWx5X25hbWUiOiJEb2UiLCJiaXJ0aGRhdGUiOiIxOTkwLTEwLTMxIiwiZW1haWwiOiJqYW5lZG9lQGV4YW1wbGUuY29tIiwicGljdHVyZSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vamFuZWRvZS9tZS5qcGcifQ.SY0ilps7yKYmYCc41zNOatfmAFhOtDYwuIT80qrHMl_4FEO2WFWSv-aDl4QfTSKY9A6MMP6xy0Z_8Kk7NeRwIV7FVScMLnPvVzs9pxza0e_rl6hmZLb5P5n4AEINwn46X9XmRB5W3EZO_x2LG65_g3NZFiPrzOC1Fs_6taJl7TfI8lOveYDoJyXCWYQMS3Oh5MM9S8W-Hc29_qJLH-kixm1S01qoICRPDGMRwhtAu1DHjwWQp9Ycfz6g3uyb7N1imBvI49t1CwWy02_mQ3g-7e7bOP1Ax2kgrwnJgsVBDULnyCZG9PE8T0CHZl_fErZtvbJJ0jdoZ1fyr48906am2w';
+      const key = {
+        "kty": "RSA",
+        "n": "u1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0_IzW7yWR7QkrmBL7jTKEn5u-qKhbwKfBstIs-bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW_VDL5AaWTg0nLVkjRo9z-40RQzuVaE8AkAFmxZzow3x-VJYKdjykkJ0iT9wCS0DRTXu269V264Vf_3jvredZiKRkgwlL9xNAwxXFg0x_XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC-9aGVd-Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmw",
+        "e": "AQAB",
+        "alg": "RS256",
+        "kid": "boop",
+        "use": "sig"
+      };
+      const jwtKeys = {
+        keys: [
+          key
+        ]
+      };
+
+      spyOn(tokenHelperService, 'getHeaderFromToken').and.returnValue({
+        "alg": "RS256",
+        "typ": "JWT"
+      });
+
+      const valueTrue$ = tokenValidationService.validateSignatureIdToken(idToken, jwtKeys, { configId: 'configId1' });
+
+      valueTrue$.subscribe((valueTrue) => {
+        expect(valueTrue).toEqual(true);
+      });
+    });
   });
 
   describe('validateIdTokenAtHash', () => {

--- a/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.spec.ts
@@ -6,6 +6,7 @@ import { CryptoService } from '../utils/crypto/crypto-service';
 import { TokenHelperService } from '../utils/tokenHelper/token-helper.service';
 import { JwtWindowCryptoService } from './jwt-window-crypto.service';
 import { TokenValidationService } from './token-validation.service';
+import { JwkWindowCryptoService } from './jwk-window-crypto.service';
 import { JwkExtractor } from '../extractors/jwk.extractor';
 
 describe('TokenValidationService', () => {
@@ -27,6 +28,7 @@ describe('TokenValidationService', () => {
           useClass: mockClass(TokenHelperService),
         },
         JwkExtractor,
+        JwkWindowCryptoService,
         JwtWindowCryptoService,
         CryptoService,
       ],

--- a/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
@@ -5,7 +5,6 @@ import { from, Observable, of } from 'rxjs';
 import { map, mergeMap, tap } from 'rxjs/operators';
 import { OpenIdConfiguration } from '../config/openid-configuration';
 import { LoggerService } from '../logging/logger.service';
-import { CryptoService } from '../utils/crypto/crypto-service';
 import { TokenHelperService } from '../utils/tokenHelper/token-helper.service';
 import { JwtWindowCryptoService } from './jwt-window-crypto.service';
 import { JwkExtractor } from '../extractors/jwk.extractor';
@@ -67,7 +66,6 @@ export class TokenValidationService {
     private readonly jwkExtractor: JwkExtractor,
     private readonly jwkWindowCryptoService: JwkWindowCryptoService,
     private readonly jwtWindowCryptoService: JwtWindowCryptoService,
-    private readonly cryptoService: CryptoService,
     @Inject(DOCUMENT) private readonly document: any
   ) {}
 

--- a/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/validation/token-validation.service.ts
@@ -356,6 +356,7 @@ export class TokenValidationService {
     let alg: string = headerData.alg;
 
     let keys: JsonWebKey[] = jwtkeys.keys;
+    let foundKeys: JsonWebKey[];
     let key: JsonWebKey;
 
     if (!this.keyAlgorithms.includes(alg)) {
@@ -368,9 +369,17 @@ export class TokenValidationService {
     const use = 'sig';
 
     try {
-      key = kid ?
-        this.jwkExtractor.extractJwk(keys, {kid, kty, use}) :
-        this.jwkExtractor.extractJwk(keys, {kty, use});
+      foundKeys = kid ?
+        this.jwkExtractor.extractJwk(keys, {kid, kty, use}, false) :
+        this.jwkExtractor.extractJwk(keys, {kty, use}, false);
+
+      if (foundKeys.length === 0) {
+        foundKeys = kid ?
+          this.jwkExtractor.extractJwk(keys, {kid, kty}) :
+          this.jwkExtractor.extractJwk(keys, {kty});
+      }
+
+      key = foundKeys[0];
     } catch (e: any) {
       this.loggerService.logError(configuration, e);
 


### PR DESCRIPTION
**Fixes**: #1339 
**Tests passing?**: Affirmative

- Added `JwkExtractor`, a service that conforms with [RFC7517](https://www.rfc-editor.org/rfc/rfc7517) when it comes to the `kty`, `kid` and `use` claims.
- Added `JwkWindowCryptoService`, a "sibling" to `JwtWindowCryptoService`
- Added an extra test case for `TokenValidationService.validateSignatureIdToken` to test for a successful result

**Description**:
The `TokenValidationService` now tries to extract keys based on `kty` and `use`, and `kid` if it exists. If no matches are found, it tries to extract keys based on `kty`, and `kid` if it exists (`kty` is required by the spec). If no matches are found, a sensible error is thrown. If matches are found, the first one is chosen, regardless of the number of matches.

Tested `sample-code-flow-refresh-tokens` successfully with https://offeringsolutions-sts.azurewebsites.net when running the project locally.

Let me know if anything is missing or not up to expectations, and I'll update the PR asap :+1: 