### PR TITLE
fix network error detection due to potential falsy instanceof ProgressEvent evaluation if ProgressEvent is monkey patched by another library

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
@@ -1,4 +1,4 @@
-import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, of, throwError, timer } from 'rxjs';
 import { catchError, mergeMap, retryWhen, switchMap } from 'rxjs/operators';
@@ -10,6 +10,7 @@ import { UrlService } from '../../utils/url/url.service';
 import { TokenValidationService } from '../../validation/token-validation.service';
 import { AuthResult, CallbackContext } from '../callback-context';
 import { FlowsDataService } from '../flows-data.service';
+import { isNetworkError } from './error-helper';
 
 @Injectable({ providedIn: 'root' })
 export class CodeFlowCallbackHandlerService {
@@ -144,12 +145,7 @@ export class CodeFlowCallbackHandlerService {
     return errors.pipe(
       mergeMap((error) => {
         // retry token refresh if there is no internet connection
-        if (
-          error &&
-          error instanceof HttpErrorResponse &&
-          error.error instanceof ProgressEvent &&
-          error.error.type === 'error'
-        ) {
+        if (isNetworkError(error)) {
           const { authority, refreshTokenRetryInSeconds } = config;
           const errorMessage = `OidcService code request ${authority} - no internet connection`;
 

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/error-helper.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/error-helper.spec.ts
@@ -1,0 +1,57 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { isNetworkError } from './error-helper';
+
+describe('error helper', () => {
+  describe('isNetworkError ', () => {
+    const HTTP_ERROR = new HttpErrorResponse({});
+
+    const CONNECTION_ERROR = new HttpErrorResponse({
+      error: new ProgressEvent('error'),
+      status: 0,
+      statusText: 'Unknown Error',
+      url: 'https://identity-server.test/openid-connect/token',
+    });
+
+    const UNKNOWN_CONNECTION_ERROR = new HttpErrorResponse({
+      error: new Error('error'),
+      status: 0,
+      statusText: 'Unknown Error',
+      url: 'https://identity-server.test/openid-connect/token',
+    });
+
+    const PARTIAL_CONNECTION_ERROR = new HttpErrorResponse({
+      error: new ProgressEvent('error'),
+      status: 418, // i am a teapot
+      statusText: 'Unknown Error',
+      url: 'https://identity-server.test/openid-connect/token',
+    });
+
+    it('returns true on http error with status = 0', () => {
+      expect(isNetworkError(CONNECTION_ERROR)).toBeTrue();
+    });
+
+    it('returns true on http error with status = 0 and unknown error', () => {
+      expect(isNetworkError(UNKNOWN_CONNECTION_ERROR)).toBeTrue();
+    });
+
+    it('returns true on http error with status <> 0 and error ProgressEvent', () => {
+      expect(isNetworkError(PARTIAL_CONNECTION_ERROR)).toBeTrue();
+    });
+
+    it('returns false on non http error', () => {
+      expect(isNetworkError(new Error('not a HttpErrorResponse'))).toBeFalse();
+    });
+
+    it('returns false on string error', () => {
+      expect(isNetworkError('not a HttpErrorResponse')).toBeFalse();
+    });
+
+    it('returns false on undefined', () => {
+      expect(isNetworkError(undefined)).toBeFalse();
+    });
+
+    it('returns false on empty http error', () => {
+      expect(isNetworkError(HTTP_ERROR)).toBeFalse();
+    });
+  });
+});

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/error-helper.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/error-helper.ts
@@ -1,0 +1,14 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+/**
+ * checks if the error is a network error
+ * by checking if either internal error is a ProgressEvent with type error
+ * or another error with status 0
+ * @param error
+ * @returns true if the error is a network error
+ */
+export const isNetworkError = (error: unknown): boolean =>
+  !!error &&
+  error instanceof HttpErrorResponse &&
+  ((error.error instanceof ProgressEvent && error.error.type === 'error') ||
+    (error.status === 0 && !!error.error));

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-token-callback-handler.service.ts
@@ -1,4 +1,4 @@
-import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
+import { HttpHeaders } from '@angular/common/http';
 import { Injectable, inject } from '@angular/core';
 import { Observable, of, throwError, timer } from 'rxjs';
 import { catchError, mergeMap, retryWhen, switchMap } from 'rxjs/operators';
@@ -8,6 +8,7 @@ import { LoggerService } from '../../logging/logger.service';
 import { StoragePersistenceService } from '../../storage/storage-persistence.service';
 import { UrlService } from '../../utils/url/url.service';
 import { AuthResult, CallbackContext } from '../callback-context';
+import { isNetworkError } from './error-helper';
 
 @Injectable({ providedIn: 'root' })
 export class RefreshTokenCallbackHandlerService {
@@ -83,12 +84,7 @@ export class RefreshTokenCallbackHandlerService {
     return errors.pipe(
       mergeMap((error) => {
         // retry token refresh if there is no internet connection
-        if (
-          error &&
-          error instanceof HttpErrorResponse &&
-          error.error instanceof ProgressEvent &&
-          error.error.type === 'error'
-        ) {
+        if (isNetworkError(error)) {
           const { authority, refreshTokenRetryInSeconds } = config;
           const errorMessage = `OidcService code request ${authority} - no internet connection`;
 


### PR DESCRIPTION
This fixes/enhances network error detection and retry behavior on token refresh callbacks due to potential falsy `instanceof ProgressEvent` evaluation if ProgressEvent is monkey patched by another library, see issue https://github.com/damienbod/angular-auth-oidc-client/issues/1930
(f.e. cordova-pluging-file monkey patches ProgressEvent, so that error instanceof ProgressEvent returns false due to overridden constructor chain..)

Although i have to emphasize that this is **not a bug of this library** and in an ideal world all libraries would get rid of their bad monkey patches, the proposed change seems reasonable according to [Angular's documentation on getting http error details](https://angular.io/guide/http-handle-request-errors#getting-error-details), which is checking for status equals 0 as a sufficient criterion for network errors.

What this PR does:

- refactor http error response check to shared `isNetworkError()` helper method, because the same code existed in two code files (this removes redundancy),
- enhance the isNetworkError check to evaluate to true if either `error instanceof ProgressEvent` evaluates to true and error.error.type equals "error" (current behavior) _OR_  error.status equals 0 and error.error is defined (proposed enhancement; the error.error is defined check ensures compatibility to the current behavior that an empty HttpErrorResponse is not treated as a network error),
- add unit tests for `isNetworkError()` helper method to test current behavior prior to the proposed changes and the enhanced checks.