### PR TITLE
fix: refresh authWellKnownEndPoints

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.spec.ts
@@ -36,11 +36,22 @@ describe('AuthWellKnownService', () => {
   });
 
   describe('getAuthWellKnownEndPoints', () => {
-    it('getAuthWellKnownEndPoints return stored endpoints if they exist', waitForAsync(() => {
+    it('getAuthWellKnownEndPoints throws an error if not config provided', waitForAsync(() => {
+      service
+        .queryAndStoreAuthWellKnownEndPoints(null)
+        .subscribe({
+          error: (error) => {
+            expect(error).toEqual(new Error('Please provide a configuration before setting up the module'))
+          }
+        });
+    }));
+
+
+    it('getAuthWellKnownEndPoints calls always dataservice', waitForAsync(() => {
       const dataServiceSpy = spyOn(
         dataService,
         'getWellKnownEndPointsForConfig'
-      );
+      ).and.returnValue(of({ issuer: 'anything' }));
 
       spyOn(storagePersistenceService, 'read')
         .withArgs('authWellKnownEndPoints', { configId: 'configId1' })
@@ -49,29 +60,13 @@ describe('AuthWellKnownService', () => {
       service
         .queryAndStoreAuthWellKnownEndPoints({ configId: 'configId1' })
         .subscribe((result) => {
-          expect(dataServiceSpy).not.toHaveBeenCalled();
-          expect(result).toEqual({ issuer: 'anything' });
-        });
-    }));
-
-    it('getAuthWellKnownEndPoints calls dataservice if none is stored', waitForAsync(() => {
-      const dataServiceSpy = spyOn(
-        dataService,
-        'getWellKnownEndPointsForConfig'
-      ).and.returnValue(of({ issuer: 'anything' }));
-
-      spyOn(storagePersistenceService, 'read')
-        .withArgs('authWellKnownEndPoints', { configId: 'configId1' })
-        .and.returnValue(null);
-      service
-        .queryAndStoreAuthWellKnownEndPoints({ configId: 'configId1' })
-        .subscribe((result) => {
+          expect(storagePersistenceService.read).not.toHaveBeenCalled();
           expect(dataServiceSpy).toHaveBeenCalled();
           expect(result).toEqual({ issuer: 'anything' });
         });
     }));
 
-    it('getAuthWellKnownEndPoints stored the result if http cal is made', waitForAsync(() => {
+    it('getAuthWellKnownEndPoints stored the result if http call is made', waitForAsync(() => {
       const dataServiceSpy = spyOn(
         dataService,
         'getWellKnownEndPointsForConfig'

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, inject } from '@angular/core';
-import { Observable, of, throwError } from 'rxjs';
+import { Observable, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { EventTypes } from '../../public-events/event-types';
 import { PublicEventsService } from '../../public-events/public-events.service';
@@ -39,15 +39,6 @@ export class AuthWellKnownService {
             'Please provide a configuration before setting up the module'
           )
       );
-    }
-
-    const alreadySavedWellKnownEndpoints = this.storagePersistenceService.read(
-      'authWellKnownEndPoints',
-      config
-    );
-
-    if (!!alreadySavedWellKnownEndpoints) {
-      return of(alreadySavedWellKnownEndpoints);
     }
 
     return this.dataService.getWellKnownEndPointsForConfig(config).pipe(


### PR DESCRIPTION
This tries to fix #1910

The idea is to unconditional refresh the wellKnownEndpoints before saving them in the storage. This avoids the dead lock situation that is currently happening when they are saved in local storage and the server updates them.
