### PR TITLE
docs: sort migrations from new to old

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/migrations/v10-to-v11.md
+++ b/docs/site/angular-auth-oidc-client/docs/migrations/v10-to-v11.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 100
 ---
 
 # Version 10 to 11
@@ -10,7 +10,8 @@ sidebar_position: 1
 
 ```ts
 export function loadConfig(oidcConfigService: OidcConfigService) {
-  return () => oidcConfigService.load_using_stsServer('https://localhost:44318');
+  return () =>
+    oidcConfigService.load_using_stsServer('https://localhost:44318');
 }
 
 @NgModule({
@@ -36,31 +37,39 @@ export function loadConfig(oidcConfigService: OidcConfigService) {
   bootstrap: [AppComponent],
 })
 export class AppModule {
-  constructor(private oidcSecurityService: OidcSecurityService, private oidcConfigService: OidcConfigService) {
-    this.oidcConfigService.onConfigurationLoaded.subscribe((configResult: ConfigResult) => {
-      const config: OpenIdConfiguration = {
-        stsServer: 'https://localhost:44318',
-        redirect_url: 'https://localhost:44395',
-        client_id: 'angularclient2',
-        response_type: 'code',
-        scope: 'dataEventRecords openid profile email',
-        post_logout_redirect_uri: 'https://localhost:44395/unauthorized',
-        start_checksession: false,
-        silent_renew: true,
-        silent_renew_url: 'https://localhost:44395/silent-renew.html',
-        post_login_route: '/dm',
-        forbidden_route: '/unauthorized',
-        unauthorized_route: '/unauthorized',
-        log_console_warning_active: true,
-        log_console_debug_active: false,
-        max_id_token_iat_offset_allowed_in_seconds: 10,
-        history_cleanup_off: true,
-        // iss_validation_off: false
-        // disable_iat_offset_validation: true
-      };
+  constructor(
+    private oidcSecurityService: OidcSecurityService,
+    private oidcConfigService: OidcConfigService
+  ) {
+    this.oidcConfigService.onConfigurationLoaded.subscribe(
+      (configResult: ConfigResult) => {
+        const config: OpenIdConfiguration = {
+          stsServer: 'https://localhost:44318',
+          redirect_url: 'https://localhost:44395',
+          client_id: 'angularclient2',
+          response_type: 'code',
+          scope: 'dataEventRecords openid profile email',
+          post_logout_redirect_uri: 'https://localhost:44395/unauthorized',
+          start_checksession: false,
+          silent_renew: true,
+          silent_renew_url: 'https://localhost:44395/silent-renew.html',
+          post_login_route: '/dm',
+          forbidden_route: '/unauthorized',
+          unauthorized_route: '/unauthorized',
+          log_console_warning_active: true,
+          log_console_debug_active: false,
+          max_id_token_iat_offset_allowed_in_seconds: 10,
+          history_cleanup_off: true,
+          // iss_validation_off: false
+          // disable_iat_offset_validation: true
+        };
 
-      this.oidcSecurityService.setupModule(config, configResult.authWellknownEndpoints);
-    });
+        this.oidcSecurityService.setupModule(
+          config,
+          configResult.authWellknownEndpoints
+        );
+      }
+    );
   }
 }
 ```
@@ -115,10 +124,16 @@ export class AppModule {}
 ```ts
 // imports
 import { NgModule, APP_INITIALIZER } from '@angular/core';
-import { AuthModule, OidcConfigService, ConfigResult, OpenIdConfiguration } from 'angular-auth-oidc-client';
+import {
+  AuthModule,
+  OidcConfigService,
+  ConfigResult,
+  OpenIdConfiguration,
+} from 'angular-auth-oidc-client';
 
 export function loadConfig(oidcConfigService: OidcConfigService) {
-  return () => oidcConfigService.load(`${window.location.origin}/api/ClientAppSettings`);
+  return () =>
+    oidcConfigService.load(`${window.location.origin}/api/ClientAppSettings`);
 }
 @NgModule({
   imports: [
@@ -144,31 +159,44 @@ export function loadConfig(oidcConfigService: OidcConfigService) {
   bootstrap: [AppComponent],
 })
 export class AppModule {
-  constructor(private oidcSecurityService: OidcSecurityService, private oidcConfigService: OidcConfigService) {
-    this.oidcConfigService.onConfigurationLoaded.subscribe((configResult: ConfigResult) => {
-      const config: OpenIdConfiguration = {
-        stsServer: configResult.customConfig.stsServer,
-        redirect_url: configResult.customConfig.redirect_url,
-        client_id: configResult.customConfig.client_id,
-        response_type: configResult.customConfig.response_type,
-        scope: configResult.customConfig.scope,
-        post_logout_redirect_uri: configResult.customConfig.post_logout_redirect_uri,
-        start_checksession: configResult.customConfig.start_checksession,
-        silent_renew: configResult.customConfig.silent_renew,
-        silent_renew_url: 'https://localhost:44311/silent-renew.html',
-        post_login_route: configResult.customConfig.startup_route,
-        forbidden_route: configResult.customConfig.forbidden_route,
-        unauthorized_route: configResult.customConfig.unauthorized_route,
-        log_console_warning_active: configResult.customConfig.log_console_warning_active,
-        log_console_debug_active: configResult.customConfig.log_console_debug_active,
-        max_id_token_iat_offset_allowed_in_seconds: configResult.customConfig.max_id_token_iat_offset_allowed_in_seconds,
-        history_cleanup_off: true,
-        // iss_validation_off: false
-        // disable_iat_offset_validation: true
-      };
+  constructor(
+    private oidcSecurityService: OidcSecurityService,
+    private oidcConfigService: OidcConfigService
+  ) {
+    this.oidcConfigService.onConfigurationLoaded.subscribe(
+      (configResult: ConfigResult) => {
+        const config: OpenIdConfiguration = {
+          stsServer: configResult.customConfig.stsServer,
+          redirect_url: configResult.customConfig.redirect_url,
+          client_id: configResult.customConfig.client_id,
+          response_type: configResult.customConfig.response_type,
+          scope: configResult.customConfig.scope,
+          post_logout_redirect_uri:
+            configResult.customConfig.post_logout_redirect_uri,
+          start_checksession: configResult.customConfig.start_checksession,
+          silent_renew: configResult.customConfig.silent_renew,
+          silent_renew_url: 'https://localhost:44311/silent-renew.html',
+          post_login_route: configResult.customConfig.startup_route,
+          forbidden_route: configResult.customConfig.forbidden_route,
+          unauthorized_route: configResult.customConfig.unauthorized_route,
+          log_console_warning_active:
+            configResult.customConfig.log_console_warning_active,
+          log_console_debug_active:
+            configResult.customConfig.log_console_debug_active,
+          max_id_token_iat_offset_allowed_in_seconds:
+            configResult.customConfig
+              .max_id_token_iat_offset_allowed_in_seconds,
+          history_cleanup_off: true,
+          // iss_validation_off: false
+          // disable_iat_offset_validation: true
+        };
 
-      this.oidcSecurityService.setupModule(config, configResult.authWellknownEndpoints);
-    });
+        this.oidcSecurityService.setupModule(
+          config,
+          configResult.authWellknownEndpoints
+        );
+      }
+    );
   }
 }
 ```
@@ -181,29 +209,35 @@ import { HttpClient, HttpClientModule } from '@angular/common/http';
 import { AuthModule, OidcConfigService } from 'angular-auth-oidc-client';
 import { map, switchMap } from 'rxjs/operators';
 
-export function configureAuth(oidcConfigService: OidcConfigService, httpClient: HttpClient) {
-  const setupAction$ = httpClient.get<any>(`${window.location.origin}/api/ClientAppSettings`).pipe(
-    map((customConfig) => {
-      return {
-        stsServer: customConfig.stsServer,
-        redirectUrl: customConfig.redirect_url,
-        clientId: customConfig.client_id,
-        responseType: customConfig.response_type,
-        scope: customConfig.scope,
-        postLogoutRedirectUri: customConfig.post_logout_redirect_uri,
-        startCheckSession: customConfig.start_checksession,
-        silentRenew: true,
-        silentRenewUrl: customConfig.redirect_url + '/silent-renew.html',
-        postLoginRoute: customConfig.startup_route,
-        forbiddenRoute: customConfig.forbidden_route,
-        unauthorizedRoute: customConfig.unauthorized_route,
-        logLevel: 0, // LogLevel.Debug, // customConfig.logLevel
-        maxIdTokenIatOffsetAllowedInSeconds: customConfig.max_id_token_iat_offset_allowed_in_seconds,
-        historyCleanupOff: true,
-      };
-    }),
-    switchMap((config) => oidcConfigService.withConfig(config))
-  );
+export function configureAuth(
+  oidcConfigService: OidcConfigService,
+  httpClient: HttpClient
+) {
+  const setupAction$ = httpClient
+    .get<any>(`${window.location.origin}/api/ClientAppSettings`)
+    .pipe(
+      map((customConfig) => {
+        return {
+          stsServer: customConfig.stsServer,
+          redirectUrl: customConfig.redirect_url,
+          clientId: customConfig.client_id,
+          responseType: customConfig.response_type,
+          scope: customConfig.scope,
+          postLogoutRedirectUri: customConfig.post_logout_redirect_uri,
+          startCheckSession: customConfig.start_checksession,
+          silentRenew: true,
+          silentRenewUrl: customConfig.redirect_url + '/silent-renew.html',
+          postLoginRoute: customConfig.startup_route,
+          forbiddenRoute: customConfig.forbidden_route,
+          unauthorizedRoute: customConfig.unauthorized_route,
+          logLevel: 0, // LogLevel.Debug, // customConfig.logLevel
+          maxIdTokenIatOffsetAllowedInSeconds:
+            customConfig.max_id_token_iat_offset_allowed_in_seconds,
+          historyCleanupOff: true,
+        };
+      }),
+      switchMap((config) => oidcConfigService.withConfig(config))
+    );
 
   return () => setupAction$.toPromise();
 }
@@ -259,9 +293,11 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.isAuthorizedSubscription = this.oidcSecurityService.getIsAuthorized().subscribe((isAuthorized: boolean) => {
-      this.isAuthorized = isAuthorized;
-    });
+    this.isAuthorizedSubscription = this.oidcSecurityService
+      .getIsAuthorized()
+      .subscribe((isAuthorized: boolean) => {
+        this.isAuthorized = isAuthorized;
+      });
   }
 
   ngOnDestroy(): void {
@@ -272,7 +308,9 @@ export class AppComponent implements OnInit, OnDestroy {
 
   private doCallbackLogicIfRequired() {
     // Will do a callback, if the url has a code and state parameter.
-    this.oidcSecurityService.authorizedCallbackWithCode(window.location.toString());
+    this.oidcSecurityService.authorizedCallbackWithCode(
+      window.location.toString()
+    );
   }
 }
 ```
@@ -297,7 +335,11 @@ export class AppComponent implements OnInit {
   ngOnInit() {
     this.isAuthenticated$ = this.oidcSecurityService.isAuthenticated$;
 
-    this.oidcSecurityService.checkAuth().subscribe((isAuthenticated) => console.log('app authenticated', isAuthenticated));
+    this.oidcSecurityService
+      .checkAuth()
+      .subscribe((isAuthenticated) =>
+        console.log('app authenticated', isAuthenticated)
+      );
   }
 }
 ```
@@ -307,17 +349,21 @@ export class AppComponent implements OnInit {
 ### Old
 
 ```ts
-this.oidcSecurityService.getIsAuthorized().subscribe((isAuthenticated: boolean) => {
-  //  work with `isAuthenticated`
-});
+this.oidcSecurityService
+  .getIsAuthorized()
+  .subscribe((isAuthenticated: boolean) => {
+    //  work with `isAuthenticated`
+  });
 ```
 
 ### New
 
 ```ts
-this.oidcSecurityService.isAuthenticated$.subscribe((isAuthenticated: boolean) => {
-  // work with `isAuthenticated`
-});
+this.oidcSecurityService.isAuthenticated$.subscribe(
+  (isAuthenticated: boolean) => {
+    // work with `isAuthenticated`
+  }
+);
 ```
 
 ## User data

--- a/docs/site/angular-auth-oidc-client/docs/migrations/v11-to-v12.md
+++ b/docs/site/angular-auth-oidc-client/docs/migrations/v11-to-v12.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 99
 ---
 
 # Version 11 to 12
@@ -77,10 +77,17 @@ Old
 ```ts
 import { HttpClient } from '@angular/common/http';
 import { APP_INITIALIZER, NgModule } from '@angular/core';
-import { AuthModule, OidcConfigService, OidcSecurityService } from 'angular-auth-oidc-client';
+import {
+  AuthModule,
+  OidcConfigService,
+  OidcSecurityService,
+} from 'angular-auth-oidc-client';
 import { map, switchMap } from 'rxjs/operators';
 
-export function configureAuth(oidcConfigService: OidcConfigService, httpClient: HttpClient) {
+export function configureAuth(
+  oidcConfigService: OidcConfigService,
+  httpClient: HttpClient
+) {
   const setupAction$ = httpClient.get<any>(`https://...`).pipe(
     map((customConfig) => {
       return {
@@ -115,7 +122,11 @@ New
 ```ts
 import { HttpClient } from '@angular/common/http';
 import { NgModule } from '@angular/core';
-import { AuthModule, StsConfigHttpLoader, StsConfigLoader } from 'angular-auth-oidc-client';
+import {
+  AuthModule,
+  StsConfigHttpLoader,
+  StsConfigLoader,
+} from 'angular-auth-oidc-client';
 import { map } from 'rxjs/operators';
 
 export const httpLoaderFactory = (httpClient: HttpClient) => {
@@ -237,7 +248,9 @@ New:
 ```ts
 export interface OpenIdConfiguration {
   customParamsAuthRequest?: { [key: string]: string | number | boolean };
-  customParamsRefreshTokenRequest?: { [key: string]: string | number | boolean };
+  customParamsRefreshTokenRequest?: {
+    [key: string]: string | number | boolean;
+  };
   customParamsEndSessionRequest?: { [key: string]: string | number | boolean };
   customParamsCodeRequest?: { [key: string]: string | number | boolean };
   // ...
@@ -326,9 +339,13 @@ this.oidcSecurityService.checkAuth().subscribe(({ isAuthenticated }) => {});
 Or
 
 ```ts
-this.oidcSecurityService.checkAuth().subscribe(({ isAuthenticated, userData, accessToken, idToken, configId }) => {
-  // ...use data
-});
+this.oidcSecurityService
+  .checkAuth()
+  .subscribe(
+    ({ isAuthenticated, userData, accessToken, idToken, configId }) => {
+      // ...use data
+    }
+  );
 ```
 
 ### `checkAuthIncludingServer()` returning `LoginResponse` instead of boolean
@@ -346,7 +363,9 @@ Same return value applies for `forceRefreshSession()`.
 Old:
 
 ```ts
-this.oidcSecurityService.forceRefreshSession().subscribe((isAuthenticated) => {});
+this.oidcSecurityService
+  .forceRefreshSession()
+  .subscribe((isAuthenticated) => {});
 ```
 
 New:
@@ -366,7 +385,9 @@ this.oidcSecurityService.isAuthenticated$.subscribe((isAuthenticated) => {});
 New:
 
 ```ts
-this.oidcSecurityService.isAuthenticated$.subscribe(({ isAuthenticated, allConfigsAuthenticated }) => {});
+this.oidcSecurityService.isAuthenticated$.subscribe(
+  ({ isAuthenticated, allConfigsAuthenticated }) => {}
+);
 ```
 
 ### `userData$` returning `UserDataResult` instead of `any` only
@@ -481,9 +502,16 @@ export interface AuthorizationResult {
 ```ts
 this.eventService
   .registerForEvents()
-  .pipe(filter((notification) => notification.type === EventTypes.NewAuthorizationResult))
+  .pipe(
+    filter(
+      (notification) => notification.type === EventTypes.NewAuthorizationResult
+    )
+  )
   .subscribe((result: OidcClientNotification<AuthorizationResult>) => {
-    console.log('isAuthenticated', result.value.authorizationState === AuthorizedState.Authorized);
+    console.log(
+      'isAuthenticated',
+      result.value.authorizationState === AuthorizedState.Authorized
+    );
   });
 ```
 
@@ -500,7 +528,11 @@ export interface AuthStateResult {
 ```ts
 this.eventService
   .registerForEvents()
-  .pipe(filter((notification) => notification.type === EventTypes.NewAuthenticationResult))
+  .pipe(
+    filter(
+      (notification) => notification.type === EventTypes.NewAuthenticationResult
+    )
+  )
   .subscribe((result: OidcClientNotification<AuthStateResult>) => {
     console.log('isAuthenticated', result.isAuthenticated);
   });
@@ -515,7 +547,11 @@ Old:
 ```ts
 this.eventService
   .registerForEvents()
-  .pipe(filter((notification) => notification.type === EventTypes.NewAuthorizationResult))
+  .pipe(
+    filter(
+      (notification) => notification.type === EventTypes.NewAuthorizationResult
+    )
+  )
   .subscribe((result: OidcClientNotification<AuthorizationResult>) => {});
 ```
 
@@ -524,7 +560,11 @@ New:
 ```ts
 this.eventService
   .registerForEvents()
-  .pipe(filter((notification) => notification.type === EventTypes.NewAuthenticationResult))
+  .pipe(
+    filter(
+      (notification) => notification.type === EventTypes.NewAuthenticationResult
+    )
+  )
   .subscribe((result: OidcClientNotification<AuthStateResult>) => {});
 ```
 
@@ -542,11 +582,20 @@ import { AutoLoginGuard } from 'angular-auth-oidc-client';
 const appRoutes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'home' },
   { path: 'home', component: HomeComponent, canActivate: [AutoLoginGuard] },
-  { path: 'protected', component: ProtectedComponent, canActivate: [AutoLoginGuard] },
-  { path: 'forbidden', component: ForbiddenComponent, canActivate: [AutoLoginGuard] },
+  {
+    path: 'protected',
+    component: ProtectedComponent,
+    canActivate: [AutoLoginGuard],
+  },
+  {
+    path: 'forbidden',
+    component: ForbiddenComponent,
+    canActivate: [AutoLoginGuard],
+  },
   {
     path: 'customers',
-    loadChildren: () => import('./customers/customers.module').then((m) => m.CustomersModule),
+    loadChildren: () =>
+      import('./customers/customers.module').then((m) => m.CustomersModule),
     canLoad: [AutoLoginGuard],
   },
   { path: 'unauthorized', component: UnauthorizedComponent },
@@ -560,12 +609,25 @@ import { AutoLoginAllRoutesGuard } from 'angular-auth-oidc-client';
 
 const appRoutes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'home' },
-  { path: 'home', component: HomeComponent, canActivate: [AutoLoginAllRoutesGuard] },
-  { path: 'protected', component: ProtectedComponent, canActivate: [AutoLoginAllRoutesGuard] },
-  { path: 'forbidden', component: ForbiddenComponent, canActivate: [AutoLoginAllRoutesGuard] },
+  {
+    path: 'home',
+    component: HomeComponent,
+    canActivate: [AutoLoginAllRoutesGuard],
+  },
+  {
+    path: 'protected',
+    component: ProtectedComponent,
+    canActivate: [AutoLoginAllRoutesGuard],
+  },
+  {
+    path: 'forbidden',
+    component: ForbiddenComponent,
+    canActivate: [AutoLoginAllRoutesGuard],
+  },
   {
     path: 'customers',
-    loadChildren: () => import('./customers/customers.module').then((m) => m.CustomersModule),
+    loadChildren: () =>
+      import('./customers/customers.module').then((m) => m.CustomersModule),
     canLoad: [AutoLoginAllRoutesGuard],
   },
   { path: 'unauthorized', component: UnauthorizedComponent },
@@ -580,11 +642,20 @@ import { AutoLoginGuard } from 'angular-auth-oidc-client';
 const appRoutes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'home' },
   { path: 'home', component: HomeComponent },
-  { path: 'protected', component: ProtectedComponent, canActivate: [AutoLoginGuard] },
-  { path: 'forbidden', component: ForbiddenComponent, canActivate: [AutoLoginGuard] },
+  {
+    path: 'protected',
+    component: ProtectedComponent,
+    canActivate: [AutoLoginGuard],
+  },
+  {
+    path: 'forbidden',
+    component: ForbiddenComponent,
+    canActivate: [AutoLoginGuard],
+  },
   {
     path: 'customers',
-    loadChildren: () => import('./customers/customers.module').then((m) => m.CustomersModule),
+    loadChildren: () =>
+      import('./customers/customers.module').then((m) => m.CustomersModule),
     canLoad: [AutoLoginGuard],
   },
   { path: 'unauthorized', component: UnauthorizedComponent },
@@ -599,11 +670,20 @@ import { AutoLoginPartialRoutesGuard } from 'angular-auth-oidc-client';
 const appRoutes: Routes = [
   { path: '', pathMatch: 'full', redirectTo: 'home' },
   { path: 'home', component: HomeComponent },
-  { path: 'protected', component: ProtectedComponent, canActivate: [AutoLoginPartialRoutesGuard] },
-  { path: 'forbidden', component: ForbiddenComponent, canActivate: [AutoLoginPartialRoutesGuard] },
+  {
+    path: 'protected',
+    component: ProtectedComponent,
+    canActivate: [AutoLoginPartialRoutesGuard],
+  },
+  {
+    path: 'forbidden',
+    component: ForbiddenComponent,
+    canActivate: [AutoLoginPartialRoutesGuard],
+  },
   {
     path: 'customers',
-    loadChildren: () => import('./customers/customers.module').then((m) => m.CustomersModule),
+    loadChildren: () =>
+      import('./customers/customers.module').then((m) => m.CustomersModule),
     canLoad: [AutoLoginPartialRoutesGuard],
   },
   { path: 'unauthorized', component: UnauthorizedComponent },

--- a/docs/site/angular-auth-oidc-client/docs/migrations/v12-to-v13.md
+++ b/docs/site/angular-auth-oidc-client/docs/migrations/v12-to-v13.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 98
 ---
 
 # Version 12 to 13

--- a/docs/site/angular-auth-oidc-client/docs/migrations/v13-to-v14.md
+++ b/docs/site/angular-auth-oidc-client/docs/migrations/v13-to-v14.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 97
 ---
 
 # Version 13 to 14

--- a/docs/site/angular-auth-oidc-client/docs/migrations/v14-to-v15.md
+++ b/docs/site/angular-auth-oidc-client/docs/migrations/v14-to-v15.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 96
 ---
 
 # Version 14 to 15


### PR DESCRIPTION
Order the migrations from new to old, previously this was from old to new.
This makes more sense to me because we're probably interested in the latest first. (this is also how angular does it)

Because auto-format is enabled prettier also formatted the older migrations.

![image](https://github.com/damienbod/angular-auth-oidc-client/assets/28659384/e4397eeb-f79c-42fa-94a3-c984977c82fb)
