### PR TITLE
feat: log when provided configId does not exist

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/config.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/config.service.spec.ts
@@ -120,9 +120,11 @@ describe('Configuration Service', () => {
 
       spyOn(configService as any, 'loadConfigs').and.returnValue(of(configs));
       spyOn(configValidationService, 'validateConfig').and.returnValue(false);
+      const consoleSpy = spyOn(console, 'warn');
 
       configService.getOpenIDConfiguration('configId1').subscribe((config) => {
         expect(config).toBeNull();
+        expect(consoleSpy).toHaveBeenCalledOnceWith(`[angular-auth-oidc-client] No configuration found for config id 'configId1'.`)
       });
     }));
 
@@ -144,6 +146,7 @@ describe('Configuration Service', () => {
 
       spyOn(configService as any, 'loadConfigs').and.returnValue(of(configs));
       spyOn(configValidationService, 'validateConfig').and.returnValue(true);
+      const consoleSpy = spyOn(console, 'warn');
 
       spyOn(storagePersistenceService, 'read').and.returnValue({
         issuer: 'auth-well-known',
@@ -153,6 +156,7 @@ describe('Configuration Service', () => {
         expect(config?.authWellknownEndpoints).toEqual({
           issuer: 'auth-well-known',
         });
+        expect(consoleSpy).not.toHaveBeenCalled()
       });
     }));
 

--- a/projects/angular-auth-oidc-client/src/lib/config/config.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/config.service.ts
@@ -1,4 +1,4 @@
-﻿import { inject, Injectable } from '@angular/core';
+﻿import {inject, Injectable, isDevMode} from '@angular/core';
 import { forkJoin, Observable, of } from 'rxjs';
 import { concatMap, map } from 'rxjs/operators';
 import { LoggerService } from '../logging/logger.service';
@@ -85,7 +85,13 @@ export class ConfigurationService {
 
   private getConfig(configId?: string): OpenIdConfiguration | null {
     if (Boolean(configId)) {
-      return this.configsInternal[configId as string] || null;
+      const config = this.configsInternal[configId!];
+
+      if(!config && isDevMode()) {
+        console.warn(`[angular-auth-oidc-client] No configuration found for config id '${configId}'.`);
+      }
+
+      return config || null;
     }
 
     const [, value] = Object.entries(this.configsInternal)[0] || [[null, null]];


### PR DESCRIPTION
As pointed out in #2008, I think this change can help developers when something went wrong.
E.g. instead of figuring out why the config is not set, it logs a message that the config is not found.
I used log to make it a nonintrusive change.