### PR TITLE
fix!: return Observable from logoffLocal and logoffLocalMultiple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Angular Lib for OpenID Connect/OAuth2 Changelog
 
+### Unreleased
+
+- **BREAKING**: `OidcSecurityService.logoffLocal()` and `logoffLocalMultiple()` now return `Observable<unknown>` instead of `void`. Callers must `.subscribe()` for the logoff to fire. Aligns with the other `logoff*` / `revoke*` methods on the service.
+  - [PR](https://github.com/damienbod/angular-auth-oidc-client/pull/2212)
+
 ### 2026-05-01 21.0.2
 
 - Update packages

--- a/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
@@ -238,8 +238,24 @@ The method also takes `configId` and `logoutAuthOptions` parameters if needed.
 
 The `logoffLocal()` method is used to reset your local session in the browser, but does not send anything to the server. It also accepts the `configId` parameter.
 
+`logoffLocal()` returns an `Observable`. You **must subscribe** for the logoff to actually happen.
+
 ```ts
 logoffLocal() {
-  this.oidcSecurityService.logoffLocal();
+  this.oidcSecurityService.logoffLocal().subscribe();
 }
 ```
+
+> **Breaking change (since v21.x):** `logoffLocal()` previously returned `void` and subscribed internally. It now returns `Observable<unknown>` to match `logoff()` / `logoffAndRevokeTokens()`. Add `.subscribe()` to existing calls — otherwise the logoff will not fire.
+
+### `logoffLocalMultiple()`
+
+Same as `logoffLocal()` but applies to every configured provider at once. Use this when you have more than one config enabled.
+
+```ts
+logoffLocalMultiple() {
+  this.oidcSecurityService.logoffLocalMultiple().subscribe();
+}
+```
+
+> **Breaking change (since v21.x):** `logoffLocalMultiple()` previously returned `void`. It now returns `Observable<unknown>` and must be subscribed to.

--- a/docs/site/angular-auth-oidc-client/docs/migrations/v21-to-v22.md
+++ b/docs/site/angular-auth-oidc-client/docs/migrations/v21-to-v22.md
@@ -1,0 +1,37 @@
+---
+sidebar_position: 92
+---
+
+# Version 21 to 22
+
+## TL;DR: Breaking Changes
+
+- `OidcSecurityService.logoffLocal()` and `logoffLocalMultiple()` now return `Observable<unknown>` instead of `void`. You must `.subscribe()` for the logoff to fire.
+
+## `logoffLocal()` / `logoffLocalMultiple()` return Observable
+
+Both methods previously returned `void` and subscribed internally to the configuration observable. That gave callers no way to chain follow-up work, no way to handle errors, and left the two methods inconsistent with the rest of the `logoff*` / `revoke*` surface, which already returns `Observable`.
+
+They now return `Observable<unknown>`. **Add `.subscribe()`** to every existing call — without it the logoff will not happen.
+
+```diff
+- this.oidcSecurityService.logoffLocal();
++ this.oidcSecurityService.logoffLocal().subscribe();
+
+- this.oidcSecurityService.logoffLocalMultiple();
++ this.oidcSecurityService.logoffLocalMultiple().subscribe();
+```
+
+Now you can also do things you couldn't before:
+
+```ts
+// Wait for logoff before navigating
+this.oidcSecurityService.logoffLocal().subscribe(() => {
+  this.router.navigate(['/goodbye']);
+});
+
+// Or await it
+await firstValueFrom(this.oidcSecurityService.logoffLocal());
+```
+
+See [PR #2212](https://github.com/damienbod/angular-auth-oidc-client/pull/2212).

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.spec.ts
@@ -627,7 +627,7 @@ describe('OidcSecurityService', () => {
   });
 
   describe('logoffLocal', () => {
-    it('calls logoffRevocationService.logoffLocal', waitForAsync(() => {
+    it('does not call logoffRevocationService.logoffLocal until subscribed', waitForAsync(() => {
       const config = { configId: 'configId1' };
 
       spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(
@@ -636,12 +636,24 @@ describe('OidcSecurityService', () => {
       const spy = spyOn(logoffRevocationService, 'logoffLocal');
 
       oidcSecurityService.logoffLocal();
+      expect(spy).not.toHaveBeenCalled();
+    }));
+
+    it('calls logoffRevocationService.logoffLocal when subscribed', waitForAsync(() => {
+      const config = { configId: 'configId1' };
+
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(
+        of({ allConfigs: [config], currentConfig: config })
+      );
+      const spy = spyOn(logoffRevocationService, 'logoffLocal');
+
+      oidcSecurityService.logoffLocal().subscribe();
       expect(spy).toHaveBeenCalledOnceWith(config, [config]);
     }));
   });
 
   describe('logoffLocalMultiple', () => {
-    it('calls logoffRevocationService.logoffLocalMultiple', waitForAsync(() => {
+    it('does not call logoffRevocationService.logoffLocalMultiple until subscribed', waitForAsync(() => {
       const config = { configId: 'configId1' };
 
       spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(
@@ -650,6 +662,18 @@ describe('OidcSecurityService', () => {
       const spy = spyOn(logoffRevocationService, 'logoffLocalMultiple');
 
       oidcSecurityService.logoffLocalMultiple();
+      expect(spy).not.toHaveBeenCalled();
+    }));
+
+    it('calls logoffRevocationService.logoffLocalMultiple when subscribed', waitForAsync(() => {
+      const config = { configId: 'configId1' };
+
+      spyOn(configurationService, 'getOpenIDConfigurations').and.returnValue(
+        of({ allConfigs: [config], currentConfig: config })
+      );
+      const spy = spyOn(logoffRevocationService, 'logoffLocalMultiple');
+
+      oidcSecurityService.logoffLocalMultiple().subscribe();
       expect(spy).toHaveBeenCalledOnceWith([config]);
     }));
   });

--- a/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/oidc.security.service.ts
@@ -458,24 +458,35 @@ export class OidcSecurityService {
    * Use this method if you have _one_ config enabled.
    *
    * @param configId The configId to perform the action in behalf of. If not passed, the first configs will be taken
+   *
+   * @returns An observable that performs the local logoff when subscribed.
+   *   You MUST subscribe (or pipe into another observable that is subscribed)
+   *   for the logoff to actually happen.
    */
-  logoffLocal(configId?: string): void {
-    this.configurationService
+  logoffLocal(configId?: string): Observable<unknown> {
+    return this.configurationService
       .getOpenIDConfigurations(configId)
-      .subscribe(({ allConfigs, currentConfig }) =>
-        this.logoffRevocationService.logoffLocal(currentConfig, allConfigs)
+      .pipe(
+        map(({ allConfigs, currentConfig }) =>
+          this.logoffRevocationService.logoffLocal(currentConfig, allConfigs)
+        )
       );
   }
 
   /**
    * Logs the user out of the application for all configs without logging them out of the server.
    * Use this method if you have _multiple_ configs enabled.
+   *
+   * @returns An observable that performs the local logoff for all configs when
+   *   subscribed. You MUST subscribe for the logoff to actually happen.
    */
-  logoffLocalMultiple(): void {
-    this.configurationService
+  logoffLocalMultiple(): Observable<unknown> {
+    return this.configurationService
       .getOpenIDConfigurations()
-      .subscribe(({ allConfigs }) =>
-        this.logoffRevocationService.logoffLocalMultiple(allConfigs)
+      .pipe(
+        map(({ allConfigs }) =>
+          this.logoffRevocationService.logoffLocalMultiple(allConfigs)
+        )
       );
   }
 

--- a/projects/sample-code-flow-http-config/src/app/home/home.component.ts
+++ b/projects/sample-code-flow-http-config/src/app/home/home.component.ts
@@ -44,6 +44,6 @@ export class HomeComponent implements OnInit {
   }
 
   logoffLocal(): void {
-    this.oidcSecurityService.logoffLocal();
+    this.oidcSecurityService.logoffLocal().subscribe();
   }
 }


### PR DESCRIPTION
## ⚠️ Breaking change

Callers of `OidcSecurityService.logoffLocal()` and `logoffLocalMultiple()` must now `.subscribe()` (or pipe into something that gets subscribed) for the logoff to actually fire.

```ts
// Before
this.oidc.logoffLocal();

// After
this.oidc.logoffLocal().subscribe();
```

## Summary
- Return type: `void` → `Observable<unknown>` for both `logoffLocal()` and `logoffLocalMultiple()`.
- Internal `.subscribe()` replaced with `pipe(map(...))` — idiomatic lazy RxJS.
- JSDoc updated to spell out the new contract.
- The one in-repo consumer (`sample-code-flow-http-config/home.component.ts`) updated to follow the new pattern.

Fixes #2066

## Why
Previously these two methods:
- Returned `void` while subscribing internally to `ConfigurationService.getOpenIDConfigurations()`.
- Had no error handler on the internal subscribe (errors went to Angular's global error handler with no context).
- Gave callers no way to await, chain, or know when the logoff was done.
- Were the only `logoff*` / `revoke*` methods on the service that returned `void` — all siblings already return `Observable`.

Issue #2066 explicitly asks for Promise/Observable return. This brings the two outliers in line with the rest of the public surface.

## Migration

Anywhere you call these methods today, append `.subscribe()`:

```diff
- this.oidcSecurityService.logoffLocal();
+ this.oidcSecurityService.logoffLocal().subscribe();

- this.oidcSecurityService.logoffLocalMultiple();
+ this.oidcSecurityService.logoffLocalMultiple().subscribe();
```

Now you can also do things you couldn't before:

```ts
// Wait for logoff before navigating
this.oidcSecurityService.logoffLocal().subscribe(() => {
  this.router.navigate(['/goodbye']);
});

// Or await it
await firstValueFrom(this.oidcSecurityService.logoffLocal());
```

## Test plan
- [x] Existing 2 tests rewritten as 4 (lazy-vs-subscribed pair per method)
- [x] Full library test suite: **985 / 985 SUCCESS**
- [x] `npm run lint-lib` clean
- [x] In-repo sample app updated

## Out of scope (intentionally)
- The nested-subscribe in `periodically-token-check.service.ts:83-96` was also flagged in the original analysis as "subscription leak." It actually subscribes to an auto-completing `of()`-based observable, so there's no real memory leak — but the pattern is still ugly. Better handled in its own focused PR that refactors the periodic-check pipeline.
- No new methods (`logoffLocal$` etc.) added — the existing names are now Observable, matching the sibling methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)