### PR TITLE
fix: export DefaultSessionStorageService

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/index.ts
+++ b/projects/angular-auth-oidc-client/src/lib/index.ts
@@ -24,6 +24,7 @@ export * from './public-events/notification';
 export * from './public-events/public-events.service';
 export * from './storage/abstract-security-storage';
 export * from './storage/default-localstorage.service';
+export * from './storage/default-sessionstorage.service';
 export * from './user-data/userdata-result';
 export * from './validation/jwtkeys';
 export * from './validation/state-validation-result';


### PR DESCRIPTION
Closes #1894

I couldn't find a history why the default session storage isn't exported, so I assumed this is by mistake. Feel free to close this PR if that's not the case.