### PR TITLE
Added useCustomAuth0Domain flag

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -527,3 +527,10 @@ Default = _false_
 Disable validation for id_token. This is not recommended! You should always validate the id_token if returned.
 
 Default = _false_
+
+### `useCustomAuth0Domain`
+
+- Type: `boolean`
+- Required: `false`
+
+Allows an Auth0 custom domain to be used as the authority without losing the special handling of Auth0's logoff endpoint. If you are using a custom domain with Auth0 it is recommended to set this flag to true.

--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -67,6 +67,12 @@ export interface OpenIdConfiguration {
    */
   renewTimeBeforeTokenExpiresInSeconds?: number;
   /**
+   * Allows for a custom domain to be used with Auth0.
+   * With this flag set the 'authority' does not have to end with
+   * 'auth0.com' to trigger the auth0 special handling of logouts.
+   */
+  useCustomAuth0Domain?: boolean;
+  /**
    * When set to true, refresh tokens are used to renew the user session.
    * When set to false, standard silent renew is used.
    * Default value is false.

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -796,13 +796,13 @@ export class UrlService {
   }
 
   private isAuth0Endpoint(configuration: OpenIdConfiguration): boolean {
-    const { authority } = configuration;
+    const { authority, useCustomAuth0Domain } = configuration;
 
     if (!authority) {
       return false;
     }
 
-    return authority.endsWith(AUTH0_ENDPOINT);
+    return authority.endsWith(AUTH0_ENDPOINT) || useCustomAuth0Domain;
   }
 
   private composeAuth0Endpoint(configuration: OpenIdConfiguration): string {


### PR DESCRIPTION
Since Auth0 does not publish it's end_session_url in it's discovery doc special handling is required for logging out.
This special handling of Auth0 logout is not triggered for custom domains since this special handling is determined by whether the authority ends with 'auth0.com'

openid-configuration now contains an optional flag to allow custom domains in auth0 to function as normal.
A small change in the url service checks if the authority ends with auth0.com OR the useCustomAuth0Domain is set.

This is probably quite a niche issue but it has been a real headache for what seems like a simple fix.

(This is my first time ever contributing to any project so apologies in advance if I've missed anything / done anything incorrectly, please do help me to learn I would be very grateful!)