### PR TITLE
ci: pin Angular 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,7 +77,7 @@ jobs:
           path: angular-auth-oidc-client-artefact
 
       - name: Install AngularCLI globally
-        run: sudo npm install -g @angular/cli
+        run: sudo npm install -g @angular/cli@16
 
       - name: Show ng Version
         run: ng version
@@ -117,7 +117,7 @@ jobs:
           path: angular-auth-oidc-client-artefact
 
       - name: Install AngularCLI globally
-        run: sudo npm install -g @angular/cli
+        run: sudo npm install -g @angular/cli@16
 
       - name: Show ng Version
         run: ng version
@@ -157,7 +157,7 @@ jobs:
           path: angular-auth-oidc-client-artefact
 
       - name: Install AngularCLI globally
-        run: sudo npm install -g @angular/cli
+        run: sudo npm install -g @angular/cli@16
 
       - name: Show ng Version
         run: ng version
@@ -197,7 +197,7 @@ jobs:
           path: angular-auth-oidc-client-artefact
 
       - name: Install AngularCLI globally
-        run: sudo npm install -g @angular/cli
+        run: sudo npm install -g @angular/cli@16
 
       - name: Show ng Version
         run: ng version


### PR DESCRIPTION
In previous PRs I noticed the CI is failing because it installs Angular v17.
This PR pins the Angular version to v16 (for now).

If you want I can also look into upgrading this library to Angular v17 next week (including the pipelines).