### PR TITLE
fix: refresh authWellKnownEndpoints when the server updates them

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.spec.ts
@@ -216,12 +216,12 @@ describe('AuthWellKnownDataService', () => {
       });
     }));
 
-    it('should merge the mapped endpoints with the provided endpoints', waitForAsync(() => {
+    it('maps only server-fetched endpoints without merging config overrides', waitForAsync(() => {
       spyOn(dataService, 'get').and.returnValue(of(DUMMY_WELL_KNOWN_DOCUMENT));
 
       const expected: AuthWellKnownEndpoints = {
-        endSessionEndpoint: 'config-endSessionEndpoint',
-        revocationEndpoint: 'config-revocationEndpoint',
+        endSessionEndpoint: DUMMY_WELL_KNOWN_DOCUMENT.end_session_endpoint,
+        tokenEndpoint: DUMMY_WELL_KNOWN_DOCUMENT.token_endpoint,
         jwksUri: DUMMY_WELL_KNOWN_DOCUMENT.jwks_uri
       };
 
@@ -236,6 +236,10 @@ describe('AuthWellKnownDataService', () => {
         })
         .subscribe((result) => {
           expect(result).toEqual(jasmine.objectContaining(expected));
+          expect(result.endSessionEndpoint).not.toBe('config-endSessionEndpoint');
+          expect(result.tokenEndpoint).toBe(
+            DUMMY_WELL_KNOWN_DOCUMENT.token_endpoint
+          );
         });
     }));
 
@@ -324,7 +328,8 @@ describe('AuthWellKnownDataService', () => {
         });
     }));
 
-    it('should merge the mapped endpoints with the provided endpoints and ignore issuer/authwellknownUrl mismatch', waitForAsync(() => {
+    it('throws error for issuer mismatch even when authWellknownEndpoints has issuer override', waitForAsync(() => {
+      const loggerSpy = spyOn(loggerService, 'logError');
       const maliciousWellKnown = {
         ...DUMMY_WELL_KNOWN_DOCUMENT,
         issuer: DUMMY_MALICIOUS_URL
@@ -332,26 +337,28 @@ describe('AuthWellKnownDataService', () => {
 
       spyOn(dataService, 'get').and.returnValue(of(maliciousWellKnown));
 
-      const expected: AuthWellKnownEndpoints = {
-        endSessionEndpoint: 'config-endSessionEndpoint',
-        revocationEndpoint: 'config-revocationEndpoint',
-        jwksUri: DUMMY_WELL_KNOWN_DOCUMENT.jwks_uri,
-        issuer: DUMMY_WELL_KNOWN_DOCUMENT.issuer,
+      const config = {
+        configId: 'configId1',
+        authWellknownEndpointUrl: DUMMY_WELL_KNOWN_DOCUMENT.issuer,
+        authWellknownEndpoints: {
+          endSessionEndpoint: 'config-endSessionEndpoint',
+          revocationEndpoint: 'config-revocationEndpoint',
+          issuer: DUMMY_WELL_KNOWN_DOCUMENT.issuer
+        },
       };
 
-      service
-        .getWellKnownEndPointsForConfig({
-          configId: 'configId1',
-          authWellknownEndpointUrl: DUMMY_WELL_KNOWN_DOCUMENT.issuer,
-          authWellknownEndpoints: {
-            endSessionEndpoint: 'config-endSessionEndpoint',
-            revocationEndpoint: 'config-revocationEndpoint',
-            issuer: DUMMY_WELL_KNOWN_DOCUMENT.issuer
-          },
-        })
-        .subscribe((result) => {
-          expect(result).toEqual(jasmine.objectContaining(expected));
-        });
+      service.getWellKnownEndPointsForConfig(config).subscribe({
+        next: (result) => {
+          fail(`Retrieval was supposed to fail. Well known endpoints returned : ${JSON.stringify(result)}`);
+        },
+        error: (error) => {
+          expect(loggerSpy).toHaveBeenCalledOnceWith(
+            config,
+            `Issuer mismatch. Well known issuer ${DUMMY_MALICIOUS_URL} does not match configured well known url ${DUMMY_WELL_KNOWN_DOCUMENT.issuer}`
+          );
+          expect(error.message).toEqual(`Issuer mismatch. Well known issuer ${DUMMY_MALICIOUS_URL} does not match configured well known url ${DUMMY_WELL_KNOWN_DOCUMENT.issuer}`);
+        }
+      });
     }));
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known-data.service.ts
@@ -16,7 +16,7 @@ export class AuthWellKnownDataService {
   getWellKnownEndPointsForConfig(
     config: OpenIdConfiguration
   ): Observable<AuthWellKnownEndpoints> {
-    const { authWellknownEndpointUrl, authWellknownEndpoints = {} } = config;
+    const { authWellknownEndpointUrl } = config;
 
     if (!authWellknownEndpointUrl) {
       const errorMessage = 'no authWellknownEndpoint given!';
@@ -43,16 +43,12 @@ export class AuthWellKnownDataService {
               wellKnownEndpoints.pushed_authorization_request_endpoint,
           } as AuthWellKnownEndpoints)
       ),
-      map((mappedWellKnownEndpoints) => ({
-        ...mappedWellKnownEndpoints,
-        ...authWellknownEndpoints,
-      })),
       tap(
         (wellKnownEndpoints) => {
           const issuer = wellKnownEndpoints.issuer || "";
           const wellKnownSuffix = config.authWellknownUrlSuffix || WELL_KNOWN_SUFFIX;
           const configuredWellKnownEndpoint = authWellknownEndpointUrl.replace(wellKnownSuffix, "");
-          
+
           if (!config.strictIssuerValidationOnWellKnownRetrievalOff && issuer !== configuredWellKnownEndpoint && issuer !== `${configuredWellKnownEndpoint}/`) {
             const errorMessage = `Issuer mismatch. Well known issuer ${wellKnownEndpoints.issuer} does not match configured well known url ${authWellknownEndpointUrl}`;
 

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.spec.ts
@@ -48,7 +48,7 @@ describe('AuthWellKnownService', () => {
       });
     }));
 
-    it('getAuthWellKnownEndPoints calls always dataservice', waitForAsync(() => {
+    it('calls dataservice when no explicit endpoints are configured', waitForAsync(() => {
       const dataServiceSpy = spyOn(
         dataService,
         'getWellKnownEndPointsForConfig'
@@ -104,6 +104,59 @@ describe('AuthWellKnownService', () => {
               null
             );
           },
+        });
+    }));
+
+    it('does not call dataservice when authWellknownEndpoints is explicitly configured', waitForAsync(() => {
+      const explicitEndpoints = { issuer: 'https://explicit.example.com', tokenEndpoint: 'https://explicit.example.com/token' };
+      const dataServiceSpy = spyOn(dataService, 'getWellKnownEndPointsForConfig');
+
+      service
+        .queryAndStoreAuthWellKnownEndPoints({
+          configId: 'configId1',
+          authWellknownEndpoints: explicitEndpoints,
+        })
+        .subscribe((result) => {
+          expect(dataServiceSpy).not.toHaveBeenCalled();
+          expect(result).toEqual(explicitEndpoints);
+        });
+    }));
+
+    it('stores and returns explicit endpoints without discovery request', waitForAsync(() => {
+      const explicitEndpoints = { issuer: 'https://explicit.example.com', tokenEndpoint: 'https://explicit.example.com/token' };
+      const storeSpy = spyOn(service, 'storeWellKnownEndpoints');
+
+      spyOn(dataService, 'getWellKnownEndPointsForConfig');
+
+      service
+        .queryAndStoreAuthWellKnownEndPoints({
+          configId: 'configId1',
+          authWellknownEndpoints: explicitEndpoints,
+        })
+        .subscribe((result) => {
+          expect(storeSpy).toHaveBeenCalledOnceWith(
+            jasmine.objectContaining({ configId: 'configId1' }),
+            explicitEndpoints
+          );
+          expect(result).toEqual(explicitEndpoints);
+        });
+    }));
+
+    it('always fetches fresh endpoints in discovery mode, ignoring previously stored values', waitForAsync(() => {
+      const freshEndpoints = { issuer: 'https://server.example.com', tokenEndpoint: 'https://server.example.com/token/fresh' };
+      const dataServiceSpy = spyOn(dataService, 'getWellKnownEndPointsForConfig').and.returnValue(of(freshEndpoints));
+      const storeSpy = spyOn(service, 'storeWellKnownEndpoints');
+
+      // config has NO explicit authWellknownEndpoints → discovery path
+      service
+        .queryAndStoreAuthWellKnownEndPoints({ configId: 'configId1' })
+        .subscribe((result) => {
+          expect(dataServiceSpy).toHaveBeenCalled();
+          expect(storeSpy).toHaveBeenCalledOnceWith(
+            jasmine.objectContaining({ configId: 'configId1' }),
+            freshEndpoints
+          );
+          expect(result).toEqual(freshEndpoints);
         });
     }));
   });

--- a/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/auth-well-known/auth-well-known.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { Observable, of, throwError } from 'rxjs';
 import { catchError, tap } from 'rxjs/operators';
 import { EventTypes } from '../../public-events/event-types';
 import { PublicEventsService } from '../../public-events/public-events.service';
@@ -37,6 +37,12 @@ export class AuthWellKnownService {
             'Please provide a configuration before setting up the module'
           )
       );
+    }
+
+    if (config.authWellknownEndpoints) {
+      this.storeWellKnownEndpoints(config, config.authWellknownEndpoints);
+
+      return of(config.authWellknownEndpoints);
     }
 
     return this.dataService.getWellKnownEndPointsForConfig(config).pipe(

--- a/projects/angular-auth-oidc-client/src/lib/config/config.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/config.service.spec.ts
@@ -4,7 +4,6 @@ import { mockAbstractProvider, mockProvider } from '../../test/auto-mock';
 import { LoggerService } from '../logging/logger.service';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { PlatformProvider } from '../utils/platform-provider/platform.provider';
 import { AuthWellKnownService } from './auth-well-known/auth-well-known.service';
 import { ConfigurationService } from './config.service';
@@ -16,7 +15,6 @@ describe('Configuration Service', () => {
   let configService: ConfigurationService;
   let publicEventsService: PublicEventsService;
   let authWellKnownService: AuthWellKnownService;
-  let storagePersistenceService: StoragePersistenceService;
   let configValidationService: ConfigValidationService;
   let platformProvider: PlatformProvider;
   let stsConfigLoader: StsConfigLoader;
@@ -27,7 +25,6 @@ describe('Configuration Service', () => {
         ConfigurationService,
         mockProvider(LoggerService),
         PublicEventsService,
-        mockProvider(StoragePersistenceService),
         ConfigValidationService,
         mockProvider(PlatformProvider),
         mockProvider(AuthWellKnownService),
@@ -40,7 +37,6 @@ describe('Configuration Service', () => {
     configService = TestBed.inject(ConfigurationService);
     publicEventsService = TestBed.inject(PublicEventsService);
     authWellKnownService = TestBed.inject(AuthWellKnownService);
-    storagePersistenceService = TestBed.inject(StoragePersistenceService);
     stsConfigLoader = TestBed.inject(StsConfigLoader);
     platformProvider = TestBed.inject(PlatformProvider);
     configValidationService = TestBed.inject(ConfigValidationService);
@@ -141,33 +137,24 @@ describe('Configuration Service', () => {
         });
     }));
 
-    it(`sets authWellKnownEndPoints on config if authWellKnownEndPoints is stored`, waitForAsync(() => {
+    it(`does not set authWellknownEndpoints on config from storage`, waitForAsync(() => {
       const configs = [{ configId: 'configId1' }];
 
       spyOn(configService as any, 'loadConfigs').and.returnValue(of(configs));
       spyOn(configValidationService, 'validateConfig').and.returnValue(true);
       const consoleSpy = spyOn(console, 'warn');
 
-      spyOn(storagePersistenceService, 'read').and.returnValue({
-        issuer: 'auth-well-known',
-      });
-
       configService.getOpenIDConfiguration('configId1').subscribe((config) => {
-        expect(config?.authWellknownEndpoints).toEqual({
-          issuer: 'auth-well-known',
-        });
-        expect(consoleSpy).not.toHaveBeenCalled()
+        expect(config?.authWellknownEndpoints).toBeUndefined();
+        expect(consoleSpy).not.toHaveBeenCalled();
       });
     }));
 
-    it(`fires ConfigLoaded if authWellKnownEndPoints is stored`, waitForAsync(() => {
+    it(`fires ConfigLoaded when configuration is loaded`, waitForAsync(() => {
       const configs = [{ configId: 'configId1' }];
 
       spyOn(configService as any, 'loadConfigs').and.returnValue(of(configs));
       spyOn(configValidationService, 'validateConfig').and.returnValue(true);
-      spyOn(storagePersistenceService, 'read').and.returnValue({
-        issuer: 'auth-well-known',
-      });
 
       const spy = spyOn(publicEventsService, 'fireEvent');
 
@@ -189,7 +176,6 @@ describe('Configuration Service', () => {
 
       spyOn(configService as any, 'loadConfigs').and.returnValue(of(configs));
       spyOn(configValidationService, 'validateConfig').and.returnValue(true);
-      spyOn(storagePersistenceService, 'read').and.returnValue(null);
 
       const fireEventSpy = spyOn(publicEventsService, 'fireEvent');
       const storeWellKnownEndpointsSpy = spyOn(

--- a/projects/angular-auth-oidc-client/src/lib/config/config.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/config.service.ts
@@ -4,7 +4,6 @@ import { concatMap, map } from 'rxjs/operators';
 import { LoggerService } from '../logging/logger.service';
 import { EventTypes } from '../public-events/event-types';
 import { PublicEventsService } from '../public-events/public-events.service';
-import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { PlatformProvider } from '../utils/platform-provider/platform.provider';
 import { AuthWellKnownService } from './auth-well-known/auth-well-known.service';
 import { DEFAULT_CONFIG } from './default-config';
@@ -18,9 +17,6 @@ export class ConfigurationService {
 
   private readonly loggerService = inject(LoggerService);
   private readonly publicEventsService = inject(PublicEventsService);
-  private readonly storagePersistenceService = inject(
-    StoragePersistenceService
-  );
   private readonly platformProvider = inject(PlatformProvider);
   private readonly authWellKnownService = inject(AuthWellKnownService);
   private readonly loader = inject(StsConfigLoader);
@@ -154,19 +150,6 @@ export class ConfigurationService {
   private enhanceConfigWithWellKnownEndpoint(
     configuration: OpenIdConfiguration
   ): OpenIdConfiguration {
-    const alreadyExistingAuthWellKnownEndpoints =
-      this.storagePersistenceService.read(
-        'authWellKnownEndPoints',
-        configuration
-      );
-
-    if (!!alreadyExistingAuthWellKnownEndpoints) {
-      configuration.authWellknownEndpoints =
-        alreadyExistingAuthWellKnownEndpoints;
-
-      return configuration;
-    }
-
     const passedAuthWellKnownEndpoints = configuration.authWellknownEndpoints;
 
     if (!!passedAuthWellKnownEndpoints) {
@@ -174,9 +157,6 @@ export class ConfigurationService {
         configuration,
         passedAuthWellKnownEndpoints
       );
-      configuration.authWellknownEndpoints = passedAuthWellKnownEndpoints;
-
-      return configuration;
     }
 
     return configuration;


### PR DESCRIPTION
## fix: refresh authWellKnownEndpoints when the server updates them

fix #1983 

### Problem
When using OIDC discovery, `authWellknownEndpoints` could be influenced by previously persisted/config-provided values. That made it possible for **stale overrides** (or cached values) to “win” over the latest server discovery document, preventing the client from correctly refreshing endpoints after the IdP updates them.

### What this PR changes
1. **Discovery results are authoritative**
   - `AuthWellKnownDataService` no longer merges `config.authWellknownEndpoints` into the mapped discovery result.
   - Outcome: in discovery mode, the returned endpoints come from the server’s `/.well-known/openid-configuration` document (i.e., fresh values), instead of being overwritten by potentially stale config overrides.

2. **Issuer mismatch is not bypassed by overrides**
   - Issuer validation now behaves strictly even if `authWellknownEndpoints` contains an `issuer` value.
   - Outcome: a mismatching issuer from discovery still fails fast, rather than being hidden by an override.

3. **Explicit endpoints mode is explicit (no discovery request)**
   - If `authWellknownEndpoints` is explicitly provided, `AuthWellKnownService` returns/stores them and **skips the discovery network call**.
   - This preserves a clear “either/or” contract:
     - Explicit endpoints: deterministic, no network discovery.
     - Discovery: always fetch fresh endpoints from the server.

4. **ConfigurationService no longer hydrates endpoints from storage**
   - `ConfigurationService` stops reading `authWellKnownEndPoints` from `StoragePersistenceService` and stamping them onto the runtime config.
   - Outcome: persisted/stale endpoints do not get injected during config loading.

### Why these decisions
This PR aims to fix #1983 with the smallest behavior change necessary to ensure **refresh correctness**:
- In discovery mode, the server must be the source of truth; otherwise refresh can’t be trusted.
- Merging overrides into discovery results reintroduces staleness and can undermine issuer validation.
- If users want to override endpoints intentionally, they can do so explicitly by providing `authWellknownEndpoints` (and the library won’t perform discovery in that case).

### Tests
- Updated/added unit tests cover:
  - No merging of config overrides into discovery results.
  - Issuer mismatch failing even when overrides exist.
  - Explicit endpoints mode skipping discovery and returning explicit endpoints.
  - ConfigurationService not sourcing endpoints from storage.


