### PR TITLE
Change from 'as string' to 'toString()' in validateUserDataSubIdToken

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/user-data/user.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/user-data/user.service.ts
@@ -153,7 +153,7 @@ export class UserService {
       return false;
     }
 
-    if ((idTokenSub as string) !== (userDataSub as string)) {
+    if ((idTokenSub.toString()) !== (userDataSub.toString())) {
       this.loggerService.logDebug(currentConfiguration, 'validateUserDataSubIdToken failed', idTokenSub, userDataSub);
 
       return false;


### PR DESCRIPTION
I had an issue where I got the error 'User data sub does not match sub in id_token'.
In my small C# / TypeScript application I use an integer as user id and I think it has to do with the OpenidDict library creating different jwt-tokens.
Sometimes it uses a string in the sub-claim and sometimes it uses a number.

For me it was easier to track down the validation in the TypeScript library and I found a small problem with the token-sub validation.
The 'as string' in TypeScript does not convert a number to a string, it's still a number. So the comparison in validateUserDataSubIdToken my fail if idTokenSub is a string and userDataSub is a number.

Is this the result of a bug in TypeScript? I'm using TypeScript 4.9.5