### PR TITLE
docs: fix typos, broken links, and invalid Docusaurus directive

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -29,7 +29,7 @@ export const appConfig: ApplicationConfig = {
 
 ### Using multiple configs
 
-You can pass an array of configs into the `provideAuth()` method. Each config will get an `configId` automatically if you do not set it for yourself.
+You can pass an array of configs into the `provideAuth()` method. Each config will get a `configId` automatically if you do not set it for yourself.
 
 ```ts
 import { ApplicationConfig } from '@angular/core';
@@ -532,7 +532,7 @@ Default = _3_
 - Required: `false`
 
 An array of secure urls to which the token should be sent if the interceptor is added to the `HTTP_INTERCEPTORS`. <br/>
-See [Http Interceptor](using-access-tokens.md/#http-interceptor)
+See [Http Interceptor](interceptors.md)
 
 ### `usePushedAuthorisationRequests`
 

--- a/docs/site/angular-auth-oidc-client/docs/documentation/interceptors.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/interceptors.md
@@ -7,7 +7,7 @@ sidebar_position: 11
 
 The `HttpClient` allows you to implement [HTTP interceptors](https://angular.dev/guide/http/interceptors#interceptors) to tap into requests and responses. A common use case would be to intercept any outgoing HTTP request and add an authorization header.
 
-:::warn
+:::warning
 
 Do not send the access token with requests for which the access token is not intended!
 

--- a/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/login-logout.md
@@ -134,7 +134,7 @@ A simplified page (instead of the application url) can be used. Here's an exampl
 
 ### Popup Sample
 
-[app.component.ts](../../../../../projects/sample-code-flow-popup/src/app/)
+[app.component.ts](https://github.com/damienbod/angular-auth-oidc-client/blob/main/projects/sample-code-flow-popup/src/app/app.component.ts)
 
 ## Logout
 

--- a/docs/site/angular-auth-oidc-client/docs/documentation/public-api.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/public-api.md
@@ -609,9 +609,9 @@ this.oidcSecurityService
 
 ## logoffAndRevokeTokens(configId?: string, authOptions?: AuthOptions)
 
-With this method the user is being logged out and the refresh token and and the access token are revoked on the server. If the refresh token does not exist only the access token is revoked. Then the logout runs normally.
+With this method the user is being logged out and the refresh token and the access token are revoked on the server. If the refresh token does not exist only the access token is revoked. Then the logout runs normally.
 
-This method takes a `configId` and and `authOptions` as parameter and returns an observable. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
+This method takes a `configId` and `authOptions` as parameter and returns an observable. If you are running with multiple configs and pass the `configId` the passed config is taken. If you are running with multiple configs and do not pass the `configId` the first config is taken. If you are running with a single config this config is taken.
 
 ```ts
 this.oidcSecurityService.logoffAndRevokeTokens().subscribe(/* ... */);

--- a/docs/site/angular-auth-oidc-client/docs/intro.md
+++ b/docs/site/angular-auth-oidc-client/docs/intro.md
@@ -17,7 +17,7 @@ You can use the schematics and `ng add` the library.
 ng add angular-auth-oidc-client
 ```
 
-Step through the wizard and select the appropriate configuration options for you environment. Once the wizard is complete, a module will be created to encapsulate your OIDC configuration. Many of the configured values are placeholders and will need to be adjusted for your individual use case. Once you've confirmed your configuration, the library is ready to use.
+Step through the wizard and select the appropriate configuration options for your environment. Once the wizard is complete, a module will be created to encapsulate your OIDC configuration. Many of the configured values are placeholders and will need to be adjusted for your individual use case. Once you've confirmed your configuration, the library is ready to use.
 
 ### Npm / Yarn / pnpm
 


### PR DESCRIPTION
## Summary
Seven small docs fixes turned up during a completeness/typo audit. One file each except `configuration.md` which had two issues.

| File:line | Fix |
|---|---|
| `interceptors.md:10` | \`:::warn\` → \`:::warning\` (Docusaurus only recognizes the full word; this has been logging as an unused directive on every CI build) |
| `configuration.md:535` | Link to Http Interceptor pointed to the wrong file with a malformed anchor (\`using-access-tokens.md/#http-interceptor\`); the section lives in \`interceptors.md\` |
| `configuration.md:32` | "an \`configId\`" → "a \`configId\`" |
| `login-logout.md:137` | "Popup Sample" link pointed to a directory via \`../../../../../projects/...\`; replaced with an absolute GitHub URL to the actual \`app.component.ts\` |
| `intro.md:20` | "for you environment" → "for your environment" |
| `public-api.md:612` | "the refresh token and and the access token" — dropped one \`and\` |
| `public-api.md:614` | "\`configId\` and and \`authOptions\`" — dropped one \`and\` |

## Why
All seven are clearly bugs (verified by `grep` or by the Docusaurus build log on existing PR runs). No design choices. Total diff: **+7 / -7**.

## Test plan
- [x] No behavior changes — docs only
- [x] `prettier` / `check-blockwords` pre-commit hooks pass
- [ ] After merge: confirm the next docs build no longer logs the "unused Markdown directive" warning for `interceptors.md:10` or the two broken-link warnings on `configuration:535` and `login-logout:137`

## Out of scope
A wider docs audit also surfaced **completeness gaps** (undocumented exports, `withAppInitializerAuthCheck` not explained, deprecated `isLoading$` still in docs) and **stale references**. Those need design discussion, not 1-line fixes, so they're not in this PR. Happy to open a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)