### PR TITLE
test: cover long-tail branches across 15 lib files (100% each)

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/api/data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/api/data.service.spec.ts
@@ -188,5 +188,19 @@ describe('Data Service', () => {
 
       httpMock.verify();
     }));
+
+    it('falls back to an empty string url when url is null', waitForAsync(() => {
+      dataService
+        .post(null, { some: 'thing' }, { configId: 'configId1' })
+        .subscribe();
+      const req = httpMock.expectOne('');
+
+      expect(req.request.method).toBe('POST');
+      expect(req.request.url).toBe('');
+
+      req.flush('bodyData');
+
+      httpMock.verify();
+    }));
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.spec.ts
@@ -28,6 +28,16 @@ describe('AutoLoginService ', () => {
   });
 
   describe('checkSavedRedirectRouteAndNavigate', () => {
+    it('does nothing if config is null', () => {
+      const readSpy = spyOn(storagePersistenceService, 'read');
+      const routerSpy = spyOn(router, 'navigateByUrl');
+
+      autoLoginService.checkSavedRedirectRouteAndNavigate(null);
+
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(routerSpy).not.toHaveBeenCalled();
+    });
+
     it('if not route is saved, router and delete are not called', () => {
       const deleteSpy = spyOn(storagePersistenceService, 'remove');
       const routerSpy = spyOn(router, 'navigateByUrl');
@@ -68,6 +78,14 @@ describe('AutoLoginService ', () => {
   });
 
   describe('saveRedirectRoute', () => {
+    it('does nothing if config is null', () => {
+      const writeSpy = spyOn(storagePersistenceService, 'write');
+
+      autoLoginService.saveRedirectRoute(null, 'some-route');
+
+      expect(writeSpy).not.toHaveBeenCalled();
+    });
+
     it('calls storageService with correct params', () => {
       const writeSpy = spyOn(storagePersistenceService, 'write');
 

--- a/projects/angular-auth-oidc-client/src/lib/callback/callback.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/callback.service.spec.ts
@@ -43,6 +43,14 @@ describe('CallbackService ', () => {
       callbackService.isCallback('anyUrl');
       expect(urlServiceSpy).toHaveBeenCalledOnceWith('anyUrl', undefined);
     });
+
+    it('returns false and does not call urlService if currentUrl is empty', () => {
+      const urlServiceSpy = spyOn(urlService, 'isCallbackFromSts');
+      const result = callbackService.isCallback('');
+
+      expect(result).toBeFalse();
+      expect(urlServiceSpy).not.toHaveBeenCalled();
+    });
   });
 
   describe('stsCallback$', () => {

--- a/projects/angular-auth-oidc-client/src/lib/callback/interval.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/interval.service.spec.ts
@@ -28,6 +28,20 @@ describe('IntervalService', () => {
     expect(intervalService).toBeTruthy();
   });
 
+  describe('isTokenValidationRunning', () => {
+    it('returns false when no validation subscription is running', () => {
+      intervalService.runTokenValidationRunning = null;
+
+      expect(intervalService.isTokenValidationRunning()).toBeFalse();
+    });
+
+    it('returns true when a validation subscription is running', () => {
+      intervalService.runTokenValidationRunning = new Subscription();
+
+      expect(intervalService.isTokenValidationRunning()).toBeTrue();
+    });
+  });
+
   describe('stopPeriodicTokenCheck', () => {
     it('calls unsubscribe and sets to null', () => {
       intervalService.runTokenValidationRunning = new Subscription();

--- a/projects/angular-auth-oidc-client/src/lib/config/validation/config-validation.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/validation/config-validation.service.spec.ts
@@ -118,8 +118,10 @@ describe('Config Validation Service', () => {
         silentRenew: true,
         useRefreshToken: true,
         scopes: 'scope1 scope2 but_no_offline_access',
-      };      const loggerSpy = spyOn(loggerService, 'logError');
-      const loggerWarningSpy = spyOn(loggerService, 'logWarning');      const result = configValidationService.validateConfig(config);
+      };
+      const loggerSpy = spyOn(loggerService, 'logError');
+      const loggerWarningSpy = spyOn(loggerService, 'logWarning');
+      const result = configValidationService.validateConfig(config);
 
       expect(result).toBeTrue();
       expect(loggerSpy).not.toHaveBeenCalled();
@@ -140,8 +142,10 @@ describe('Config Validation Service', () => {
         silentRenew: true,
         useRefreshToken: true,
         scopes: 'scope1 scope2 but_no_offline_access',
-      };      const loggerErrorSpy = spyOn(loggerService, 'logError');
-      const loggerWarningSpy = spyOn(loggerService, 'logWarning');      const result = configValidationService.validateConfigs([
+      };
+      const loggerErrorSpy = spyOn(loggerService, 'logError');
+      const loggerWarningSpy = spyOn(loggerService, 'logWarning');
+      const result = configValidationService.validateConfigs([
         config1,
         config2,
       ]);
@@ -159,7 +163,8 @@ describe('Config Validation Service', () => {
     });
 
     it('should return false and a better error message when config is not passed as object with config property', () => {
-      const loggerWarningSpy = spyOn(loggerService, 'logWarning');      const result = configValidationService.validateConfigs([]);
+      const loggerWarningSpy = spyOn(loggerService, 'logWarning');
+      const result = configValidationService.validateConfigs([]);
 
       expect(result).toBeFalse();
       expect(loggerWarningSpy).not.toHaveBeenCalled();
@@ -171,7 +176,21 @@ describe('Config Validation Service', () => {
       const spy = spyOn(
         configValidationService as any,
         'validateConfigsInternal'
-      ).and.callThrough();      const result = configValidationService.validateConfigs([]);
+      ).and.callThrough();
+      const result = configValidationService.validateConfigs([]);
+
+      expect(result).toBeFalse();
+      expect(spy).toHaveBeenCalledOnceWith([], allMultipleConfigRules);
+    });
+
+    it('falls back to an empty array when null is passed', () => {
+      const spy = spyOn(
+        configValidationService as any,
+        'validateConfigsInternal'
+      ).and.callThrough();
+      const result = configValidationService.validateConfigs(
+        null as unknown as OpenIdConfiguration[]
+      );
 
       expect(result).toBeFalse();
       expect(spy).toHaveBeenCalledOnceWith([], allMultipleConfigRules);

--- a/projects/angular-auth-oidc-client/src/lib/config/validation/rules/ensure-no-duplicated-configs.rule.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/validation/rules/ensure-no-duplicated-configs.rule.spec.ts
@@ -1,0 +1,55 @@
+import { OpenIdConfiguration } from '../../openid-configuration';
+import { ensureNoDuplicatedConfigsRule } from './ensure-no-duplicated-configs.rule';
+
+describe('ensureNoDuplicatedConfigsRule', () => {
+  const createConfig = (
+    overrides: Partial<OpenIdConfiguration> = {}
+  ): OpenIdConfiguration => ({
+    authority: 'https://authority',
+    clientId: 'clientId',
+    scope: 'openid profile',
+    ...overrides,
+  });
+
+  it('returns an error when a config is not set (passed without a config property)', () => {
+    const result = ensureNoDuplicatedConfigsRule([
+      null as unknown as OpenIdConfiguration,
+    ]);
+
+    expect(result).toEqual({
+      result: false,
+      messages: [
+        `Please make sure you add an object with a 'config' property: ....({ config }) instead of ...(config)`,
+      ],
+      level: 'error',
+    });
+  });
+
+  it('returns a warning when two configs share authority, clientId and scope', () => {
+    const result = ensureNoDuplicatedConfigsRule([
+      createConfig(),
+      createConfig(),
+    ]);
+
+    expect(result).toEqual({
+      result: false,
+      messages: [
+        'You added multiple configs with the same authority, clientId and scope',
+      ],
+      level: 'warning',
+    });
+  });
+
+  it('returns a positive result for distinct configs', () => {
+    const result = ensureNoDuplicatedConfigsRule([
+      createConfig(),
+      createConfig({ clientId: 'clientId2' }),
+    ]);
+
+    expect(result).toEqual({
+      result: true,
+      messages: [],
+      level: 'none',
+    });
+  });
+});

--- a/projects/angular-auth-oidc-client/src/lib/flows/reset-auth-data.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/reset-auth-data.service.spec.ts
@@ -36,6 +36,30 @@ describe('ResetAuthDataService', () => {
   });
 
   describe('resetAuthorizationData', () => {
+    it('does nothing if no current configuration is provided', () => {
+      // arrange
+      const resetUserDataInStoreSpy = spyOn(
+        userService,
+        'resetUserDataInStore'
+      );
+      const resetStorageFlowDataSpy = spyOn(
+        flowsDataService,
+        'resetStorageFlowData'
+      );
+      const setUnauthenticatedAndFireEventSpy = spyOn(
+        authStateService,
+        'setUnauthenticatedAndFireEvent'
+      );
+
+      // act
+      service.resetAuthorizationData(null, [{ configId: 'configId1' }]);
+
+      // assert
+      expect(resetUserDataInStoreSpy).not.toHaveBeenCalled();
+      expect(resetStorageFlowDataSpy).not.toHaveBeenCalled();
+      expect(setUnauthenticatedAndFireEventSpy).not.toHaveBeenCalled();
+    });
+
     it('calls resetUserDataInStore when autoUserInfo is true', () => {
       const resetUserDataInStoreSpy = spyOn(
         userService,

--- a/projects/angular-auth-oidc-client/src/lib/iframe/existing-iframe.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/iframe/existing-iframe.service.spec.ts
@@ -1,0 +1,70 @@
+import { DOCUMENT } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { mockProvider } from '../../test/auto-mock';
+import { LoggerService } from '../logging/logger.service';
+import { IFrameService } from './existing-iframe.service';
+
+describe('IFrameService', () => {
+  let service: IFrameService;
+
+  describe('getExistingIFrame - found on parent window', () => {
+    let iframe: HTMLIFrameElement;
+
+    beforeEach(() => {
+      iframe = document.createElement('iframe');
+      iframe.id = 'iframeId';
+
+      TestBed.configureTestingModule({
+        providers: [
+          mockProvider(LoggerService),
+          {
+            provide: DOCUMENT,
+            useValue: {
+              defaultView: {
+                parent: {
+                  document: { getElementById: (): HTMLIFrameElement => iframe },
+                },
+              },
+              getElementById: (): null => null,
+            },
+          },
+        ],
+      });
+      service = TestBed.inject(IFrameService);
+    });
+
+    it('returns the iframe found on the parent window', () => {
+      const result = service.getExistingIFrame('iframeId');
+
+      expect(result).toBe(iframe);
+    });
+  });
+
+  describe('getExistingIFrame - parent window access throws', () => {
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        providers: [
+          mockProvider(LoggerService),
+          {
+            provide: DOCUMENT,
+            useValue: {
+              defaultView: {
+                get parent(): never {
+                  throw new Error('cross-origin access blocked');
+                },
+              },
+              getElementById: (): null => null,
+            },
+          },
+        ],
+      });
+      service = TestBed.inject(IFrameService);
+    });
+
+    it('returns null when accessing the parent window throws', () => {
+      const result = service.getExistingIFrame('iframeId');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/projects/angular-auth-oidc-client/src/lib/interceptor/closest-matching-route.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/interceptor/closest-matching-route.service.spec.ts
@@ -196,6 +196,18 @@ describe('ClosestMatchingRouteService', () => {
       expect(matchingConfig).toEqual(allConfigs[0]);
     });
 
+    it('treats a config without secureRoutes as having no routes', () => {
+      const allConfigs = [{ configId: 'configId1' }];
+      const { matchingConfig, matchingRoute } =
+        service.getConfigIdForClosestMatchingRoute(
+          'https://my-secure-url.com/',
+          allConfigs
+        );
+
+      expect(matchingConfig).toBeNull();
+      expect(matchingRoute).toBeNull();
+    });
+
     it('gets best match for configured routes - no config Id', () => {
       const allConfigs = [
         {

--- a/projects/angular-auth-oidc-client/src/lib/logging/logger.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/logging/logger.service.spec.ts
@@ -248,5 +248,57 @@ describe('Logger Service', () => {
       );
       expect(spy).not.toHaveBeenCalled();
     });
+
+    it('should not log if configuration is null', () => {
+      const spy = spyOn(console, 'debug');
+
+      loggerService.logDebug(null, 'some message');
+
+      expect(spy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('currentLogLevelIsEqualOrSmallerThan', () => {
+    it('returns false when no log level is configured', () => {
+      const result = (loggerService as any).currentLogLevelIsEqualOrSmallerThan(
+        null,
+        LogLevel.Debug
+      );
+
+      expect(result).toBeFalse();
+    });
+  });
+
+  describe('logLevelIsSet', () => {
+    it('returns false when log level is explicitly null', () => {
+      const result = (loggerService as any).logLevelIsSet({
+        configId: 'configId1',
+        logLevel: null,
+      });
+
+      expect(result).toBeFalse();
+    });
+
+    it('returns false when log level is undefined', () => {
+      const result = (loggerService as any).logLevelIsSet({
+        configId: 'configId1',
+      });
+
+      expect(result).toBeFalse();
+    });
+
+    it('returns false when configuration is null', () => {
+      const result = (loggerService as any).logLevelIsSet(null);
+
+      expect(result).toBeFalse();
+    });
+  });
+
+  describe('loggingIsTurnedOff', () => {
+    it('does not throw and returns false when configuration is null', () => {
+      const result = (loggerService as any).loggingIsTurnedOff(null);
+
+      expect(result).toBeFalse();
+    });
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/login/login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/login/login.service.spec.ts
@@ -91,7 +91,8 @@ describe('LoginService', () => {
       const config = null;
       const loginParSpy = spyOn(parLoginService, 'loginPar');
       const standardLoginSpy = spyOn(standardLoginService, 'loginStandard');
-      const authOptions = { customParams: { custom: 'params' } };      // act
+      const authOptions = { customParams: { custom: 'params' } };
+      // act
       const fn = (): void => service.login(config, authOptions);
 
       // assert
@@ -167,6 +168,27 @@ describe('LoginService', () => {
         );
       });
     }));
+
+    it('throws error if configuration is null', () => {
+      // arrange
+      const config = null;
+      const loginWithPopUpParSpy = spyOn(parLoginService, 'loginWithPopUpPar');
+      const loginWithPopUpStandardSpy = spyOn(
+        popUpLoginService,
+        'loginWithPopUpStandard'
+      );
+      // act
+      const fn = (): void => {
+        service.loginWithPopUp(config, []);
+      };
+
+      // assert
+      expect(fn).toThrow(
+        new Error('Please provide a configuration before setting up the module')
+      );
+      expect(loginWithPopUpParSpy).not.toHaveBeenCalled();
+      expect(loginWithPopUpStandardSpy).not.toHaveBeenCalled();
+    });
 
     it('returns error if there is already a popup open', () => {
       // arrange

--- a/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.spec.ts
@@ -31,6 +31,12 @@ describe('BrowserStorageService', () => {
   });
 
   describe('read', () => {
+    it('returns null if configId is missing', () => {
+      const config = { configId: '' };
+
+      expect(service.read('anything', config)).toBeNull();
+    });
+
     it('returns null if there is no storage', () => {
       const config = { configId: 'configId1' };
 
@@ -63,6 +69,12 @@ describe('BrowserStorageService', () => {
   });
 
   describe('write', () => {
+    it('returns false if configId is missing', () => {
+      const config = { configId: '' };
+
+      expect(service.write('anyvalue', config)).toBeFalse();
+    });
+
     it('returns false if there is no storage', () => {
       const config = { configId: 'configId1' };
 
@@ -78,7 +90,8 @@ describe('BrowserStorageService', () => {
       const writeSpy = spyOn(
         abstractSecurityStorage,
         'write'
-      ).and.callThrough();      const result = service.write({ anyKey: 'anyvalue' }, config);
+      ).and.callThrough();
+      const result = service.write({ anyKey: 'anyvalue' }, config);
 
       expect(result).toBe(true);
       expect(writeSpy).toHaveBeenCalledOnceWith(
@@ -96,7 +109,8 @@ describe('BrowserStorageService', () => {
         abstractSecurityStorage,
         'write'
       ).and.callThrough();
-      const somethingFalsy = '';      const result = service.write(somethingFalsy, config);
+      const somethingFalsy = '';
+      const result = service.write(somethingFalsy, config);
 
       expect(result).toBe(true);
       expect(writeSpy).toHaveBeenCalledOnceWith(
@@ -123,10 +137,12 @@ describe('BrowserStorageService', () => {
 
     it('removes the entire config blob for the configId', () => {
       spyOn(service as any, 'hasStorage').and.returnValue(true);
-      const config = { configId: 'configId1' };      const removeSpy = spyOn(
+      const config = { configId: 'configId1' };
+      const removeSpy = spyOn(
         abstractSecurityStorage,
         'remove'
-      ).and.callThrough();      const result = service.remove('anyKey', config);
+      ).and.callThrough();
+      const result = service.remove('anyKey', config);
 
       expect(result).toBe(true);
       expect(removeSpy).toHaveBeenCalledOnceWith('configId1');
@@ -155,7 +171,8 @@ describe('BrowserStorageService', () => {
         abstractSecurityStorage,
         'remove'
       ).and.callThrough();
-      const config = { configId: 'configId1' };      const result = service.clear(config);
+      const config = { configId: 'configId1' };
+      const result = service.clear(config);
 
       expect(result).toBe(true);
       expect(removeSpy).toHaveBeenCalledOnceWith('configId1');
@@ -165,7 +182,8 @@ describe('BrowserStorageService', () => {
   describe('multi-config isolation', () => {
     it('clear() should only remove the specified config, not other configs', () => {
       spyOn(service as any, 'hasStorage').and.returnValue(true);
-      const config1 = { configId: 'configId1' };      const removeSpy = spyOn(abstractSecurityStorage, 'remove');
+      const config1 = { configId: 'configId1' };
+      const removeSpy = spyOn(abstractSecurityStorage, 'remove');
 
       service.clear(config1);
 
@@ -175,7 +193,8 @@ describe('BrowserStorageService', () => {
 
     it('remove() should only remove the specified config blob, not other configs', () => {
       spyOn(service as any, 'hasStorage').and.returnValue(true);
-      const config1 = { configId: 'configId1' };      const removeSpy = spyOn(abstractSecurityStorage, 'remove');
+      const config1 = { configId: 'configId1' };
+      const removeSpy = spyOn(abstractSecurityStorage, 'remove');
 
       service.remove('anyKey', config1);
 
@@ -187,7 +206,8 @@ describe('BrowserStorageService', () => {
   describe('storage scope safety', () => {
     it('clear() should not call abstractSecurityStorage.clear() which would destroy all storage', () => {
       spyOn(service as any, 'hasStorage').and.returnValue(true);
-      const config = { configId: 'configId1' };      const clearSpy = spyOn(abstractSecurityStorage, 'clear');
+      const config = { configId: 'configId1' };
+      const clearSpy = spyOn(abstractSecurityStorage, 'clear');
       const removeSpy = spyOn(abstractSecurityStorage, 'remove');
 
       service.clear(config);
@@ -200,7 +220,8 @@ describe('BrowserStorageService', () => {
 
     it('remove() should not call abstractSecurityStorage.clear() which would destroy all storage', () => {
       spyOn(service as any, 'hasStorage').and.returnValue(true);
-      const config = { configId: 'configId1' };      const clearSpy = spyOn(abstractSecurityStorage, 'clear');
+      const config = { configId: 'configId1' };
+      const clearSpy = spyOn(abstractSecurityStorage, 'clear');
       const removeSpy = spyOn(abstractSecurityStorage, 'remove');
 
       service.remove('anyKey', config);

--- a/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/equality/equality.service.spec.ts
@@ -149,6 +149,18 @@ describe('EqualityService Tests', () => {
 
   describe('isStringEqualOrNonOrderedArrayEqual', () => {
     const testCases = [
+      // first value null/undefined is invalid
+      {
+        input1: null as any,
+        input2: 'value1',
+        expected: false,
+      },
+      // second value null/undefined is invalid
+      {
+        input1: 'value1',
+        input2: null as any,
+        expected: false,
+      },
       {
         input1: 'value1',
         input2: 'value1',

--- a/projects/angular-auth-oidc-client/src/lib/utils/flowHelper/flow-helper.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/flowHelper/flow-helper.service.spec.ts
@@ -57,19 +57,22 @@ describe('Flow Helper Service', () => {
   });
 
   it('isCurrentFlowImplicitFlowWithAccessToken return true if flow is "id_token token"', () => {
-    const config = { responseType: 'id_token token' };    const result = flowHelper.isCurrentFlowImplicitFlowWithAccessToken(config);
+    const config = { responseType: 'id_token token' };
+    const result = flowHelper.isCurrentFlowImplicitFlowWithAccessToken(config);
 
     expect(result).toBeTrue();
   });
 
   it('isCurrentFlowImplicitFlowWithAccessToken return false if flow is not "id_token token"', () => {
-    const config = { responseType: 'id_token2 token2' };    const result = flowHelper.isCurrentFlowImplicitFlowWithAccessToken(config);
+    const config = { responseType: 'id_token2 token2' };
+    const result = flowHelper.isCurrentFlowImplicitFlowWithAccessToken(config);
 
     expect(result).toBeFalse();
   });
 
   it('isCurrentFlowImplicitFlowWithoutAccessToken return true if flow is "id_token"', () => {
-    const config = { responseType: 'id_token' };    const result = (
+    const config = { responseType: 'id_token' };
+    const result = (
       flowHelper as any
     ).isCurrentFlowImplicitFlowWithoutAccessToken(config);
 
@@ -77,27 +80,37 @@ describe('Flow Helper Service', () => {
   });
 
   it('isCurrentFlowImplicitFlowWithoutAccessToken return false if flow is not "id_token token"', () => {
-    const config = { responseType: 'id_token2' };    const result = (
+    const config = { responseType: 'id_token2' };
+    const result = (
       flowHelper as any
     ).isCurrentFlowImplicitFlowWithoutAccessToken(config);
 
     expect(result).toBeFalse();
   });
 
+  it('isCurrentFlowCodeFlowWithRefreshTokens return false if configuration is null', () => {
+    const result = flowHelper.isCurrentFlowCodeFlowWithRefreshTokens(null);
+
+    expect(result).toBeFalse();
+  });
+
   it('isCurrentFlowCodeFlowWithRefreshTokens return false if flow is not code flow', () => {
-    const config = { responseType: 'not code' };    const result = flowHelper.isCurrentFlowCodeFlowWithRefreshTokens(config);
+    const config = { responseType: 'not code' };
+    const result = flowHelper.isCurrentFlowCodeFlowWithRefreshTokens(config);
 
     expect(result).toBeFalse();
   });
 
   it('isCurrentFlowCodeFlowWithRefreshTokens return false if useRefreshToken is set to false', () => {
-    const config = { responseType: 'not code', useRefreshToken: false };    const result = flowHelper.isCurrentFlowCodeFlowWithRefreshTokens(config);
+    const config = { responseType: 'not code', useRefreshToken: false };
+    const result = flowHelper.isCurrentFlowCodeFlowWithRefreshTokens(config);
 
     expect(result).toBeFalse();
   });
 
   it('isCurrentFlowCodeFlowWithRefreshTokens return true if useRefreshToken is set to true and code flow', () => {
-    const config = { responseType: 'code', useRefreshToken: true };    const result = flowHelper.isCurrentFlowCodeFlowWithRefreshTokens(config);
+    const config = { responseType: 'code', useRefreshToken: true };
+    const result = flowHelper.isCurrentFlowCodeFlowWithRefreshTokens(config);
 
     expect(result).toBeTrue();
   });

--- a/projects/angular-auth-oidc-client/src/lib/utils/url/current-url.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/utils/url/current-url.service.spec.ts
@@ -75,3 +75,28 @@ describe('CurrentUrlService with existing Url', () => {
     });
   });
 });
+
+describe('CurrentUrlService without defaultView', () => {
+  let service: CurrentUrlService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: DOCUMENT,
+          useValue: {},
+        },
+      ],
+    });
+
+    service = TestBed.inject(CurrentUrlService);
+  });
+
+  describe('getCurrentUrl', () => {
+    it('returns null when defaultView is not available', () => {
+      const currentUrl = service.getCurrentUrl();
+
+      expect(currentUrl).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## What

Quick-win unit-test coverage pass: closes the long-tail of small files that were each missing only a handful of guard / edge-case branches. Every file below is now at **100% line / branch / function** coverage. No production code changes — tests only.

### Files taken to 100%
- `api/data.service` — null `url` fallback in `post`
- `auto-login.service` — null-config guards in `checkSavedRedirectRouteAndNavigate` / `saveRedirectRoute`
- `callback.service` — empty `currentUrl` early return
- `callback/interval.service` — `isTokenValidationRunning`
- `config/validation/config-validation.service` — null `passedConfigs` fallback
- `config/validation/rules/ensure-no-duplicated-configs.rule` — **new spec** (null config → error, duplicate → warning, distinct → positive)
- `flows/reset-auth-data.service` — null-config guard
- `interceptor/closest-matching-route.service` — config without `secureRoutes`
- `logging/logger.service` — null-config `logDebug` + private level helpers
- `login/login.service` — `loginWithPopUp` null-config throw
- `storage/browser-storage.service` — missing `configId` on `read` / `write`
- `utils/equality/equality.service` — null value1 / value2 in `isStringEqualOrNonOrderedArrayEqual`
- `utils/flowHelper/flow-helper.service` — null config in `isCurrentFlowCodeFlowWithRefreshTokens`
- `utils/url/current-url.service` — no `defaultView`
- `iframe/existing-iframe.service` — **new spec** (iframe found on parent window + cross-origin access throws)

All 1020 lib tests pass; lint + block-word hooks pass.

## Note on diff size
Running the repo's Prettier on the touched spec files also split some pre-existing merged-statement lines (e.g. `).and.callThrough();      const result = ...`), which inflates the line counts. Those are formatting-only changes that bring the files into line with `check-prettier`.

## Not included
Larger gaps left for a follow-up: the two iframe services (`check-session`, `refresh-session-iframe`), the RxJS error-callback paths in `auth-state` / `check-auth` / `periodically-token-check` / `logoff-revocation`, and finicky/unreachable branches (e.g. `signin-key-data`'s `err || ''`, which is always `'{}'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)