### PR TITLE
Bugfix: Updated URL service `isCallbackFromSts`

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -260,9 +260,10 @@ This is the `redirect_url` which was configured on the Security Token Service (S
 
 - Type: `boolean`
 - Required: `false`
-- Default: `false` *NB:* Default will be `true` in v18.
 
 Whether to check if current URL matches the redirect URI when determining if current URL is in fact the redirect URI.
+
+Default = _false_ *NB:* Default will be `true` in v18.
 
 ### `clientId`
 

--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -256,6 +256,14 @@ Allows you to set custom URLs for the Well-Known endpoints.
 
 This is the `redirect_url` which was configured on the Security Token Service (STS).
 
+### `checkRedirectUrlWhenCheckingIfIsCallback`
+
+- Type: `boolean`
+- Required: `false`
+- Default: `false` *NB:* Default will be `true` in v18.
+
+Whether to check if current URL matches the redirect URI when determining if current URL is in fact the redirect URI.
+
 ### `clientId`
 
 - Type: `string`

--- a/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
@@ -164,7 +164,7 @@ export class CheckAuthService {
       });
     }
 
-    const isCallback = this.callbackService.isCallback(currentUrl);
+    const isCallback = this.callbackService.isCallback(currentUrl, config);
 
     this.loggerService.logDebug(
       config,

--- a/projects/angular-auth-oidc-client/src/lib/callback/callback.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/callback.service.spec.ts
@@ -46,7 +46,7 @@ describe('CallbackService ', () => {
       const urlServiceSpy = spyOn(urlService, 'isCallbackFromSts');
 
       callbackService.isCallback('anyUrl');
-      expect(urlServiceSpy).toHaveBeenCalledOnceWith('anyUrl');
+      expect(urlServiceSpy).toHaveBeenCalledOnceWith('anyUrl', undefined);
     });
   });
 

--- a/projects/angular-auth-oidc-client/src/lib/callback/callback.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/callback.service.ts
@@ -23,8 +23,8 @@ export class CallbackService {
     private readonly codeFlowCallbackService: CodeFlowCallbackService
   ) {}
 
-  isCallback(currentUrl: string): boolean {
-    return this.urlService.isCallbackFromSts(currentUrl);
+  isCallback(currentUrl: string, config?: OpenIdConfiguration): boolean {
+    return this.urlService.isCallbackFromSts(currentUrl, config);
   }
 
   handleCallbackAndFireEvents(

--- a/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
@@ -6,6 +6,7 @@ export const DEFAULT_CONFIG: OpenIdConfiguration = {
   authWellknownEndpointUrl: '',
   authWellknownEndpoints: null,
   redirectUrl: 'https://please_set',
+  checkRedirectUrlWhenCheckingIfIsCallback: false,
   clientId: 'please_set',
   responseType: 'code',
   scope: 'openid email profile',

--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -21,6 +21,14 @@ export interface OpenIdConfiguration {
   /** The redirect URL defined on the Security Token Service. */
   redirectUrl?: string;
   /**
+   * Whether to check if current URL matches the redirect URI when determining
+   * if current URL is in fact the redirect URI.
+   * Default: false
+   *
+   * NB: Default will be true in v18.
+   */
+  checkRedirectUrlWhenCheckingIfIsCallback?: boolean;
+  /**
    * The Client MUST validate that the aud (audience) Claim contains its `client_id` value
    * registered at the Issuer identified by the iss (issuer) Claim as an audience.
    * The ID Token MUST be rejected if the ID Token does not list the Client as a valid audience,

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -55,6 +55,29 @@ describe('UrlService Tests', () => {
     expect(service).toBeTruthy();
   });
 
+  describe('getUrlWithoutQueryParameters', () => {
+    it('should return a new instance of the passed URL without any query parameters', () => {
+      const url = new URL('https://any.url');
+
+      const params = [
+        {key: 'doot', value: 'boop'},
+        {key: 'blep', value: 'blep'},
+      ];
+
+      params.forEach((p) => {
+        url.searchParams.set(p.key, p.value);
+      });
+
+      const sut = service.getUrlWithoutQueryParameters(url);
+
+      params.forEach((p) => {
+        expect(sut.searchParams.has(p.key)).toBeFalse();
+      });
+
+      // expect(sut.searchParams.toString()).toEqual('');
+    });
+  });
+
   describe('isCallbackFromSts', () => {
     const testingValues = [
       { param: 'code', isCallbackFromSts: true },

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -114,6 +114,36 @@ describe('UrlService Tests', () => {
   });
 
   describe('isCallbackFromSts', () => {
+    it(`should return false if config says to check redirect URI, and it doesn't match`, () => {
+      const nonMatchingUrls = [
+        {
+          url: 'https://the-redirect.url',
+          config: {
+            redirectUrl: 'https://the-redirect.url?with=parameter',
+            checkRedirectUrlWhenCheckingIfIsCallback: true
+          }
+        },
+        {
+          url: 'https://the-redirect.url?wrong=parameter',
+          config: {
+            redirectUrl: 'https://the-redirect.url?with=parameter',
+            checkRedirectUrlWhenCheckingIfIsCallback: true
+          }
+        },
+        {
+          url: 'https://not-the-redirect.url',
+          config: {
+            redirectUrl: 'https://the-redirect.url',
+            checkRedirectUrlWhenCheckingIfIsCallback: true
+          }
+        }
+      ];
+
+      nonMatchingUrls.forEach((nmu) => {
+        expect(service.isCallbackFromSts(nmu.url, nmu.config)).toBeFalse();
+      });
+    })
+
     const testingValues = [
       { param: 'code', isCallbackFromSts: true },
       { param: 'state', isCallbackFromSts: true },

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -78,6 +78,41 @@ describe('UrlService Tests', () => {
     });
   });
 
+  describe('queryParametersExist', () => {
+    const expected = new URLSearchParams();
+
+    const params = [
+      {key: 'doot', value: 'boop'},
+      {key: 'blep', value: 'blep'},
+    ]
+
+    params.forEach((p) => {
+      expected.set(p.key, p.value);
+    });
+
+    const matchingUrls = [
+      new URL('https://any.url?doot=boop&blep=blep'),
+      new URL('https://any.url?doot=boop&blep=blep&woop=doot'),
+    ];
+
+    const nonMatchingUrls = [
+      new URL('https://any.url?doot=boop'),
+      new URL('https://any.url?blep=blep&woop=doot'),
+    ];
+
+    matchingUrls.forEach((mu) => {
+      it(`should return true for ${mu.toString()}`, () => {
+        expect(service.queryParametersExist(expected, mu.searchParams)).toBeTrue();
+      });
+    });
+
+    nonMatchingUrls.forEach((nmu) => {
+      it(`should return false for ${nmu.toString()}`, () => {
+        expect(service.queryParametersExist(expected, nmu.searchParams)).toBeFalse();
+      });
+    })
+  });
+
   describe('isCallbackFromSts', () => {
     const testingValues = [
       { param: 'code', isCallbackFromSts: true },

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -73,9 +73,13 @@ export class UrlService {
       const currentUrlInstance = new URL(currentUrl);
       const redirectUriUrlInstance = new URL(this.getRedirectUrl(config));
 
+      const redirectUriWithoutQueryParams = this.getUrlWithoutQueryParameters(redirectUriUrlInstance).toString();
+      const currentUrlWithoutQueryParams = this.getUrlWithoutQueryParameters(currentUrlInstance).toString();
+      const redirectUriQueryParamsArePresentInCurrentUrl = this.queryParametersExist(redirectUriUrlInstance.searchParams, currentUrlInstance.searchParams);
+
       if (
-        this.getUrlWithoutQueryParameters(redirectUriUrlInstance).toString() !== this.getUrlWithoutQueryParameters(currentUrlInstance).toString() ||
-        !this.queryParametersExist(redirectUriUrlInstance.searchParams, currentUrlInstance.searchParams)
+        redirectUriWithoutQueryParams !== currentUrlWithoutQueryParams ||
+        !redirectUriQueryParamsArePresentInCurrentUrl
       ) {
         return false;
       }

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -57,6 +57,18 @@ export class UrlService {
     return u;
   }
 
+  queryParametersExist(expected: URLSearchParams, actual: URLSearchParams): boolean {
+    let r = true;
+
+    expected.forEach((v, k) => {
+      if (!actual.has(k)) {
+        r = false;
+      }
+    });
+
+    return r;
+  }
+
     return CALLBACK_PARAMS_TO_CHECK.some(
       (x) => !!this.getUrlParameter(currentUrl, x)
     );

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -41,6 +41,22 @@ export class UrlService {
   }
 
   isCallbackFromSts(currentUrl: string): boolean {
+  getUrlWithoutQueryParameters(url: URL): URL {
+    const u = new URL(url.toString());
+
+    const keys = [];
+
+    for (const key of u.searchParams.keys()) {
+      keys.push(key);
+    }
+
+    keys.forEach((key) => {
+      u.searchParams.delete(key);
+    });
+
+    return u;
+  }
+
     return CALLBACK_PARAMS_TO_CHECK.some(
       (x) => !!this.getUrlParameter(currentUrl, x)
     );

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -40,7 +40,6 @@ export class UrlService {
     return results === null ? '' : decodeURIComponent(results[1]);
   }
 
-  isCallbackFromSts(currentUrl: string): boolean {
   getUrlWithoutQueryParameters(url: URL): URL {
     const u = new URL(url.toString());
 
@@ -68,6 +67,19 @@ export class UrlService {
 
     return r;
   }
+
+  isCallbackFromSts(currentUrl: string, config?: OpenIdConfiguration): boolean {
+    if (config && config.checkRedirectUrlWhenCheckingIfIsCallback) {
+      const currentUrlInstance = new URL(currentUrl);
+      const redirectUriUrlInstance = new URL(this.getRedirectUrl(config));
+
+      if (
+        this.getUrlWithoutQueryParameters(redirectUriUrlInstance).toString() !== this.getUrlWithoutQueryParameters(currentUrlInstance).toString() ||
+        !this.queryParametersExist(redirectUriUrlInstance.searchParams, currentUrlInstance.searchParams)
+      ) {
+        return false;
+      }
+    }
 
     return CALLBACK_PARAMS_TO_CHECK.some(
       (x) => !!this.getUrlParameter(currentUrl, x)


### PR DESCRIPTION
Hey @damienbod :)

Let me know if I've missed or misunderstood anything.
Also let me know if you want a PR for 17 as well.


I added the option to match current URL to the redirect URI when determining whether or not it's a callback.

Fixes #1935 with backwards compatibility.

Also added a comment in the config interface saying `NB: Default will be true in v18.` (for the new `checkRedirectUrlWhenCheckingIfIsCallback` config option), as I do think that this should be done, because the default should be to only regard the redirect URI as a possible callback URL.