### PR TITLE
Feature/OIDC error

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.spec.ts
@@ -218,6 +218,7 @@ describe('CheckAuthService', () => {
           expect(result).toEqual({
             isAuthenticated: false,
             errorMessage: 'ERROR',
+            oidcError: undefined,
             configId: 'configId1',
             idToken: '',
             userData: null,
@@ -833,7 +834,8 @@ describe('CheckAuthService', () => {
       const allConfigs = [
         { configId: 'configId1', authority: 'some-authority1' },
         { configId: 'configId2', authority: 'some-authority2' },
-      ];      const spy = spyOn(
+      ];
+      const spy = spyOn(
         checkAuthService as any,
         'checkAuthWithConfig'
       ).and.callThrough();
@@ -863,7 +865,8 @@ describe('CheckAuthService', () => {
       const allConfigs = [
         { configId: 'configId1', authority: 'some-authority1' },
         { configId: 'configId2', authority: 'some-authority2' },
-      ];      const spy = spyOn(
+      ];
+      const spy = spyOn(
         checkAuthService as any,
         'checkAuthWithConfig'
       ).and.callThrough();

--- a/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
@@ -17,6 +17,7 @@ import { StoragePersistenceService } from '../storage/storage-persistence.servic
 import { UserService } from '../user-data/user.service';
 import { CurrentUrlService } from '../utils/url/current-url.service';
 import { AuthStateService } from './auth-state.service';
+import { OidcError } from '../flows/callback-handling/oidc-error';
 
 @Injectable({ providedIn: 'root' })
 export class CheckAuthService {
@@ -263,7 +264,9 @@ export class CheckAuthService {
           this.autoLoginService.checkSavedRedirectRouteAndNavigate(config);
         }
       }),
-      catchError(({ message }) => {
+      catchError(error => {
+        const message = error.message;
+
         this.loggerService.logError(config, message);
         this.publicEventsService.fireEvent(
           EventTypes.CheckingAuthFinishedWithError,
@@ -273,6 +276,7 @@ export class CheckAuthService {
         const result: LoginResponse = {
           isAuthenticated: false,
           errorMessage: message,
+          oidcError: error instanceof OidcError ? error : undefined,
           userData: null,
           idToken: '',
           accessToken: '',

--- a/projects/angular-auth-oidc-client/src/lib/callback/code-flow-callback.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/code-flow-callback.service.ts
@@ -7,6 +7,7 @@ import { CallbackContext } from '../flows/callback-context';
 import { FlowsDataService } from '../flows/flows-data.service';
 import { FlowsService } from '../flows/flows.service';
 import { IntervalService } from './interval.service';
+import { OidcError } from '../flows/callback-handling/oidc-error';
 
 @Injectable({ providedIn: 'root' })
 export class CodeFlowCallbackService {
@@ -43,6 +44,10 @@ export class CodeFlowCallbackService {
           this.intervalService.stopPeriodicTokenCheck();
           if (!triggerAuthorizationResultEvent && !isRenewProcess) {
             this.router.navigateByUrl(unauthorizedRoute);
+          }
+
+          if (error instanceof OidcError) {
+            return throwError(() => error);
           }
 
           return throwError(() => new Error(error));

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/code-flow-callback-handler.service.ts
@@ -11,6 +11,7 @@ import { TokenValidationService } from '../../validation/token-validation.servic
 import { AuthResult, CallbackContext } from '../callback-context';
 import { FlowsDataService } from '../flows-data.service';
 import { isNetworkError } from './error-helper';
+import { OidcError } from './oidc-error';
 
 @Injectable({ providedIn: 'root' })
 export class CodeFlowCallbackHandlerService {
@@ -30,6 +31,9 @@ export class CodeFlowCallbackHandlerService {
   ): Observable<CallbackContext> {
     const code = this.urlService.getUrlParameter(urlToCheck, 'code');
     const state = this.urlService.getUrlParameter(urlToCheck, 'state');
+    const error = this.urlService.getUrlParameter(urlToCheck, 'error');
+    const errorDescription = this.urlService.getUrlParameter(urlToCheck, 'error_description');
+    const errorUri = this.urlService.getUrlParameter(urlToCheck, 'error_uri');
     const sessionState = this.urlService.getUrlParameter(
       urlToCheck,
       'session_state'
@@ -39,6 +43,12 @@ export class CodeFlowCallbackHandlerService {
       this.loggerService.logDebug(config, 'no state in url');
 
       return throwError(() => new Error('no state in url'));
+    }
+
+    if (error) {
+      this.loggerService.logDebug(config, 'error in callback', error);
+
+      return throwError(() => new OidcError(error, errorDescription, errorUri));
     }
 
     if (!code) {

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/oidc-error.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/oidc-error.ts
@@ -1,0 +1,18 @@
+   export class OidcError extends Error {
+     error: string;
+
+     errorDescription?: string;
+
+     errorUri?: string;
+
+     constructor(error: string, errorDescription?: string, errorUri?: string) {
+       super(errorDescription || error); // Pass the error description or error to the base Error class
+       this.name = 'OidcError';
+       this.error = error;
+       this.errorDescription = errorDescription;
+       this.errorUri = errorUri;
+
+       // Set the prototype explicitly to retain the instance type in JavaScript
+       Object.setPrototypeOf(this, OidcError.prototype);
+     }
+   }

--- a/projects/angular-auth-oidc-client/src/lib/login/login-response.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/login-response.ts
@@ -1,3 +1,5 @@
+import { OidcError } from '../flows/callback-handling/oidc-error';
+
 export interface LoginResponse {
   isAuthenticated: boolean;
   userData: any;
@@ -5,4 +7,5 @@ export interface LoginResponse {
   idToken: string;
   configId?: string;
   errorMessage?: string;
+  oidcError?: OidcError;
 }


### PR DESCRIPTION
When the authorization server redirects back to the callback url with parameters "error" and potentially "error_description" and "error_uri" those are read and propagated within the LoginResponse in an oidcError field.

This is just a suggestion serving as inspiration to the maintainers. I have little experience with the project and look forward to seeing this issue take steps forward, as we think the mentioned parameters should be propagated to those using this library.

#976 