### PR TITLE
refactor: replace any types

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/api/data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/api/data.service.spec.ts
@@ -29,7 +29,7 @@ describe('Data Service', () => {
 
   describe('get', () => {
     it('get call sets the accept header', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
 
       dataService
         .get(url, { configId: 'configId1' })
@@ -47,7 +47,7 @@ describe('Data Service', () => {
     }));
 
     it('get call with token the accept header and the token', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
       const token = 'token';
 
       dataService
@@ -67,7 +67,7 @@ describe('Data Service', () => {
     }));
 
     it('call without ngsw-bypass param by default', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
 
       dataService
         .get(url, { configId: 'configId1' })
@@ -86,7 +86,7 @@ describe('Data Service', () => {
     }));
 
     it('call with ngsw-bypass param', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
 
       dataService
         .get(url, { configId: 'configId1', ngswBypass: true })
@@ -107,7 +107,7 @@ describe('Data Service', () => {
 
   describe('post', () => {
     it('call sets the accept header when no other params given', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
 
       dataService
         .post(url, { some: 'thing' }, { configId: 'configId1' })
@@ -123,7 +123,7 @@ describe('Data Service', () => {
     }));
 
     it('call sets custom headers ONLY (No ACCEPT header) when custom headers are given', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
       let headers = new HttpHeaders();
 
       headers = headers.set('X-MyHeader', 'Genesis');
@@ -143,7 +143,7 @@ describe('Data Service', () => {
     }));
 
     it('call without ngsw-bypass param by default', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
 
       dataService
         .post(url, { some: 'thing' }, { configId: 'configId1' })
@@ -160,7 +160,7 @@ describe('Data Service', () => {
     }));
 
     it('call with ngsw-bypass param', waitForAsync(() => {
-      const url = 'anyurl';
+      const url = 'testurl';
 
       dataService
         .post(

--- a/projects/angular-auth-oidc-client/src/lib/api/data.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/api/data.service.ts
@@ -26,7 +26,7 @@ export class DataService {
 
   post<T>(
     url: string | null,
-    body: any,
+    body: unknown,
     config: OpenIdConfiguration,
     headersParams?: HttpHeaders
   ): Observable<T> {

--- a/projects/angular-auth-oidc-client/src/lib/api/http-base.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/api/http-base.service.ts
@@ -6,14 +6,14 @@ import { Observable } from 'rxjs';
 export class HttpBaseService {
   private readonly http = inject(HttpClient);
 
-  get<T>(url: string, params?: { [key: string]: any }): Observable<T> {
+  get<T>(url: string, params?: { [key: string]: unknown }): Observable<T> {
     return this.http.get<T>(url, params);
   }
 
   post<T>(
     url: string,
-    body: any,
-    params?: { [key: string]: any }
+    body: unknown,
+    params?: { [key: string]: unknown }
   ): Observable<T> {
     return this.http.post<T>(url, body, params);
   }

--- a/projects/angular-auth-oidc-client/src/lib/auth-options.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-options.ts
@@ -1,12 +1,12 @@
 export interface AuthOptions {
   customParams?: { [key: string]: string | number | boolean };
-  urlHandler?(url: string): any;
+  urlHandler?(url: string): void;
   /** overrides redirectUrl from configuration */
   redirectUrl?: string;
 }
 
 export interface LogoutAuthOptions {
   customParams?: { [key: string]: string | number | boolean };
-  urlHandler?(url: string): any;
+  urlHandler?(url: string): void;
   logoffMethod?: 'GET' | 'POST';
 }

--- a/projects/angular-auth-oidc-client/src/lib/auth.module.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth.module.spec.ts
@@ -12,8 +12,6 @@ import {
 
 describe('AuthModule', () => {
   describe('APP_CONFIG', () => {
-    let config: any;
-
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [AuthModule.forRoot({ config: { authority: 'something' } })],
@@ -27,7 +25,8 @@ describe('AuthModule', () => {
     });
 
     it('should provide config', () => {
-      config = TestBed.inject(PASSED_CONFIG);
+      const config = TestBed.inject(PASSED_CONFIG);
+
       expect(config).toEqual({ config: { authority: 'something' } });
     });
 

--- a/projects/angular-auth-oidc-client/src/lib/callback/interval.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/interval.service.ts
@@ -39,3 +39,4 @@ export class IntervalService {
     });
   }
 }
+

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
@@ -107,7 +107,7 @@ describe('AuthWellKnownDataService', () => {
       (service as any)
         .getWellKnownDocument('anyurl', { configId: 'configId1' })
         .subscribe({
-          next: (res: any) => {
+          next: (res: unknown) => {
             expect(res).toBeTruthy();
             expect(res).toEqual(DUMMY_WELL_KNOWN_DOCUMENT);
           },
@@ -144,7 +144,7 @@ describe('AuthWellKnownDataService', () => {
       );
 
       (service as any).getWellKnownDocument('anyurl', 'configId').subscribe({
-        error: (err: any) => {
+        error: (err: unknown) => {
           expect(err).toBeTruthy();
         },
       });

--- a/projects/angular-auth-oidc-client/src/lib/config/validation/config-validation.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/validation/config-validation.service.ts
@@ -21,7 +21,7 @@ export class ConfigValidationService {
 
   private validateConfigsInternal(
     passedConfigs: OpenIdConfiguration[],
-    allRulesToUse: any[]
+    allRulesToUse: ((passedConfig: OpenIdConfiguration[]) => RuleValidationResult)[]
   ): boolean {
     if (passedConfigs.length === 0) {
       return false;
@@ -47,7 +47,7 @@ export class ConfigValidationService {
 
   private validateConfigInternal(
     passedConfig: OpenIdConfiguration,
-    allRulesToUse: any[]
+    allRulesToUse: ((passedConfig: OpenIdConfiguration) => RuleValidationResult)[]
   ): boolean {
     const allValidationResults = allRulesToUse.map((rule) =>
       rule(passedConfig)

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-context.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-context.ts
@@ -10,7 +10,7 @@ export interface CallbackContext {
   isRenewProcess: boolean;
   jwtKeys: JwtKeys | null;
   validationResult: StateValidationResult | null;
-  existingIdToken: any;
+  existingIdToken: string | null;
 }
 
 export interface AuthResult {

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.spec.ts
@@ -52,9 +52,9 @@ describe('CodeFlowCallbackHandlerService', () => {
         'getUrlParameter'
       ).and.returnValue('params');
 
-      getUrlParameterSpy.withArgs('any-url', 'state').and.returnValue('');
+      getUrlParameterSpy.withArgs('test-url', 'state').and.returnValue('');
 
-      service.codeFlowCallback('any-url', { configId: 'configId1' }).subscribe({
+      service.codeFlowCallback('test-url', { configId: 'configId1' }).subscribe({
         error: (err) => {
           expect(err).toBeTruthy();
         },
@@ -67,9 +67,9 @@ describe('CodeFlowCallbackHandlerService', () => {
         'getUrlParameter'
       ).and.returnValue('params');
 
-      getUrlParameterSpy.withArgs('any-url', 'code').and.returnValue('');
+      getUrlParameterSpy.withArgs('test-url', 'code').and.returnValue('');
 
-      service.codeFlowCallback('any-url', { configId: 'configId1' }).subscribe({
+      service.codeFlowCallback('test-url', { configId: 'configId1' }).subscribe({
         error: (err) => {
           expect(err).toBeTruthy();
         },
@@ -92,7 +92,7 @@ describe('CodeFlowCallbackHandlerService', () => {
       } as CallbackContext;
 
       service
-        .codeFlowCallback('any-url', { configId: 'configId1' })
+        .codeFlowCallback('test-url', { configId: 'configId1' })
         .subscribe((callbackContext) => {
           expect(callbackContext).toEqual(expectedCallbackContext);
         });

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
@@ -138,9 +138,9 @@ export class CodeFlowCallbackHandlerService {
   }
 
   private handleRefreshRetry(
-    errors: Observable<any>,
+    errors: Observable<unknown>,
     config: OpenIdConfiguration
-  ): Observable<any> {
+  ): Observable<unknown> {
     return errors.pipe(
       mergeMap((error) => {
         // retry token refresh if there is no internet connection

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/history-jwt-keys-callback-handler.service.ts
@@ -137,12 +137,12 @@ export class HistoryJwtKeysCallbackHandlerService {
   }
 
   private handleResultErrorFromCallback(
-    result: any,
+    result: unknown,
     isRenewProcess: boolean
   ): void {
     let validationResult = ValidationResult.SecureTokenServerError;
 
-    if ((result.error as string) === 'login_required') {
+    if (result && typeof result === 'object' && 'error' in result && (result.error as string) === 'login_required') {
       validationResult = ValidationResult.LoginRequired;
     }
 

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/implicit-flow-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/implicit-flow-callback-handler.service.ts
@@ -3,7 +3,7 @@ import { Injectable, inject } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { OpenIdConfiguration } from '../../config/openid-configuration';
 import { LoggerService } from '../../logging/logger.service';
-import { CallbackContext } from '../callback-context';
+import { AuthResult, CallbackContext } from '../callback-context';
 import { FlowsDataService } from '../flows-data.service';
 import { ResetAuthDataService } from '../reset-auth-data.service';
 
@@ -34,7 +34,7 @@ export class ImplicitFlowCallbackHandlerService {
 
     hash = hash || this.document.location.hash.substring(1);
 
-    const authResult: any = hash
+    const authResult = hash
       .split('&')
       .reduce((resultData: any, item: string) => {
         const parts = item.split('=');
@@ -42,7 +42,7 @@ export class ImplicitFlowCallbackHandlerService {
         resultData[parts.shift() as string] = parts.join('=');
 
         return resultData;
-      }, {});
+      }, {} as AuthResult);
 
     const callbackContext: CallbackContext = {
       code: '',

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.spec.ts
@@ -50,7 +50,7 @@ describe('RefreshTokenCallbackHandlerService', () => {
       (service as any)
         .refreshTokensRequestTokens({} as CallbackContext)
         .subscribe({
-          error: (err: any) => {
+          error: (err: unknown) => {
             expect(err).toBeTruthy();
           },
         });

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.ts
@@ -77,9 +77,9 @@ export class RefreshTokenCallbackHandlerService {
   }
 
   private handleRefreshRetry(
-    errors: Observable<any>,
+    errors: Observable<unknown>,
     config: OpenIdConfiguration
-  ): Observable<any> {
+  ): Observable<unknown> {
     return errors.pipe(
       mergeMap((error) => {
         // retry token refresh if there is no internet connection

--- a/projects/angular-auth-oidc-client/src/lib/iframe/silent-renew.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/silent-renew.service.ts
@@ -152,7 +152,7 @@ export class SilentRenewService {
         this.refreshSessionWithIFrameCompletedInternal$.next(callbackContext);
         this.flowsDataService.resetSilentRenewRunning(config);
       },
-      error: (err: any) => {
+      error: (err: unknown) => {
         this.loggerService.logError(config, 'Error: ' + err);
         this.refreshSessionWithIFrameCompletedInternal$.next(null);
         this.flowsDataService.resetSilentRenewRunning(config);

--- a/projects/angular-auth-oidc-client/src/lib/logging/abstract-logger.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/logging/abstract-logger.service.ts
@@ -5,9 +5,10 @@ import { Injectable } from '@angular/core';
  */
 @Injectable({ providedIn: 'root' })
 export abstract class AbstractLoggerService {
-  abstract logError(message: any, ...args: any[]): void;
+  abstract logError(message: string|object, ...args: any[]): void;
 
-  abstract logWarning(message: any, ...args: any[]): void;
+  abstract logWarning(message: string|object, ...args: any[]): void;
 
-  abstract logDebug(message: any, ...args: any[]): void;
+  abstract logDebug(message: string|object, ...args: any[]): void;
 }
+

--- a/projects/angular-auth-oidc-client/src/lib/logging/console-logger.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/logging/console-logger.service.ts
@@ -3,15 +3,15 @@ import { AbstractLoggerService } from './abstract-logger.service';
 
 @Injectable({ providedIn: 'root' })
 export class ConsoleLoggerService implements AbstractLoggerService {
-  logError(message?: any, ...args: any[]): void {
+  logError(message: string|object, ...args: any[]): void {
     console.error(message, ...args);
   }
 
-  logWarning(message?: any, ...args: any[]): void {
+  logWarning(message: string|object, ...args: any[]): void {
     console.warn(message, ...args);
   }
 
-  logDebug(message?: any, ...args: any[]): void {
+  logDebug(message: string|object, ...args: any[]): void {
     console.debug(message, ...args);
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/logging/logger.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/logging/logger.service.ts
@@ -9,7 +9,7 @@ export class LoggerService {
 
   logError(
     configuration: OpenIdConfiguration,
-    message: any,
+    message: string|object,
     ...args: any[]
   ): void {
     if (this.loggingIsTurnedOff(configuration)) {
@@ -35,7 +35,7 @@ export class LoggerService {
 
   logWarning(
     configuration: OpenIdConfiguration,
-    message: any,
+    message: string|object,
     ...args: any[]
   ): void {
     if (!this.logLevelIsSet(configuration)) {
@@ -71,7 +71,7 @@ export class LoggerService {
 
   logDebug(
     configuration: OpenIdConfiguration | null,
-    message: any,
+    message: string|object,
     ...args: any[]
   ): void {
     if (!configuration) {

--- a/projects/angular-auth-oidc-client/src/lib/provide-auth.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/provide-auth.spec.ts
@@ -12,8 +12,6 @@ import { provideAuth } from './provide-auth';
 
 describe('provideAuth', () => {
   describe('APP_CONFIG', () => {
-    let config: any;
-
     beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         providers: [
@@ -24,7 +22,8 @@ describe('provideAuth', () => {
     }));
 
     it('should provide config', () => {
-      config = TestBed.inject(PASSED_CONFIG);
+      const config = TestBed.inject(PASSED_CONFIG);
+
       expect(config).toEqual({ config: { authority: 'something' } });
     });
 

--- a/projects/angular-auth-oidc-client/src/lib/storage/abstract-security-storage.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/abstract-security-storage.ts
@@ -10,7 +10,7 @@ export abstract class AbstractSecurityStorage {
    *
    * @return The value of the given key
    */
-  abstract read(key: string): any;
+  abstract read(key: string): string|null;
 
   /**
    * This method must contain the logic to write the storage.
@@ -18,7 +18,7 @@ export abstract class AbstractSecurityStorage {
    * @param key The key to write a value for
    * @param value The value for the given key
    */
-  abstract write(key: string, value: any): void;
+  abstract write(key: string, value: string): void;
 
   /**
    * This method must contain the logic to remove an item from the storage.

--- a/projects/angular-auth-oidc-client/src/lib/storage/default-localstorage.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/default-localstorage.service.ts
@@ -5,11 +5,11 @@ import { AbstractSecurityStorage } from './abstract-security-storage';
   providedIn: 'root',
 })
 export class DefaultLocalStorageService implements AbstractSecurityStorage {
-  public read(key: string): any {
+  public read(key: string): string|null {
     return localStorage.getItem(key);
   }
 
-  public write(key: string, value: any): void {
+  public write(key: string, value: string): void {
     localStorage.setItem(key, value);
   }
 

--- a/projects/angular-auth-oidc-client/src/lib/storage/default-sessionstorage.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/default-sessionstorage.service.ts
@@ -3,11 +3,11 @@ import { AbstractSecurityStorage } from './abstract-security-storage';
 
 @Injectable({ providedIn: 'root' })
 export class DefaultSessionStorageService implements AbstractSecurityStorage {
-  public read(key: string): any {
+  public read(key: string): string|null {
     return sessionStorage.getItem(key);
   }
 
-  public write(key: string, value: any): void {
+  public write(key: string, value: string): void {
     sessionStorage.setItem(key, value);
   }
 

--- a/projects/angular-auth-oidc-client/src/lib/user-data/user-service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/user-data/user-service.spec.ts
@@ -59,7 +59,7 @@ describe('User Service', () => {
   describe('getAndPersistUserDataInStore', () => {
     it('if not currentFlow is NOT id Token or Code flow, return decoded ID Token - passed as argument', waitForAsync(() => {
       const isRenewProcess = false;
-      const idToken = false;
+      const idToken = '';
       const decodedIdToken = 'decodedIdToken';
       const userDataInstore = '';
 
@@ -87,7 +87,7 @@ describe('User Service', () => {
 
     it('if not currentFlow is NOT id Token or Code flow, "setUserDataToStore" is called with the decodedIdToken', waitForAsync(() => {
       const isRenewProcess = false;
-      const idToken = false;
+      const idToken = '';
       const decodedIdToken = 'decodedIdToken';
       const userDataInstore = '';
 
@@ -118,7 +118,7 @@ describe('User Service', () => {
 
     it('if not currentFlow is id token or code flow with renewProcess going -> return existing data from storage', waitForAsync(() => {
       const isRenewProcess = true;
-      const idToken = false;
+      const idToken = '';
       const decodedIdToken = 'decodedIdToken';
       const userDataInstore = 'userDataInstore';
 
@@ -146,7 +146,7 @@ describe('User Service', () => {
 
     it('if not currentFlow is id token or code flow and not renewProcess --> ask server for data', waitForAsync(() => {
       const isRenewProcess = false;
-      const idToken = false;
+      const idToken = '';
       const decodedIdToken = 'decodedIdToken';
       const userDataInstore = '';
       const userDataFromSts = 'userDataFromSts';
@@ -183,7 +183,7 @@ describe('User Service', () => {
           --> ask server for data
           --> logging if it has userdata`, waitForAsync(() => {
       const isRenewProcess = false;
-      const idToken = false;
+      const idToken = '';
       const decodedIdToken = 'decodedIdToken';
       const userDataInstore = '';
       const userDataFromSts = 'userDataFromSts';
@@ -226,7 +226,7 @@ describe('User Service', () => {
           --> ask server for data
           --> throwing Error if it has no userdata `, waitForAsync(() => {
       const isRenewProcess = false;
-      const idToken = false;
+      const idToken = '';
       const decodedIdToken = { sub: 'decodedIdToken' };
       const userDataInstore = '';
       const userDataFromSts = null;
@@ -271,7 +271,7 @@ describe('User Service', () => {
     it(`if not currentFlow is id token or code flow and renewprocess and renewUserInfoAfterTokenRenew
           --> ask server for data`, waitForAsync(() => {
       const isRenewProcess = true;
-      const idToken = false;
+      const idToken = '';
       const decodedIdToken = 'decodedIdToken';
       const userDataInstore = 'userDataInStore';
       const userDataFromSts = 'userDataFromSts';

--- a/projects/angular-auth-oidc-client/src/lib/user-data/user.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/user-data/user.service.ts
@@ -41,7 +41,7 @@ export class UserService {
     currentConfiguration: OpenIdConfiguration,
     allConfigs: OpenIdConfiguration[],
     isRenewProcess = false,
-    idToken?: any,
+    idToken?: string,
     decodedIdToken?: any
   ): Observable<any> {
     idToken =

--- a/projects/angular-auth-oidc-client/src/lib/utils/tokenHelper/token-helper.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/tokenHelper/token-helper.service.ts
@@ -24,7 +24,7 @@ export class TokenHelperService {
   }
 
   getSigningInputFromToken(
-    token: any,
+    token: string|undefined|null,
     encoded: boolean,
     configuration: OpenIdConfiguration
   ): string {
@@ -47,7 +47,7 @@ export class TokenHelperService {
   }
 
   getHeaderFromToken(
-    token: any,
+    token: string|undefined|null,
     encoded: boolean,
     configuration: OpenIdConfiguration
   ): any {
@@ -59,7 +59,7 @@ export class TokenHelperService {
   }
 
   getPayloadFromToken(
-    token: any,
+    token: string|undefined|null,
     encoded: boolean,
     configuration: OpenIdConfiguration | null
   ): any {
@@ -75,7 +75,7 @@ export class TokenHelperService {
   }
 
   getSignatureFromToken(
-    token: any,
+    token: string|undefined|null,
     encoded: boolean,
     configuration: OpenIdConfiguration
   ): any {
@@ -139,9 +139,9 @@ export class TokenHelperService {
   }
 
   private tokenIsValid(
-    token: string,
+    token: string|undefined|null,
     configuration: OpenIdConfiguration
-  ): boolean {
+  ): token is string {
     if (!token) {
       this.loggerService.logError(
         configuration,

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -171,7 +171,7 @@ export class UrlService {
   }
 
   createRevocationEndpointBodyAccessToken(
-    token: any,
+    token: string,
     configuration: OpenIdConfiguration
   ): string | null {
     const clientId = this.getClientId(configuration);
@@ -190,7 +190,7 @@ export class UrlService {
   }
 
   createRevocationEndpointBodyRefreshToken(
-    token: any,
+    token: string,
     configuration: OpenIdConfiguration
   ): string | null {
     const clientId = this.getClientId(configuration);


### PR DESCRIPTION
This PR updates some `any` types to its runtime type or to `unknown` for errors.
Some tests are also updates to replace a "magic string" that contains `any` within the string. 