### PR TITLE
feat: add support for route data to autoLoginPartialRoutesGuard

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.spec.ts
@@ -438,6 +438,37 @@ describe(`AutoLoginPartialRoutesGuard`, () => {
         });
       }));
 
+      it('should save current route and call `login` if not authenticated already and add custom params', waitForAsync(() => {
+        spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
+          false
+        );
+        const checkSavedRedirectRouteAndNavigateSpy = spyOn(
+          autoLoginService,
+          'checkSavedRedirectRouteAndNavigate'
+        );
+        const saveRedirectRouteSpy = spyOn(
+          autoLoginService,
+          'saveRedirectRoute'
+        );
+        const loginSpy = spyOn(loginService, 'login');
+
+        const guard$ = TestBed.runInInjectionContext(
+          () => autoLoginPartialRoutesGuard({data: {custom: 'param'}} as unknown as ActivatedRouteSnapshot)
+        );
+
+        guard$.subscribe(() => {
+          expect(saveRedirectRouteSpy).toHaveBeenCalledOnceWith(
+            { configId: 'configId1' },
+            ''
+          );
+          expect(loginSpy).toHaveBeenCalledOnceWith(
+            { configId: 'configId1' },
+            { customParams: { custom: 'param' } }
+          );
+          expect(checkSavedRedirectRouteAndNavigateSpy).not.toHaveBeenCalled();
+        });
+      }));
+
       it('should call `checkSavedRedirectRouteAndNavigate` if authenticated already', waitForAsync(() => {
         spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
           true

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
@@ -77,12 +77,15 @@ export class AutoLoginPartialRoutesGuard {
   }
 }
 
-export function autoLoginPartialRoutesGuard(): Observable<boolean> {
+export function autoLoginPartialRoutesGuard(route?: ActivatedRouteSnapshot): Observable<boolean> {
   const configurationService = inject(ConfigurationService);
   const authStateService = inject(AuthStateService);
   const loginService = inject(LoginService);
   const autoLoginService = inject(AutoLoginService);
   const router = inject(Router);
+  const authOptions: AuthOptions | undefined = route?.data
+    ? { customParams: route.data }
+    : undefined;
 
   const url =
     router.getCurrentNavigation()?.extractedUrl.toString().substring(1) ?? '';
@@ -92,7 +95,8 @@ export function autoLoginPartialRoutesGuard(): Observable<boolean> {
     configurationService,
     authStateService,
     autoLoginService,
-    loginService
+    loginService,
+    authOptions
   );
 }
 


### PR DESCRIPTION
This PR adds the option to provide `authOptions` using the functional guard `autoLoginPartialRoutesGuard`.
This was already supported via the class-based version of the guard, but we forgot to include it in the functional guard.