### PR TITLE
ci: specify node version

### DIFF
--- a/docs/site/angular-auth-oidc-client/package.json
+++ b/docs/site/angular-auth-oidc-client/package.json
@@ -1,6 +1,9 @@
 {
   "name": "angular-auth-oidc-client",
   "version": "0.0.0",
+  "engines": {
+    "node": "^18.0.0"
+  },
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",


### PR DESCRIPTION
This should fix the failing deploy step on `main`.

According to this blog https://timdeschryver.dev/blog/specify-your-nodejs-version-for-the-azure-static-web-app-github-action this should resolve the problem 😅
The problem was the Azure deploy step, which uses Node.js v16.