### PR TITLE
Check if savedRouteForRedirect is null

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.ts
@@ -15,7 +15,7 @@ export class AutoLoginService {
   checkSavedRedirectRouteAndNavigate(config: OpenIdConfiguration): void {
     const savedRouteForRedirect = this.getStoredRedirectRoute(config);
 
-    if (savedRouteForRedirect) {
+    if (savedRouteForRedirect != null) {
       this.deleteStoredRedirectRoute(config);
       this.router.navigateByUrl(savedRouteForRedirect);
     }


### PR DESCRIPTION
If the default route redirect to a protected route the saved route for redirect is an empty string ("") so after login the user get stuck in callback page without redirect, if we check for null instead the user get redirected to the root