### PR TITLE
ci: run RxJS 6 with Angular 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -180,10 +180,10 @@ jobs:
         working-directory: ./angular-auth-oidc-client-test
         run: sudo npm run build
 
-  AngularLatestVersionWithRxJs6:
+  Angular16VersionWithRxJs6:
     needs: build_job
     runs-on: ubuntu-latest
-    name: Angular latest & RxJs 6
+    name: Angular 16 & RxJs 6
     steps:
       - name: Setup Node.js
         uses: actions/setup-node@v2
@@ -197,7 +197,7 @@ jobs:
           path: angular-auth-oidc-client-artefact
 
       - name: Install AngularCLI globally
-        run: sudo npm install -g @angular/cli
+        run: sudo npm install -g @angular/cli@16
 
       - name: Show ng Version
         run: ng version


### PR DESCRIPTION
I noticed the CI build is failing.
This PR fixes that by downgrading the Angular version from 17 to 16 to work with RxJS v6.

The reason for this is that Angular dropped support for RxJS 6 in Angular 17 - https://github.com/angular/angular/blob/main/package.json#L131.

As an alternative we can also drop support for RxJS v6 and remove these build jobs.