### PR TITLE
fix: inject DOCUMENT

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/callback/interval.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/interval.service.ts
@@ -1,11 +1,12 @@
 import { Injectable, NgZone, inject } from '@angular/core';
 import { Observable, Subscription } from 'rxjs';
+import { DOCUMENT } from '@angular/common';
 
 @Injectable({ providedIn: 'root' })
 export class IntervalService {
   private readonly zone = inject(NgZone);
 
-  private readonly document = inject<Document>(Document);
+  private readonly document = inject(DOCUMENT);
 
   runTokenValidationRunning: Subscription | null = null;
 


### PR DESCRIPTION
@FabianGosebrink the example apps are not working anymore.
This is probably something we missed in #1917 

```
core.mjs:11760  ERROR NullInjectorError: R3InjectorError(AppModule)[OidcSecurityService -> CheckAuthService -> SilentRenewService -> ImplicitFlowCallbackService -> IntervalService -> Document -> Document]: 
  NullInjectorError: No provider for Document!
    at NullInjector.get (core.mjs:5626:27)
    at R3Injector.get (core.mjs:6069:33)
    at R3Injector.get (core.mjs:6069:33)
    at injectInjectorOnly (core.mjs:911:40)
    at ɵɵinject (core.mjs:917:60)
    at inject (core.mjs:1001:12)
    at new IntervalService (interval.service.ts:8:37)
    at Object.IntervalService_Factory [as factory] (interval.service.ts:40:4)
    at core.mjs:6189:43
    at runInInjectorProfilerContext (core.mjs:867:9)
```