### PR TITLE
ci: build docs only on push to main, not on PRs

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -4,14 +4,9 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - main
 
 jobs:
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
     runs-on: ubuntu-latest
     name: Build and Deploy Docs Job
     steps:
@@ -47,15 +42,3 @@ jobs:
           app_location: '/docs/site/angular-auth-oidc-client' # App source code path
           app_artifact_location: 'build' # Built app content directory - optional
           ###### End of Repository/Build Configurations ######
-
-  close_pull_request_job:
-    if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    runs-on: ubuntu-latest
-    name: Close Pull Request Job
-    steps:
-      - name: Close Pull Request
-        id: closepullrequest
-        uses: Azure/static-web-apps-deploy@v1
-        with:
-          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN }}
-          action: 'close'


### PR DESCRIPTION
## Summary
- Removes the `pull_request` trigger from the Docs workflow so docs only build on push to main.
- Removes the now-orphan `close_pull_request_job` (its only purpose was cleaning up Azure SWA staging environments created per PR; we won't create any).

## Why
Every PR currently fails the **Build and Deploy Docs Job** with:

> The content server has rejected the request with: BadRequest. Reason: This Static Web App already has the maximum number of staging environments. Please remove one and try again.

The Azure Static Web Apps staging-env quota is exhausted. Docs deploy was also pointlessly running on every PR even though the live docs site is only served from main.

## Tradeoff
Doc-only breakages (broken Markdown links, bad Docusaurus directives) won't surface on the PR — they'll appear in the next post-merge run on main. The previous setup did catch these on PRs, so this is a deliberate downgrade for the sake of unblocking PRs.

If you'd rather keep PR-time validation, the alternative is to keep the build step but skip the `Azure/static-web-apps-deploy@v1` upload action on PRs. Happy to do that variant if preferred.

## Manual follow-up
Existing PR staging environments on Azure still need a one-time manual cleanup via the Azure portal (or via Azure CLI) to free the quota. Future PRs won't add new ones.

## Test plan
- [x] Workflow file lints (passes `prettier`/`check-blockwords` via lefthook pre-commit)
- [ ] After merge: confirm next push to main still triggers docs build & deploy
- [ ] Open a fresh PR after merge to confirm no docs job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)