### PR TITLE
test(popup): full branch coverage for popup services + fix stale storage flag

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup-login.service.spec.ts
@@ -54,6 +54,7 @@ describe('PopUpLoginService', () => {
 
   describe('loginWithPopUpStandard', () => {
     it('does nothing if it has an invalid response type', waitForAsync(() => {
+      // arrange
       const config = { responseType: 'stubValue' };
 
       spyOn(
@@ -62,7 +63,9 @@ describe('PopUpLoginService', () => {
       ).and.returnValue(false);
       const loggerSpy = spyOn(loggerService, 'logError');
 
+      // act
       popUpLoginService.loginWithPopUpStandard(config, [config]).subscribe({
+        // assert
         error: (err) => {
           expect(loggerSpy).toHaveBeenCalled();
           expect(err.message).toBe('Invalid response type!');
@@ -71,6 +74,7 @@ describe('PopUpLoginService', () => {
     }));
 
     it('calls urlService.getAuthorizeUrl() if everything fits', waitForAsync(() => {
+      // arrange
       const config = {
         authWellknownEndpointUrl: 'authWellknownEndpoint',
         responseType: 'stubValue',
@@ -92,14 +96,17 @@ describe('PopUpLoginService', () => {
         of({} as LoginResponse)
       );
 
+      // act
       popUpLoginService
         .loginWithPopUpStandard(config, [config])
         .subscribe(() => {
+          // assert
           expect(urlService.getAuthorizeUrl).toHaveBeenCalled();
         });
     }));
 
     it('opens popup if everything fits', waitForAsync(() => {
+      // arrange
       const config = {
         authWellknownEndpointUrl: 'authWellknownEndpoint',
         responseType: 'stubValue',
@@ -122,14 +129,17 @@ describe('PopUpLoginService', () => {
       );
       const popupSpy = spyOn(popupService, 'openPopUp');
 
+      // act
       popUpLoginService
         .loginWithPopUpStandard(config, [config])
         .subscribe(() => {
+          // assert
           expect(popupSpy).toHaveBeenCalled();
         });
     }));
 
     it('returns three properties when popupservice received an url', waitForAsync(() => {
+      // arrange
       const config = {
         authWellknownEndpointUrl: 'authWellknownEndpoint',
         responseType: 'stubValue',
@@ -161,9 +171,11 @@ describe('PopUpLoginService', () => {
 
       spyOnProperty(popupService, 'result$').and.returnValue(of(popupResult));
 
+      // act
       popUpLoginService
         .loginWithPopUpStandard(config, [config])
         .subscribe((result) => {
+          // assert
           expect(checkAuthSpy).toHaveBeenCalledOnceWith(
             config,
             [config],
@@ -181,6 +193,7 @@ describe('PopUpLoginService', () => {
     }));
 
     it('returns two properties if popup was closed by user', waitForAsync(() => {
+      // arrange
       const config = {
         authWellknownEndpointUrl: 'authWellknownEndpoint',
         responseType: 'stubValue',
@@ -204,9 +217,11 @@ describe('PopUpLoginService', () => {
 
       spyOnProperty(popupService, 'result$').and.returnValue(of(popupResult));
 
+      // act
       popUpLoginService
         .loginWithPopUpStandard(config, [config])
         .subscribe((result) => {
+          // assert
           expect(checkAuthSpy).not.toHaveBeenCalled();
           expect(result).toEqual({
             isAuthenticated: false,

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.spec.ts
@@ -84,6 +84,64 @@ describe('PopUpService', () => {
       expect(result).toBe(false);
     });
 
+    it('returns false if there is no window available', () => {
+      // arrange
+      spyOn(popUpService as any, 'canAccessSessionStorage').and.returnValue(
+        true
+      );
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue(
+        null
+      );
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        popupauth: true,
+      });
+      const config = {} as OpenIdConfiguration;
+      // act
+      const result = popUpService.isCurrentlyInPopup(config);
+
+      // assert
+      expect(result).toBe(false);
+    });
+
+    it('returns false if there is no popup flag in storage', () => {
+      // arrange
+      spyOn(popUpService as any, 'canAccessSessionStorage').and.returnValue(
+        true
+      );
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue({
+        opener: {} as Window,
+      });
+      spyOn(storagePersistenceService, 'read').and.returnValue(null);
+      const config = {} as OpenIdConfiguration;
+      // act
+      const result = popUpService.isCurrentlyInPopup(config);
+
+      // assert
+      expect(result).toBe(false);
+    });
+
+    it('returns false if window is its own opener', () => {
+      // arrange
+      const windowMock: any = { opener: null };
+
+      windowMock.opener = windowMock;
+      spyOn(popUpService as any, 'canAccessSessionStorage').and.returnValue(
+        true
+      );
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue(
+        windowMock
+      );
+      spyOn(storagePersistenceService, 'read').and.returnValue({
+        popupauth: true,
+      });
+      const config = {} as OpenIdConfiguration;
+      // act
+      const result = popUpService.isCurrentlyInPopup(config);
+
+      // assert
+      expect(result).toBe(false);
+    });
+
     it('returns true if isCurrentlyInPopup', () => {
       // arrange
       spyOn(popUpService as any, 'canAccessSessionStorage').and.returnValue(
@@ -106,15 +164,18 @@ describe('PopUpService', () => {
 
   describe('result$', () => {
     it('emits when internal subject is called', waitForAsync(() => {
+      // arrange
       const popupResult: PopupResult = {
         userClosed: false,
         receivedUrl: 'some-url1111',
       };
 
+      // assert
       popUpService.result$.subscribe((result) => {
         expect(result).toBe(popupResult);
       });
 
+      // act
       (popUpService as any).resultInternal$.next(popupResult);
     }));
   });
@@ -177,6 +238,38 @@ describe('PopUpService', () => {
       );
     });
 
+    it('logs error and does not open or write storage if url is empty', () => {
+      // arrange
+      const popupSpy = spyOn(window, 'open');
+      const loggerSpy = spyOn(loggerService, 'logError');
+      const writeSpy = spyOn(storagePersistenceService, 'write');
+
+      // act
+      popUpService.openPopUp('', {}, { configId: 'configId1' });
+
+      // assert
+      expect(loggerSpy).toHaveBeenCalledOnceWith(
+        { configId: 'configId1' },
+        'Could not open popup, url is empty'
+      );
+      expect(popupSpy).not.toHaveBeenCalled();
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does nothing if there is no window available', () => {
+      // arrange
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue(
+        null
+      );
+      const writeSpy = spyOn(storagePersistenceService, 'write');
+
+      // act
+      popUpService.openPopUp('url', {}, { configId: 'configId1' });
+
+      // assert
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
     describe('popup closed', () => {
       let popup: Window;
       let popupResult: PopupResult;
@@ -198,6 +291,7 @@ describe('PopUpService', () => {
       });
 
       it('message received with data', fakeAsync(() => {
+        // arrange
         let listener: (event: MessageEvent) => void = () => {
           return;
         };
@@ -206,6 +300,7 @@ describe('PopUpService', () => {
           (_: any, func: any) => (listener = func)
         );
 
+        // act
         popUpService.openPopUp('url', {}, { configId: 'configId1' });
 
         expect(popupResult).toEqual({} as PopupResult);
@@ -215,6 +310,7 @@ describe('PopUpService', () => {
 
         tick(200);
 
+        // assert
         expect(popupResult).toEqual({
           userClosed: false,
           receivedUrl: 'some-url1111',
@@ -225,6 +321,7 @@ describe('PopUpService', () => {
       }));
 
       it('message received without data does return but cleanup does not throw event', fakeAsync(() => {
+        // arrange
         let listener: (event: MessageEvent) => void = () => {
           return;
         };
@@ -234,6 +331,7 @@ describe('PopUpService', () => {
         );
         const nextSpy = spyOn((popUpService as any).resultInternal$, 'next');
 
+        // act
         popUpService.openPopUp('url', {}, { configId: 'configId1' });
 
         expect(popupResult).toEqual({} as PopupResult);
@@ -243,12 +341,46 @@ describe('PopUpService', () => {
 
         tick(200);
 
+        // assert
         expect(popupResult).toEqual({} as PopupResult);
         expect(cleanUpSpy).toHaveBeenCalled();
         expect(nextSpy).not.toHaveBeenCalled();
       }));
 
+      it('message received without data does not clean up when disableCleaningPopupOnInvalidMessage is true', fakeAsync(() => {
+        // arrange
+        let listener: (event: MessageEvent) => void = () => {
+          return;
+        };
+
+        spyOn(window, 'addEventListener').and.callFake(
+          (_: any, func: any) => (listener = func)
+        );
+        const nextSpy = spyOn((popUpService as any).resultInternal$, 'next');
+
+        // act
+        popUpService.openPopUp(
+          'url',
+          {},
+          {
+            configId: 'configId1',
+            disableCleaningPopupOnInvalidMessage: true,
+          }
+        );
+
+        listener(new MessageEvent('message', { data: null }));
+
+        // assert
+        expect(cleanUpSpy).not.toHaveBeenCalled();
+        expect(nextSpy).not.toHaveBeenCalled();
+
+        // cleanup the interval started by openPopUp
+        (popup as any).closed = true;
+        tick(200);
+      }));
+
       it('user closed', fakeAsync(() => {
+        // arrange & act
         popUpService.openPopUp('url', undefined, { configId: 'configId1' });
 
         expect(popupResult).toEqual({} as PopupResult);
@@ -258,6 +390,7 @@ describe('PopUpService', () => {
 
         tick(200);
 
+        // assert
         expect(popupResult).toEqual({
           userClosed: true,
           receivedUrl: '',
@@ -268,6 +401,22 @@ describe('PopUpService', () => {
   });
 
   describe('sendMessageToMainWindow', () => {
+    it('does nothing if there is no window available', waitForAsync(() => {
+      // arrange
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue(
+        null
+      );
+      const sendMessageSpy = spyOn(popUpService as any, 'sendMessage');
+
+      // act
+      popUpService.sendMessageToMainWindow('someUrl', {
+        configId: 'configId1',
+      });
+
+      // assert
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+    }));
+
     it('does nothing if window.opener is null', waitForAsync(() => {
       // arrange
       spyOnProperty(window, 'opener').and.returnValue(null);
@@ -297,9 +446,41 @@ describe('PopUpService', () => {
         jasmine.any(String)
       );
     }));
+
+    it('does not postMessage and logs debug when url is empty', waitForAsync(() => {
+      // arrange
+      spyOnProperty(window, 'opener').and.returnValue({
+        postMessage: () => undefined,
+      });
+      const sendMessageSpy = spyOn(window.opener, 'postMessage');
+      const loggerSpy = spyOn(loggerService, 'logDebug');
+
+      // act
+      popUpService.sendMessageToMainWindow('', { configId: 'configId1' });
+
+      // assert
+      expect(sendMessageSpy).not.toHaveBeenCalled();
+      expect(loggerSpy).toHaveBeenCalled();
+    }));
   });
 
   describe('cleanUp', () => {
+    it('does nothing if there is no window available', waitForAsync(() => {
+      // arrange
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue(
+        null
+      );
+      const removeSpy = spyOn(window, 'removeEventListener');
+      const removeItemSpy = spyOn(storagePersistenceService, 'remove');
+
+      // act
+      (popUpService as any).cleanUp(null, { configId: 'configId1' });
+
+      // assert
+      expect(removeSpy).not.toHaveBeenCalled();
+      expect(removeItemSpy).not.toHaveBeenCalled();
+    }));
+
     it('calls removeEventListener on window with correct params', waitForAsync(() => {
       // arrange
       const spy = spyOn(window, 'removeEventListener').and.callFake(
@@ -336,5 +517,72 @@ describe('PopUpService', () => {
       expect(closeSpy).toHaveBeenCalledTimes(1);
       expect((popUpService as any).popUp).toBeNull();
     }));
+  });
+
+  describe('sendMessage', () => {
+    it('does nothing if there is no window available', waitForAsync(() => {
+      // arrange
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue(
+        null
+      );
+      const loggerSpy = spyOn(loggerService, 'logDebug');
+      // act
+      const result = (popUpService as any).sendMessage('url', 'href', {
+        configId: 'configId1',
+      });
+
+      // assert
+      expect(result).toBeUndefined();
+      expect(loggerSpy).not.toHaveBeenCalled();
+    }));
+  });
+
+  describe('getOptions', () => {
+    it('returns an empty string if there is no window available', () => {
+      // arrange
+      spyOnProperty(popUpService as any, 'windowInternal').and.returnValue(
+        null
+      );
+
+      // act
+      const result = (popUpService as any).getOptions({});
+
+      // assert
+      expect(result).toBe('');
+    });
+
+    it('falls back to default width and height when passed values are falsy', () => {
+      // arrange
+      const popupOptions = { width: 0, height: 0 };
+      // act
+      const result = (popUpService as any).getOptions(popupOptions);
+
+      // assert
+      expect(result).toContain('left=');
+      expect(result).toContain('top=');
+      expect(typeof result).toBe('string');
+    });
+
+    it('returns a comma separated, url-encoded options string', () => {
+      // arrange
+      const popupOptions = { width: 100, height: 200 };
+      // act
+      const result = (popUpService as any).getOptions(popupOptions);
+
+      // assert
+      expect(result).toContain('width=100');
+      expect(result).toContain('height=200');
+      expect(result.split(',').length).toBe(4);
+    });
+  });
+
+  describe('canAccessSessionStorage', () => {
+    it('returns a boolean based on navigator, cookies and Storage availability', () => {
+      // act
+      const result = (popUpService as any).canAccessSessionStorage();
+
+      // assert
+      expect(typeof result).toBe('boolean');
+    });
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/popup/popup.service.ts
@@ -57,13 +57,6 @@ export class PopUpService {
     config: OpenIdConfiguration
   ): void {
     const optionsToPass = this.getOptions(popupOptions);
-
-    this.storagePersistenceService.write(
-      this.STORAGE_IDENTIFIER,
-      'true',
-      config
-    );
-
     const windowIdentifier = this.windowInternal;
 
     if (!windowIdentifier) {
@@ -75,6 +68,12 @@ export class PopUpService {
 
       return;
     }
+
+    this.storagePersistenceService.write(
+      this.STORAGE_IDENTIFIER,
+      'true',
+      config
+    );
 
     this.popUp = windowIdentifier.open(url, '_blank', optionsToPass);
 
@@ -132,7 +131,10 @@ export class PopUpService {
     }
   }
 
-  private cleanUp(listener: any, config: OpenIdConfiguration): void {
+  private cleanUp(
+    listener: (event: MessageEvent) => void,
+    config: OpenIdConfiguration
+  ): void {
     const windowIdentifier = this.windowInternal;
 
     if (!windowIdentifier) {


### PR DESCRIPTION
## What

Improves the `src/lib/login/popup/` services.

### Fix
- `openPopUp` wrote the `popupauth` storage flag *before* validating the window/url. On an empty-url failure the flag was left behind, making `isCurrentlyInPopup` return a false positive on the next load. The write now happens **after** the guards.
- Typed the `cleanUp` listener param as `(event: MessageEvent) => void` instead of `any`.

### Tests
- Added coverage for previously-untested branches: the `!windowInternal` early returns, empty url, `disableCleaningPopupOnInvalidMessage`, `getOptions` edge cases, and `canAccessSessionStorage`.
- Both `popup.service.ts` and `popup-login.service.ts` are now at **100% line / branch / function** coverage.
- Applied consistent arrange/act/assert comments throughout both spec files.

All 1007 lib tests pass; lint and block-word hooks pass.

## Note (not addressed here)
`sendMessageToMainWindow` passes the popup's own full `href` as the `postMessage` `targetOrigin` (should be the opener's origin). Left as-is since it's a behavior change worth discussing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)