### PR TITLE
fix: auto login guard passes correct config id

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
@@ -79,6 +79,7 @@ export class AutoLoginPartialRoutesGuard {
 
 export function autoLoginPartialRoutesGuard(
   route?: ActivatedRouteSnapshot,
+  state?: RouterStateSnapshot,
   configId?: string
 ): Observable<boolean> {
   const configurationService = inject(ConfigurationService);
@@ -106,9 +107,12 @@ export function autoLoginPartialRoutesGuard(
 
 export function autoLoginPartialRoutesGuardWithConfig(
   configId: string
-): (route?: ActivatedRouteSnapshot) => Observable<boolean> {
-  return (route?: ActivatedRouteSnapshot) =>
-    autoLoginPartialRoutesGuard(route, configId);
+): (
+  route?: ActivatedRouteSnapshot,
+  state?: RouterStateSnapshot
+) => Observable<boolean> {
+  return (route?: ActivatedRouteSnapshot, state?: RouterStateSnapshot) =>
+    autoLoginPartialRoutesGuard(route, state, configId);
 }
 
 function checkAuth(


### PR DESCRIPTION
Closes #2007 

This PR corrects the arguments that are passed to the functional guards.
The second argument is always the state.

Without the parameter the state was passed as config id where `autoLoginPartialRoutesGuard` was used.

I tested both guards within the standalone application and everything seems fine after this change.

One question that came to surface was if we should provide a better error message when there's something wrong with the config.
A quick-win that helps the developer is mentioning the config id in the error message.

For example, if an non-existing config id is used with `autoLoginPartialRoutesGuardWithConfig` the following error is thrown, which doesn't help the developer.

```
Error: Please provide a configuration before setting up the module
```

I can turn this question into an issue and/or PR if you'd like.