### PR TITLE
Fix checkSession messageHandler configuration

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -191,8 +191,8 @@ export class CheckSessionService {
     }
   }
 
-  private bindMessageEventToIframe(configId: string): void {
-    const iframeMessageEvent = this.messageHandler.bind(this, configId);
+  private bindMessageEventToIframe(configuration: OpenIdConfiguration): void {
+    const iframeMessageEvent = this.messageHandler.bind(this, configuration);
 
     this.document.defaultView.addEventListener('message', iframeMessageEvent, false);
   }
@@ -202,9 +202,8 @@ export class CheckSessionService {
 
     if (!existingIframe) {
       const frame = this.iFrameService.addIFrameToWindowBody(IFRAME_FOR_CHECK_SESSION_IDENTIFIER, configuration);
-      const { configId } = configuration;
 
-      this.bindMessageEventToIframe(configId);
+      this.bindMessageEventToIframe(configuration);
 
       return frame;
     }


### PR DESCRIPTION
`messageHandler` need `OpenIdConfiguration` type in first parameter, but `configId: string` was passed in `this.messageHandler.bind`, so `authWellKnownEndPoints` return null value.