### PR TITLE
fix: scope the fix-prettier npm script to its arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "build-docs": "cd \"docs/site/angular-auth-oidc-client\" && npm run build",
     "check-prettier": "prettier --check \"projects/angular-auth-oidc-client/**/*.*\"",
     "check-blockwords": "node ./tools/check-blockwords.js",
-    "fix-prettier": "prettier --write  \"projects/**/*.*\"",
+    "fix-prettier": "prettier --write",
     "coveralls": "cat ./coverage/angular-auth-oidc-client/lcov.info | coveralls",
     "start": "ng serve sample-code-flow-refresh-tokens --ssl -o",
     "start-sample-code-flow-auto-login": "ng serve sample-code-flow-auto-login --ssl -o",


### PR DESCRIPTION
## Summary
Drop the hardcoded glob from the `fix-prettier` npm script so it only formats the files passed to it.

**One-line change** in `package.json`.

## The bug
\`\`\`json
\"fix-prettier\": \"prettier --write  \\\"projects/**/*.*\\\"\"
\`\`\`

`lefthook.yml` calls this on pre-push:

\`\`\`yaml
fix-prettier:
  glob: '*.{js,ts}'
  run: npm run fix-prettier {staged_files}
\`\`\`

The intent: format only the staged js/ts files. The reality: `npm run` appends the staged files **after** the existing glob in the script, so the command becomes:

\`\`\`
prettier --write "projects/**/*.*" <staged-file-1> <staged-file-2> ...
\`\`\`

prettier then runs on every file matching the glob (the entire `projects/` tree) plus the staged files. A push touching a single spec file ends up modifying every prettier-out-of-compliance file in the repo (~200 files), leaving the contributor with a giant dirty working tree.

I hit this on PR #2215 — the hook left hundreds of unrelated files modified and I had to revert them manually before being able to push cleanly.

## The fix
\`\`\`diff
- \"fix-prettier\": \"prettier --write  \\\"projects/**/*.*\\\"\",
+ \"fix-prettier\": \"prettier --write\",
\`\`\`

Now `npm run fix-prettier {staged_files}` becomes `prettier --write <staged-file-1> <staged-file-2>` — exactly what lefthook intended.

## Verification
- `npm run fix-prettier -- projects/angular-auth-oidc-client/karma.conf.js` formats only that one file. ✓
- No other file in the repo is touched. ✓

## Notes
- `fix-prettier` was only referenced by `lefthook.yml` — no other tooling, scripts, or docs use it. Confirmed via repo-wide grep.
- For manual full-project formatting (was the prior behavior of `npm run fix-prettier` with no args), the equivalent is now `npx prettier --write \"projects/**/*.*\"`.
- The companion `check-prettier` script (used for CI/check, not for fixing) is untouched.
- Pre-existing prettier-out-of-compliance files in the repo are unaffected by this change — they'll only get re-formatted if they're staged for a push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)