### PR TITLE
Fix issue #1954: Ensure CheckingAuthFinished event fires regardless of authentication state

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.spec.ts
@@ -608,6 +608,28 @@ describe('CheckAuthService', () => {
         ]);
       });
     }));
+
+    it('fires CheckingAuth-Event on start and finished event on end if not authenticated', waitForAsync(() => {
+      const allConfigs = [
+        { configId: 'configId1', authority: 'some-authority' },
+      ];
+
+      spyOn(currentUrlService, 'getCurrentUrl').and.returnValue(
+        'http://localhost:4200'
+      );
+      spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
+        false
+      );
+
+      const fireEventSpy = spyOn(publicEventsService, 'fireEvent');
+
+      checkAuthService.checkAuth(allConfigs[0], allConfigs).subscribe(() => {
+        expect(fireEventSpy.calls.allArgs()).toEqual([
+          [EventTypes.CheckingAuth],
+          [EventTypes.CheckingAuthFinished],
+        ]);
+      });
+    }));
   });
 
   describe('checkAuthIncludingServer', () => {

--- a/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
@@ -257,9 +257,8 @@ export class CheckAuthService {
             this.authStateService.setAuthenticatedAndFireEvent(allConfigs);
             this.userService.publishUserDataIfExists(config, allConfigs);
           }
-
-          this.publicEventsService.fireEvent(EventTypes.CheckingAuthFinished);
         }
+        this.publicEventsService.fireEvent(EventTypes.CheckingAuthFinished);
 
         const result: LoginResponse = {
           isAuthenticated,


### PR DESCRIPTION
Hello,

This pull request addresses issue [#1954](https://github.com/damienbod/angular-auth-oidc-client/issues/1954) by ensuring that the `EventTypes.CheckingAuthFinished` event is fired regardless of the authentication state.

### Problem

In commit [4143e2444330dc86ab3a59574f7511b461e75a61](https://github.com/damienbod/angular-auth-oidc-client/commit/4143e2444330dc86ab3a59574f7511b461e75a61), the `fireEvent(EventTypes.CheckingAuthFinished)` was moved inside the `if (isAuthenticated)` block. This change caused the event not to fire when the authentication state is false, which leads to the issue described in #1954.