### PR TITLE
feat: add guard `autoLoginPartialRoutesGuardWithConfig` for specific configurations

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
@@ -78,7 +78,8 @@ export class AutoLoginPartialRoutesGuard {
 }
 
 export function autoLoginPartialRoutesGuard(
-  route?: ActivatedRouteSnapshot
+  route?: ActivatedRouteSnapshot,
+  configId?: string
 ): Observable<boolean> {
   const configurationService = inject(ConfigurationService);
   const authStateService = inject(AuthStateService);
@@ -98,8 +99,16 @@ export function autoLoginPartialRoutesGuard(
     authStateService,
     autoLoginService,
     loginService,
-    authOptions
+    authOptions,
+    configId
   );
+}
+
+export function autoLoginPartialRoutesGuardWithConfig(
+  configId: string
+): (route?: ActivatedRouteSnapshot) => Observable<boolean> {
+  return (route?: ActivatedRouteSnapshot) =>
+    autoLoginPartialRoutesGuard(route, configId);
 }
 
 function checkAuth(
@@ -108,9 +117,10 @@ function checkAuth(
   authStateService: AuthStateService,
   autoLoginService: AutoLoginService,
   loginService: LoginService,
-  authOptions?: AuthOptions
+  authOptions?: AuthOptions,
+  configId?: string
 ): Observable<boolean> {
-  return configurationService.getOpenIDConfiguration().pipe(
+  return configurationService.getOpenIDConfiguration(configId).pipe(
     map((configuration) => {
       const isAuthenticated =
         authStateService.areAuthStorageTokensValid(configuration);


### PR DESCRIPTION
It is currently not possible to use the login guard for multiple configurations, as the current guard will only check the first configuration. This PR adds `autoLoginPartialRoutesGuardWithConfig`, which accepts a parameter and returns a guard function.

```ts
  ...
  {
    ...
    canActivate: [autoLoginPartialRoutesGuardWithConfig('myConfig')],
  },
```