### PR TITLE
should fix #1852

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
@@ -33,20 +33,18 @@ export class HistoryJwtKeysCallbackHandlerService {
     config: OpenIdConfiguration,
     allConfigs: OpenIdConfiguration[]
   ): Observable<CallbackContext> {
+    let toWrite = { ...callbackContext.authResult };
+
     if (!this.responseHasIdToken(callbackContext)) {
       const existingIdToken = this.storagePersistenceService.getIdToken(config);
 
-      callbackContext.authResult = {
-        ...callbackContext.authResult,
+      toWrite = {
+        ...toWrite,
         id_token: existingIdToken,
       };
     }
 
-    this.storagePersistenceService.write(
-      'authnResult',
-      callbackContext.authResult,
-      config
-    );
+    this.storagePersistenceService.write('authnResult', toWrite, config);
 
     if (
       config.allowUnsafeReuseRefreshToken &&


### PR DESCRIPTION
If refresh token does not return id_token store existing id_token as authnResult without altering original refresh token data.