### PR TITLE
Silent renew prompt mode is now configurable via options.

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "bugs": {
     "url": "https://github.com/damienbod/angular-auth-oidc-client/issues"
   },
-  "version": "14.1.5",
+  "version": "14.1.6",
   "scripts": {
     "ng": "ng",
     "build": "npm run build-lib",

--- a/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
@@ -13,6 +13,7 @@ export const DEFAULT_CONFIG: OpenIdConfiguration = {
   postLogoutRedirectUri: 'https://please_set',
   startCheckSession: false,
   silentRenew: false,
+  silentRenewPrompt: 'none',
   silentRenewUrl: 'https://please_set',
   silentRenewTimeoutInSeconds: 20,
   renewTimeBeforeTokenExpiresInSeconds: 0,

--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -56,6 +56,8 @@ export interface OpenIdConfiguration {
   silentRenew?: boolean;
   /** An optional URL to handle silent renew callbacks */
   silentRenewUrl?: string;
+  /** An optional prompt value when performing silent renew. Default is 'none' if not provided.  */
+  silentRenewPrompt?: string;
   /**
    * Sets the maximum waiting time for silent renew process. If this time is exceeded, the silent renew state will
    * be reset. Default = 20.

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -408,7 +408,7 @@ export class UrlService {
     const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints', configuration);
 
     if (authWellKnownEndPoints) {
-      return this.createAuthorizeUrl('', silentRenewUrl, nonce, state, configuration, 'none', customParams);
+      return this.createAuthorizeUrl('', silentRenewUrl, nonce, state, configuration, configuration.silentRenewPrompt, customParams);
     }
 
     this.loggerService.logError(configuration, 'authWellKnownEndpoints is undefined');
@@ -439,7 +439,7 @@ export class UrlService {
         const authWellKnownEndPoints = this.storagePersistenceService.read('authWellKnownEndPoints', configuration);
 
         if (authWellKnownEndPoints) {
-          return this.createAuthorizeUrl(codeChallenge, silentRenewUrl, nonce, state, configuration, 'none', customParams);
+          return this.createAuthorizeUrl(codeChallenge, silentRenewUrl, nonce, state, configuration,configuration.silentRenewPrompt, customParams);
         }
 
         this.loggerService.logWarning(configuration, 'authWellKnownEndpoints is undefined');


### PR DESCRIPTION
Allow to configure the prompt option used when performing a silent renew. 

Helps to fix #1856 