### PR TITLE
fix: Allow trailing slash when comparing OIDC issuer and OIDC discovery URL

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
@@ -271,6 +271,28 @@ describe('AuthWellKnownDataService', () => {
       });
     }));
 
+    it('should not throws error and logs if well known issuer has a trailing slash compared to authwellknownUrl ', waitForAsync(() => {
+      const trailingSlashIssuerWellKnown = {
+        ...DUMMY_WELL_KNOWN_DOCUMENT,
+        issuer: DUMMY_WELL_KNOWN_DOCUMENT.issuer+"/"
+      };
+
+      spyOn(dataService, 'get').and.returnValue(of(trailingSlashIssuerWellKnown));
+
+      const expected: AuthWellKnownEndpoints = {
+        issuer: DUMMY_WELL_KNOWN_DOCUMENT.issuer+"/",
+      };
+
+      service
+        .getWellKnownEndPointsForConfig({
+          configId: 'configId1',
+          authWellknownEndpointUrl: DUMMY_WELL_KNOWN_DOCUMENT.issuer
+        })
+        .subscribe((result) => {
+          expect(result).toEqual(jasmine.objectContaining(expected));
+        });
+    }));
+
     it('should merge the mapped endpoints with the provided endpoints and ignore issuer/authwellknownUrl mismatch', waitForAsync(() => {
       const maliciousWellKnown = {
         ...DUMMY_WELL_KNOWN_DOCUMENT,

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.ts
@@ -51,8 +51,9 @@ export class AuthWellKnownDataService {
         (wellKnownEndpoints) => {
           const issuer = wellKnownEndpoints.issuer || "";
           const wellKnownSuffix = config.authWellknownUrlSuffix || WELL_KNOWN_SUFFIX;
-
-          if (issuer !== authWellknownEndpointUrl.replace(wellKnownSuffix, "")) {
+          const configuredWellKnownEndpoint = authWellknownEndpointUrl.replace(wellKnownSuffix, "");
+          
+          if (issuer !== configuredWellKnownEndpoint && issuer !== `${configuredWellKnownEndpoint}/`) {
             const errorMessage = `Issuer mismatch. Well known issuer ${wellKnownEndpoints.issuer} does not match configured well known url ${authWellknownEndpointUrl}`;
 
             this.loggerService.logError(config, errorMessage);


### PR DESCRIPTION
Follow up of #2116 

Fix **Auth0** related samples (Trailing slash on returned `issuer`) : 

- start-sample-code-flow-multi-Auth0-ID4
- start-sample-code-flow-multi-Auth0-ID4-popup
- start-sample-code-flow-auth0