### PR TITLE
fix: prevent clear() from destroying all sessionStorage

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.ts
@@ -67,6 +67,17 @@ export class BrowserStorageService {
   }
 
   remove(key: string, configuration: OpenIdConfiguration): boolean {
+    const { configId } = configuration;
+
+    if (!configId) {
+      this.loggerService.logDebug(
+        configuration,
+        `Wanted to remove '${key}' but configId was '${configId}'`
+      );
+
+      return false;
+    }
+
     if (!this.hasStorage()) {
       this.loggerService.logDebug(
         configuration,
@@ -76,20 +87,23 @@ export class BrowserStorageService {
       return false;
     }
 
-    // const storage = this.getStorage(configuration);
-    // if (!storage) {
-    //   this.loggerService.logDebug(configuration, `Wanted to write '${key}' but Storage was falsy`);
-
-    //   return false;
-    // }
-
-    this.abstractSecurityStorage.remove(key);
+    this.abstractSecurityStorage.remove(configId);
 
     return true;
   }
 
-  // TODO THIS STORAGE WANTS AN ID BUT CLEARS EVERYTHING
   clear(configuration: OpenIdConfiguration): boolean {
+    const { configId } = configuration;
+
+    if (!configId) {
+      this.loggerService.logDebug(
+        configuration,
+        `Wanted to clear storage but configId was '${configId}'`
+      );
+
+      return false;
+    }
+
     if (!this.hasStorage()) {
       this.loggerService.logDebug(
         configuration,
@@ -99,14 +113,7 @@ export class BrowserStorageService {
       return false;
     }
 
-    // const storage = this.getStorage(configuration);
-    // if (!storage) {
-    //   this.loggerService.logDebug(configuration, `Wanted to clear storage but Storage was falsy`);
-
-    //   return false;
-    // }
-
-    this.abstractSecurityStorage.clear();
+    this.abstractSecurityStorage.remove(configId);
 
     return true;
   }


### PR DESCRIPTION
Hey @damienbod (and fellow contributors!) - thanks for this library and all the work maintaining it!

### Summary

This PR updates the storage behavior in `BrowserStorageService` to ensure that `clear()` and `remove()` only remove data associated with the specific OIDC configuration, instead of clearing all browser storage for the origin.

### Problem

The previous implementation called `abstractSecurityStorage.clear()`, which could result in the underlying `sessionStorage.clear()` / `localStorage.clear()` being invoked. This cleared all keys for the origin, including:

- Other OIDC configuration entries (in multi-config setups)
- Application-managed session/local storage (e.g., analytics, support widgets, SPA state)

### Goal

Ensure correct isolation between configurations and preserve consumer application data, while maintaining compatibility with the existing storage contract.

### Changes

- `clear()` and `remove()` now remove only the entry associated with the current `configId`
- Added guard to ensure `configId` exists before storing / clearing
- Behavior now matches `read()` and `write()`, which already operate on `configId`

### Benefits

- Proper isolation for multi-configuration setups
- Prevents accidental erasure of application storage
- Fully backward-compatible — behavior aligns with existing read/write patterns

Thanks again @damienbod for the library, happy to adjust anything here if needed! I appreciate the time and consideration!
