### PR TITLE
Prevent event listener accumulation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,7 +55,7 @@ jobs:
         run: ls
 
       - name: Upload Artefact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: angular_auth_oidc_client_artefact
           path: dist/angular-auth-oidc-client
@@ -71,7 +71,7 @@ jobs:
           node-version: 20
 
       - name: Download Artefact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: angular_auth_oidc_client_artefact
           path: angular-auth-oidc-client-artefact
@@ -111,7 +111,7 @@ jobs:
           node-version: 20
 
       - name: Download Artefact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: angular_auth_oidc_client_artefact
           path: angular-auth-oidc-client-artefact
@@ -151,7 +151,7 @@ jobs:
           node-version: 20
 
       - name: Download Artefact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: angular_auth_oidc_client_artefact
           path: angular-auth-oidc-client-artefact
@@ -191,7 +191,7 @@ jobs:
           node-version: 20
 
       - name: Download Artefact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: angular_auth_oidc_client_artefact
           path: angular-auth-oidc-client-artefact
@@ -235,7 +235,7 @@ jobs:
             node-version: 18
 
         - name: Download Artefact
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             name: angular_auth_oidc_client_artefact
             path: angular-auth-oidc-client-artefact

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
@@ -304,6 +304,60 @@ describe('CheckSessionService', () => {
     }));
   });
 
+  describe('bindMessageEventToIframe', () => {
+    it('remove event listener when iframeMessageEventListener already exist', () => {
+      const serviceAsAny = checkSessionService as any;
+      const defaultView = serviceAsAny.document.defaultView;
+      const configuration = { configId: 'configId1' };
+      const existingListener = serviceAsAny.messageHandler.bind(
+        this,
+        configuration
+      );
+
+      serviceAsAny.iframeMessageEventListener = existingListener;
+
+      const spyRemoveEventListener = spyOn(defaultView, 'removeEventListener');
+
+      serviceAsAny.bindMessageEventToIframe(configuration);
+
+      expect(spyRemoveEventListener).toHaveBeenCalledOnceWith(
+        'message',
+        existingListener,
+        false
+      );
+    });
+
+    it('doesn\'t remove event listener when iframeMessageEventListener not exist', () => {
+      const serviceAsAny = checkSessionService as any;
+      const defaultView = serviceAsAny.document.defaultView;
+
+      serviceAsAny.iframeMessageEventListener = undefined;
+
+      const spyRemoveEventListener = spyOn(defaultView, 'removeEventListener');
+      const configuration = { configId: 'configId1' };
+
+      serviceAsAny.bindMessageEventToIframe(configuration);
+
+      expect(spyRemoveEventListener).not.toHaveBeenCalled();
+    });
+
+    it('add event listener', () => {
+      const serviceAsAny = checkSessionService as any;
+      const defaultView = serviceAsAny.document.defaultView;
+
+      const spyAddEventListener = spyOn(defaultView, 'addEventListener');
+      const configuration = { configId: 'configId1' };
+
+      serviceAsAny.bindMessageEventToIframe(configuration);
+
+      expect(spyAddEventListener).toHaveBeenCalledOnceWith(
+        'message',
+        jasmine.any(Function),
+        false
+      );
+    });
+  });
+
   describe('isCheckSessionConfigured', () => {
     it('returns true if startCheckSession on config is true', () => {
       const config = { configId: 'configId1', startCheckSession: true };

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -289,12 +289,16 @@ export class CheckSessionService implements OnDestroy {
   }
 
   private bindMessageEventToIframe(configuration: OpenIdConfiguration): void {
+    const defaultView = this.document.defaultView;
+
+    if (this.iframeMessageEventListener && defaultView) {
+      defaultView.removeEventListener('message', this.iframeMessageEventListener, false);
+    }
+
     this.iframeMessageEventListener = this.messageHandler.bind(
       this,
       configuration
     );
-
-    const defaultView = this.document.defaultView;
 
     if (defaultView) {
       defaultView.addEventListener(


### PR DESCRIPTION
Fix event listener leak in CheckSession service

After migrating our applications to Angular 17, users reported significant performance degradation after 2-3 hours of application usage. Our analysis revealed abnormal CPU usage and an increasing number of event listeners without any user actions.

This issue was previously reported in [#2015.](https://github.com/damienbod/angular-auth-oidc-client/issues/2015) Implementing the proposed solution on fork resolved the performance problems.

Changes made:
- Properly remove existing event listeners before adding new ones in CheckSession service
- Prevent event listener accumulation during session checks
- Add unit test

This fix addresses the eventListener leak that was causing performance degradation over time.

Related issue: [#2015](https://github.com/damienbod/angular-auth-oidc-client/issues/2015)