### PR TITLE
fix: strip hash fragment when comparing redirect vs current URL (closes #2143)

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -45,7 +45,8 @@ describe('UrlService Tests', () => {
 
   describe('getUrlWithoutQueryParameters', () => {
     it('should return a new instance of the passed URL without any query parameters', () => {
-      const url = new URL('https://any.url');      const params = [
+      const url = new URL('https://any.url');
+      const params = [
         { key: 'doot', value: 'boop' },
         { key: 'blep', value: 'blep' },
       ];
@@ -63,7 +64,8 @@ describe('UrlService Tests', () => {
   });
 
   describe('queryParametersExist', () => {
-    const expected = new URLSearchParams();    const params = [
+    const expected = new URLSearchParams();
+    const params = [
       { key: 'doot', value: 'boop' },
       { key: 'blep', value: 'blep' },
     ];
@@ -75,7 +77,8 @@ describe('UrlService Tests', () => {
     const matchingUrls = [
       new URL('https://any.url?doot=boop&blep=blep'),
       new URL('https://any.url?doot=boop&blep=blep&woop=doot'),
-    ];    const nonMatchingUrls = [
+    ];
+    const nonMatchingUrls = [
       new URL('https://any.url?doot=boop'),
       new URL('https://any.url?blep=blep&woop=doot'),
     ];
@@ -351,7 +354,8 @@ describe('UrlService Tests', () => {
         'nonce',
         'state',
         config
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=code' +
@@ -389,7 +393,8 @@ describe('UrlService Tests', () => {
         'state',
         config,
         'myprompt'
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -427,7 +432,8 @@ describe('UrlService Tests', () => {
         config,
         'myprompt',
         { to: 'add', as: 'well' }
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -465,7 +471,8 @@ describe('UrlService Tests', () => {
         'nonce',
         'state',
         config
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -505,7 +512,8 @@ describe('UrlService Tests', () => {
         'nonce',
         'state',
         config
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -548,7 +556,8 @@ describe('UrlService Tests', () => {
         'nonce',
         'state',
         config
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -590,7 +599,8 @@ describe('UrlService Tests', () => {
         config,
         null,
         { to: 'add', as: 'well' }
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -629,7 +639,8 @@ describe('UrlService Tests', () => {
         config,
         null,
         { to: 'add', as: 'well' }
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -666,7 +677,8 @@ describe('UrlService Tests', () => {
         config,
         null,
         { to: 'add', as: 'well' }
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -702,7 +714,8 @@ describe('UrlService Tests', () => {
         'nonce',
         'state',
         config
-      );      const expectValue =
+      );
+      const expectValue =
         'https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/authorize?p=b2c_1_sign_in' +
         '&client_id=myid' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
@@ -738,7 +751,8 @@ describe('UrlService Tests', () => {
         'nonce',
         'state',
         config
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=id_token%20token' +
@@ -775,7 +789,8 @@ describe('UrlService Tests', () => {
         'state',
         config,
         'somePrompt'
-      );      const expectValue =
+      );
+      const expectValue =
         'http://example?client_id=188968487735-b1hh7k87nkkh6vv84548sinju2kpr7gn.apps.googleusercontent.com' +
         '&redirect_uri=https%3A%2F%2Flocalhost%3A44386' +
         '&response_type=code' +
@@ -901,7 +916,8 @@ describe('UrlService Tests', () => {
           revocationEndpoint,
         });
 
-      const value = service.getRevocationEndpointUrl(config);      const expectValue = 'http://example';
+      const value = service.getRevocationEndpointUrl(config);
+      const expectValue = 'http://example';
 
       expect(value).toEqual(expectValue);
     });
@@ -926,7 +942,8 @@ describe('UrlService Tests', () => {
           revocationEndpoint,
         });
 
-      const value = service.getRevocationEndpointUrl(config);      const expectValue = 'http://example';
+      const value = service.getRevocationEndpointUrl(config);
+      const expectValue = 'http://example';
 
       expect(value).toEqual(expectValue);
     });
@@ -1006,7 +1023,8 @@ describe('UrlService Tests', () => {
         scope: 'testScope',
         hdParam: undefined,
         customParamsAuthRequest: undefined,
-      } as OpenIdConfiguration;      const authorizationEndpoint = 'authorizationEndpoint';
+      } as OpenIdConfiguration;
+      const authorizationEndpoint = 'authorizationEndpoint';
 
       spyOn(jwtWindowCryptoService, 'generateCodeChallenge').and.returnValue(
         of('some-code-challenge')
@@ -1450,7 +1468,9 @@ describe('UrlService Tests', () => {
 
       const config = {
         silentRenewUrl,
-      };      const serviceAsAny = service as any;      const result = serviceAsAny.createUrlImplicitFlowWithSilentRenew(config);
+      };
+      const serviceAsAny = service as any;
+      const result = serviceAsAny.createUrlImplicitFlowWithSilentRenew(config);
 
       expect(result).toBeNull();
     });
@@ -1482,7 +1502,8 @@ describe('UrlService Tests', () => {
           authorizationEndpoint,
         });
 
-      const serviceAsAny = service as any;      const result = serviceAsAny.createUrlImplicitFlowWithSilentRenew(config);
+      const serviceAsAny = service as any;
+      const result = serviceAsAny.createUrlImplicitFlowWithSilentRenew(config);
 
       expect(result).toBe(
         `authorizationEndpoint?client_id=${clientId}&redirect_uri=http%3A%2F%2Fany-url.com&response_type=${responseType}&scope=${scope}&nonce=${nonce}&state=${state}&prompt=none`
@@ -1511,7 +1532,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue(null);
 
-      const serviceAsAny = service as any;      const result = serviceAsAny.createUrlImplicitFlowWithSilentRenew(config);
+      const serviceAsAny = service as any;
+      const result = serviceAsAny.createUrlImplicitFlowWithSilentRenew(config);
 
       expect(result).toBe(null);
     });
@@ -1539,7 +1561,9 @@ describe('UrlService Tests', () => {
 
       const config = {
         silentRenewUrl,
-      };      const serviceAsAny = service as any;      const resultObs$ = serviceAsAny.createUrlCodeFlowWithSilentRenew(config);
+      };
+      const serviceAsAny = service as any;
+      const resultObs$ = serviceAsAny.createUrlCodeFlowWithSilentRenew(config);
 
       resultObs$.subscribe((result: any) => {
         expect(result).toBe('');
@@ -1579,7 +1603,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue({ authorizationEndpoint });
 
-      const serviceAsAny = service as any;      const resultObs$ = serviceAsAny.createUrlCodeFlowWithSilentRenew(config);
+      const serviceAsAny = service as any;
+      const resultObs$ = serviceAsAny.createUrlCodeFlowWithSilentRenew(config);
 
       resultObs$.subscribe((result: any) => {
         expect(result).toBe(
@@ -1617,7 +1642,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue(null);
 
-      const serviceAsAny = service as any;      const resultObs$ = serviceAsAny.createUrlCodeFlowWithSilentRenew(config);
+      const serviceAsAny = service as any;
+      const resultObs$ = serviceAsAny.createUrlCodeFlowWithSilentRenew(config);
 
       resultObs$.subscribe((result: any) => {
         expect(result).toBe('');
@@ -1651,7 +1677,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue({ authorizationEndpoint });
 
-      const serviceAsAny = service as any;      const result = serviceAsAny.createUrlImplicitFlowAuthorize(config);
+      const serviceAsAny = service as any;
+      const result = serviceAsAny.createUrlImplicitFlowAuthorize(config);
 
       expect(result).toBe(
         `authorizationEndpoint?client_id=clientId&redirect_uri=http%3A%2F%2Fany-url.com&response_type=${responseType}&scope=${scope}&nonce=${nonce}&state=${state}`
@@ -1676,7 +1703,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue(null);
 
-      const serviceAsAny = service as any;      const result = serviceAsAny.createUrlImplicitFlowAuthorize(config);
+      const serviceAsAny = service as any;
+      const result = serviceAsAny.createUrlImplicitFlowAuthorize(config);
 
       expect(result).toBe(null);
     });
@@ -1698,7 +1726,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue(null);
 
-      const serviceAsAny = service as any;      const result = serviceAsAny.createUrlImplicitFlowAuthorize(config);
+      const serviceAsAny = service as any;
+      const result = serviceAsAny.createUrlImplicitFlowAuthorize(config);
 
       expect(result).toBe(null);
     });
@@ -1719,7 +1748,8 @@ describe('UrlService Tests', () => {
       ).and.returnValue(state);
       spyOn(flowsDataService, 'createNonce').and.returnValue(nonce);
 
-      const serviceAsAny = service as any;      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config);
+      const serviceAsAny = service as any;
+      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config);
 
       resultObs$.subscribe((result: any) => {
         expect(result).toBeNull();
@@ -1758,7 +1788,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue({ authorizationEndpoint });
 
-      const serviceAsAny = service as any;      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config);
+      const serviceAsAny = service as any;
+      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config);
 
       resultObs$.subscribe((result: any) => {
         expect(result).toBe(
@@ -1802,7 +1833,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue({ authorizationEndpoint });
 
-      const serviceAsAny = service as any;      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config, {
+      const serviceAsAny = service as any;
+      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config, {
         customParams: { to: 'add', as: 'well' },
       });
 
@@ -1839,7 +1871,8 @@ describe('UrlService Tests', () => {
         .withArgs('authWellKnownEndPoints', config)
         .and.returnValue(null);
 
-      const serviceAsAny = service as any;      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config);
+      const serviceAsAny = service as any;
+      const resultObs$ = serviceAsAny.createUrlCodeFlowAuthorize(config);
 
       resultObs$.subscribe((result: any) => {
         expect(result).toBe('');
@@ -1868,7 +1901,8 @@ describe('UrlService Tests', () => {
         });
 
       // Act
-      const value = service.getEndSessionUrl(config);      // Assert
+      const value = service.getEndSessionUrl(config);
+      // Assert
       const expectValue =
         'http://example?id_token_hint=mytoken&post_logout_redirect_uri=https%3A%2F%2Flocalhost%3A44386%2FUnauthorized';
 
@@ -1889,7 +1923,8 @@ describe('UrlService Tests', () => {
         });
 
       // Act
-      const value = service.getEndSessionUrl(config);      // Assert
+      const value = service.getEndSessionUrl(config);
+      // Assert
       const expectValue =
         'http://example?post_logout_redirect_uri=https%3A%2F%2Flocalhost%3A44386%2FUnauthorized';
 
@@ -1910,7 +1945,8 @@ describe('UrlService Tests', () => {
         });
 
       // Act
-      const value = service.getEndSessionUrl(config, { param: 'to-add' });      // Assert
+      const value = service.getEndSessionUrl(config, { param: 'to-add' });
+      // Assert
       const expectValue =
         'http://example?id_token_hint=mytoken&post_logout_redirect_uri=https%3A%2F%2Flocalhost%3A44386%2FUnauthorized&param=to-add';
 
@@ -1935,7 +1971,8 @@ describe('UrlService Tests', () => {
       );
 
       // Act
-      const value = service.getEndSessionUrl(config);      // Assert
+      const value = service.getEndSessionUrl(config);
+      // Assert
       const expectValue =
         'https://login.microsoftonline.com/fabrikamb2c.onmicrosoft.com/oauth2/v2.0/logout?p=b2c_1_sign_in' +
         '&id_token_hint=UzI1NiIsImtpZCI6Il' +
@@ -1957,7 +1994,8 @@ describe('UrlService Tests', () => {
       spyOn(storagePersistenceService, 'getIdToken').and.returnValue('mytoken');
 
       // Act
-      const value = service.getEndSessionUrl(config);      // Assert
+      const value = service.getEndSessionUrl(config);
+      // Assert
       const expectValue = 'http://example?id_token_hint=mytoken';
 
       expect(value).toEqual(expectValue);
@@ -1985,8 +2023,10 @@ describe('UrlService Tests', () => {
         authority: 'something.auth0.com',
         clientId: 'someClientId',
         postLogoutRedirectUri: 'https://localhost:1234/unauthorized',
-      };      // Act
-      const value = service.getEndSessionUrl(config);      // Assert
+      };
+      // Act
+      const value = service.getEndSessionUrl(config);
+      // Assert
       const expectValue = `something.auth0.com/v2/logout?client_id=someClientId&returnTo=https://localhost:1234/unauthorized`;
 
       expect(value).toEqual(expectValue);

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.spec.ts
@@ -61,6 +61,14 @@ describe('UrlService Tests', () => {
         expect(sut.searchParams.has(p.key)).toBeFalse();
       });
     });
+
+    it('should also strip the hash fragment', () => {
+      const url = new URL('https://any.url/path?q=1#anything');
+      const sut = service.getUrlWithoutQueryParameters(url);
+
+      expect(sut.hash).toBe('');
+      expect(sut.searchParams.has('q')).toBeFalse();
+    });
   });
 
   describe('queryParametersExist', () => {
@@ -129,6 +137,39 @@ describe('UrlService Tests', () => {
       nonMatchingUrls.forEach((nmu) => {
         expect(service.isCallbackFromSts(nmu.url, nmu.config)).toBeFalse();
       });
+    });
+
+    it('should return true when currentUrl has an extra hash fragment vs redirectUrl (Facebook #_=_ regression)', () => {
+      // Facebook appends "#_=_" to OAuth redirects. With
+      // checkRedirectUrlWhenCheckingIfIsCallback enabled, the trailing hash
+      // made currentUrl != redirectUrl after stripping query, so
+      // isCallbackFromSts returned false and the page got stuck on the
+      // callback URL.
+      // https://github.com/damienbod/angular-auth-oidc-client/issues/2143
+      const result = service.isCallbackFromSts(
+        'https://example.com/auth-callback?state=abc&iss=xyz&code=def#_=_',
+        {
+          redirectUrl: 'https://example.com/auth-callback',
+          checkRedirectUrlWhenCheckingIfIsCallback: true,
+        }
+      );
+
+      expect(result).toBeTrue();
+    });
+
+    it('should return true when currentUrl carries the response in the fragment (implicit flow)', () => {
+      // Implicit flow puts the auth response in the URL fragment by design.
+      // The URL comparison must not be tripped up by the presence of that
+      // fragment.
+      const result = service.isCallbackFromSts(
+        'https://example.com/auth-callback#access_token=xyz&state=abc&token_type=Bearer',
+        {
+          redirectUrl: 'https://example.com/auth-callback',
+          checkRedirectUrlWhenCheckingIfIsCallback: true,
+        }
+      );
+
+      expect(result).toBeTrue();
     });
 
     const testingValues = [

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/url.service.ts
@@ -52,6 +52,14 @@ export class UrlService {
       u.searchParams.delete(key);
     });
 
+    // Also drop the hash fragment. Some identity providers (e.g. Facebook)
+    // append "#_=_" to their redirect URL, and implicit flow puts the auth
+    // response in the fragment by design. Either way, the fragment is not
+    // part of the configured redirect URL and must not factor into the
+    // base-URL comparison done by isCallbackFromSts.
+    // https://github.com/damienbod/angular-auth-oidc-client/issues/2143
+    u.hash = '';
+
     return u;
   }
 


### PR DESCRIPTION
## Summary
`UrlService.getUrlWithoutQueryParameters` now also clears `u.hash`. That's the entire production change — 1 line + a comment. Closes #2143 (Facebook `#_=_` callback stuck) and fixes a related implicit-flow regression two commenters reported on the same issue.

**Two commits** so the diff is reviewable:
1. `chore: normalize line endings on url.service.spec.ts` — the spec file was checked in with mixed CRLF/CR/LF (git treated it as `-text`/binary). Re-encode to LF to match the rest of the repo. No semantic change.
2. `fix: strip hash fragment when comparing redirect vs current URL` — the actual fix + 3 new tests.

## The bug

With `checkRedirectUrlWhenCheckingIfIsCallback: true`, `isCallbackFromSts` compared `currentUrl` and `redirectUrl` after stripping the query string. The hash fragment was kept. Two providers were silently broken:

- **Facebook** appends `"#_=_"` to OAuth redirects ([known behavior](https://stackoverflow.com/a/41917323/3791820)). Result: `https://app.com/cb?code=…#_=_` was rejected because `https://app.com/cb#_=_` ≠ `https://app.com/cb`.
- **Implicit flow** puts the auth response in the fragment by design (`#access_token=…&state=…`). Same root cause: the fragment made the URL strings unequal.

Both reported in #2143 — original author for Facebook, two follow-up commenters for implicit flow and a regression on the v17→v20 upgrade.

## The fix

```diff
 keys.forEach((key) => {
   u.searchParams.delete(key);
 });

+// Also drop the hash fragment. Some identity providers (e.g. Facebook)
+// append "#_=_" to their redirect URL, and implicit flow puts the auth
+// response in the fragment by design. Either way, the fragment is not
+// part of the configured redirect URL and must not factor into the
+// base-URL comparison done by isCallbackFromSts.
+// https://github.com/damienbod/angular-auth-oidc-client/issues/2143
+u.hash = '';

 return u;
```

The companion check (the configured redirect's query parameters must all be present on the current URL) is **unchanged** — it still defends against partial-match callback URLs.

## Does it change behaviour?

**Yes — but only in the direction the bug report demands.**

- `isCallbackFromSts` may now return `true` in cases where it previously (incorrectly) returned `false`: specifically, when `currentUrl` carries a hash fragment that the configured `redirectUrl` doesn't have. That covers the Facebook + implicit-flow cases above.
- It does **not** turn any previously-`true` result into `false`. Nothing that worked before stops working.
- The query-parameter presence check is untouched, so a current URL missing the redirect URL's required query params still fails as before.

The only edge case would be a user who **configures** `redirectUrl` with a hash fragment (e.g. `https://app.com/cb#foo`) and expects the fragment to be enforced. That's against the OAuth spec ([RFC 6749 §3.1.2](https://datatracker.ietf.org/doc/html/rfc6749#section-3.1.2): redirect URI MUST NOT include a fragment) and would have been broken in other ways even before this PR.

Internal helper note: `getUrlWithoutQueryParameters` is now slightly misnamed (it also strips the fragment). The method isn't exported via the lib's `index.ts` so the rename can happen separately if you want. Left as-is here to keep the fix minimal.

## Test plan
- [x] 3 new tests, all failed before the fix:
  - helper: `getUrlWithoutQueryParameters` also strips the hash
  - `isCallbackFromSts`: Facebook `#_=_` regression
  - `isCallbackFromSts`: implicit-flow fragment
- [x] Full library test suite passes (101/101 in this spec; full suite green)
- [x] `npm run lint-lib` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)