### PR TITLE
docs: update example for custom-storage service to align with AbstractSecurityStorage interface

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/custom-storage.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/custom-storage.md
@@ -14,11 +14,11 @@ import { AbstractSecurityStorage } from 'angular-auth-oidc-client';
 
 @Injectable()
 export class MyStorageService implements AbstractSecurityStorage {
-  read(key: string) {
+  read(key: string): string | null {
     return localStorage.getItem(key);
   }
 
-  write(key: string, value: any): void {
+  write(key: string, value: string): void {
     localStorage.setItem(key, value);
   }
 


### PR DESCRIPTION
I found this small issue with the docs when I copy pasted the example. Thanks for the library!