### PR TITLE
fix(check-session): require exact origin match in postMessage handler

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.spec.ts
@@ -356,6 +356,108 @@ describe('CheckSessionService', () => {
     });
   });
 
+  describe('messageHandler', () => {
+    const fakeIframe = {
+      contentWindow: { id: 'fake-iframe-content-window' },
+    } as any;
+    let eventService: PublicEventsService;
+    let serviceAsAny: any;
+
+    beforeEach(() => {
+      eventService = TestBed.inject(PublicEventsService);
+      serviceAsAny = checkSessionService as any;
+      spyOn(serviceAsAny, 'getExistingIframe').and.returnValue(fakeIframe);
+    });
+
+    function messageEvent(overrides: Partial<MessageEvent> = {}): MessageEvent {
+      return {
+        origin: 'https://idp.example.com',
+        source: fakeIframe.contentWindow,
+        data: 'changed',
+        ...overrides,
+      } as MessageEvent;
+    }
+
+    it('processes the message when e.origin exactly matches the origin of checkSessionIframe', () => {
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        checkSessionIframe: 'https://idp.example.com/connect/checksession',
+      });
+      const fireEventSpy = spyOn(eventService, 'fireEvent');
+
+      serviceAsAny.messageHandler({ configId: 'configId1' }, messageEvent());
+
+      expect(fireEventSpy).toHaveBeenCalled();
+    });
+
+    it('rejects the message when e.origin is only a prefix substring of checkSessionIframe (typosquat regression)', () => {
+      // Real-world risk: an attacker registers idp.example.co (one char short of
+      // idp.example.com) and tricks the iframe into loading from there. With the
+      // old startsWith check this passes because the configured URL string starts
+      // with the attacker's shorter origin. With exact-origin equality it fails.
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        checkSessionIframe: 'https://idp.example.com/connect/checksession',
+      });
+      const fireEventSpy = spyOn(eventService, 'fireEvent');
+
+      serviceAsAny.messageHandler(
+        { configId: 'configId1' },
+        messageEvent({ origin: 'https://idp.example.co' })
+      );
+
+      expect(fireEventSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects the message when e.origin is an unrelated host', () => {
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        checkSessionIframe: 'https://idp.example.com/checksession',
+      });
+      const fireEventSpy = spyOn(eventService, 'fireEvent');
+
+      serviceAsAny.messageHandler(
+        { configId: 'configId1' },
+        messageEvent({ origin: 'https://attacker.example' })
+      );
+
+      expect(fireEventSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects the message when checkSessionIframe is missing', () => {
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        checkSessionIframe: undefined,
+      });
+      const fireEventSpy = spyOn(eventService, 'fireEvent');
+
+      serviceAsAny.messageHandler({ configId: 'configId1' }, messageEvent());
+
+      expect(fireEventSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects the message when checkSessionIframe is a malformed URL', () => {
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        checkSessionIframe: 'not a valid url',
+      });
+      const fireEventSpy = spyOn(eventService, 'fireEvent');
+
+      serviceAsAny.messageHandler({ configId: 'configId1' }, messageEvent());
+
+      expect(fireEventSpy).not.toHaveBeenCalled();
+    });
+
+    it('rejects the message when e.source is not the existing iframe (defense in depth)', () => {
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        checkSessionIframe: 'https://idp.example.com/checksession',
+      });
+      const fireEventSpy = spyOn(eventService, 'fireEvent');
+
+      serviceAsAny.messageHandler(
+        { configId: 'configId1' },
+        messageEvent({ source: { id: 'some-other-window' } as any })
+      );
+
+      expect(fireEventSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('isCheckSessionConfigured', () => {
     it('returns true if startCheckSession on config is true', () => {
       const config = { configId: 'configId1', startCheckSession: true };      const result = checkSessionService.isCheckSessionConfigured(config);

--- a/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/check-session.service.ts
@@ -243,15 +243,17 @@ export class CheckSessionService implements OnDestroy {
       'authWellKnownEndPoints',
       configuration
     );
-    const startsWith = !!authWellKnownEndPoints?.checkSessionIframe?.startsWith(
-      e.origin
+    const expectedOrigin = this.getOriginOrNull(
+      authWellKnownEndPoints?.checkSessionIframe
     );
+    const originMatches =
+      expectedOrigin !== null && e.origin === expectedOrigin;
 
     this.outstandingMessages = 0;
 
     if (
       existingIFrame &&
-      startsWith &&
+      originMatches &&
       e.source === existingIFrame.contentWindow
     ) {
       if (e.data === 'error') {
@@ -312,5 +314,16 @@ export class CheckSessionService implements OnDestroy {
         configuration
       )
     );
+  }
+
+  private getOriginOrNull(url: string | undefined | null): string | null {
+    if (!url) {
+      return null;
+    }
+    try {
+      return new URL(url).origin;
+    } catch {
+      return null;
+    }
   }
 }


### PR DESCRIPTION
## Summary
Replace the loose `startsWith` origin check in `CheckSessionService.messageHandler` with exact-origin comparison against `new URL(checkSessionIframe).origin`.

**2 files, +118 / -3.** Production change is ~15 lines in `check-session.service.ts`; the rest is the new `describe('messageHandler')` test block (6 tests, the file had none).

## The bug

`check-session.service.ts:246`:

\`\`\`ts
const startsWith = !!authWellKnownEndPoints?.checkSessionIframe?.startsWith(
  e.origin
);
\`\`\`

This compares the configured iframe URL against the raw origin string as substrings, not as URL components. **Real-world risk: typosquatting.** With `checkSessionIframe = "https://idp.example.com/check"`, a typosquat origin like `https://idp.example.co` passes because the configured URL string literally starts with that shorter origin.

The `e.source === existingIFrame.contentWindow` check below is the strong defense today and was not bypassed by this bug — but the origin check is defense in depth, and it wasn't actually defending. If the source check ever fails (browser quirk, sandbox edge, future refactor), the loose origin check would be the only line — and it wouldn't hold.

## The fix

\`\`\`ts
const expectedOrigin = this.getOriginOrNull(
  authWellKnownEndPoints?.checkSessionIframe
);
const originMatches = expectedOrigin !== null && e.origin === expectedOrigin;
\`\`\`

\`\`\`ts
private getOriginOrNull(url: string | undefined | null): string | null {
  if (!url) {
    return null;
  }
  try {
    return new URL(url).origin;
  } catch {
    return null;
  }
}
\`\`\`

Edge cases handled:
- `checkSessionIframe` is `null`/`undefined` → no expected origin → reject
- `checkSessionIframe` is a malformed URL → `new URL()` throws → return null → reject
- Otherwise → exact `===` comparison of `e.origin` against the parsed origin

## Test plan
- [x] Added 6 `messageHandler` tests (the file had none before). Negative case for typosquat fails before the fix, passes after — proven via TDD.
- [x] Test for exact origin match (accept) — confirms legitimate flows still work
- [x] Tests for prefix substring, unrelated host, missing config, malformed URL, source mismatch (all reject)
- [x] Full library test suite passes
- [x] `npm run lint-lib` clean
- [x] Coverage went up (95.37% lines vs 94.97% before — this code path was previously untested)

## Compatibility

This is a behavior tightening. Two questions a reviewer should consider:

1. **Could it break a legitimate flow?** Browsers always emit `e.origin` as `scheme://host[:port]`. `new URL(checkSessionIframe).origin` produces the same format. For any correctly-configured OP they match exactly. The only way this could newly reject a legitimate message is if the configured `checkSessionIframe` URL is malformed — in which case rejection is the correct behavior anyway.

2. **What about IdPs that publish multiple `checkSessionIframe` URLs across tenants?** Each config has one `checkSessionIframe`. The iframe is loaded from that URL. Browser tags messages from that iframe with that URL's origin. Match — works as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)