### PR TITLE
fix: prevent guard to be called with wrong parameter

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login-partial-routes.guard.ts
@@ -78,6 +78,18 @@ export class AutoLoginPartialRoutesGuard {
 }
 
 export function autoLoginPartialRoutesGuard(
+  route?: ActivatedRouteSnapshot
+): Observable<boolean> {
+  return callCheckAuthFor(route);
+}
+
+export function autoLoginPartialRoutesGuardWithConfig(
+  configId: string
+): (route?: ActivatedRouteSnapshot) => Observable<boolean> {
+  return (route?: ActivatedRouteSnapshot) => callCheckAuthFor(route, configId);
+}
+
+function callCheckAuthFor(
   route?: ActivatedRouteSnapshot,
   configId?: string
 ): Observable<boolean> {
@@ -102,13 +114,6 @@ export function autoLoginPartialRoutesGuard(
     authOptions,
     configId
   );
-}
-
-export function autoLoginPartialRoutesGuardWithConfig(
-  configId: string
-): (route?: ActivatedRouteSnapshot) => Observable<boolean> {
-  return (route?: ActivatedRouteSnapshot) =>
-    autoLoginPartialRoutesGuard(route, configId);
 }
 
 function checkAuth(


### PR DESCRIPTION
Previously `autoLoginPartialRoutesGuardWithConfig` was added/implemented, which added a parameter to `autoLoginPartialRoutesGuard`. This however introduced a subtle bug, as guards are called with a second parameter, which broke the usage.
This change extracts the common code into its own function and removes the second parameter from `autoLoginPartialRoutesGuard`.