### PR TITLE
Rudimentary fix for popup closing too early

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -198,4 +198,8 @@ export interface OpenIdConfiguration {
    * Authorize request will be sent without code challenge.
    */
   disablePkce?: boolean;
+  /**
+   * Disable cleaning up the popup when receiving invalid messages
+   */
+  disableCleaningPopupOnInvalidMessage?: boolean
 }

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
@@ -94,6 +94,9 @@ export class PopUpService {
 
     const listener = (event: MessageEvent): void => {
       if (!event?.data || typeof event.data !== 'string') {
+        if (config.disableCleaningPopupOnInvalidMessage) {
+          return;
+        }
         this.cleanUp(listener, config);
 
         return;


### PR DESCRIPTION
This is a very basic fix for #1851.

It introduces a new config option and a check for that option in the popup event listener. If the option is set, the listener skips the cleanup step when it determines the message data to not be the correct format.