### PR TITLE
Fixed wrong DOCUMENT import. Change from @angular/core to @angular/common

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/implicit-flow-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/implicit-flow-callback-handler.service.spec.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { mockProvider } from '../../../test/auto-mock';
 import { LoggerService } from '../../logging/logger.service';

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/state-validation-callback-handler.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/state-validation-callback-handler.service.spec.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { mockProvider } from '../../../test/auto-mock';

--- a/projects/angular-auth-oidc-client/src/lib/utils/crypto/crypto.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/crypto/crypto.service.spec.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { CryptoService } from './crypto.service';
 

--- a/projects/angular-auth-oidc-client/src/lib/utils/redirect/redirect.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/redirect/redirect.service.spec.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { RedirectService } from './redirect.service';
 

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/current-url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/current-url.service.spec.ts
@@ -1,4 +1,4 @@
-import { DOCUMENT } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 import { TestBed } from '@angular/core/testing';
 import { CurrentUrlService } from './current-url.service';
 


### PR DESCRIPTION
I was getting build errors that were happening because DOCUMENT was getting imported from @angular/core instead of @angular/common. This PR addresses that issue.