### PR TITLE
fix: reset abandoned code flow flag on non-callback checkAuth (#2221)

### DIFF
--- a/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.spec.ts
@@ -12,6 +12,7 @@ import {
 } from '../config/loader/config-loader';
 import { OpenIdConfiguration } from '../config/openid-configuration';
 import { CallbackContext } from '../flows/callback-context';
+import { FlowsDataService } from '../flows/flows-data.service';
 import { CheckSessionService } from '../iframe/check-session.service';
 import { SilentRenewService } from '../iframe/silent-renew.service';
 import { LoggerService } from '../logging/logger.service';
@@ -39,6 +40,7 @@ describe('CheckAuthService', () => {
   let storagePersistenceService: StoragePersistenceService;
   let currentUrlService: CurrentUrlService;
   let publicEventsService: PublicEventsService;
+  let flowsDataService: FlowsDataService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -58,6 +60,7 @@ describe('CheckAuthService', () => {
         mockAbstractProvider(StsConfigLoader, StsConfigStaticLoader),
         AutoLoginService,
         mockProvider(StoragePersistenceService),
+        mockProvider(FlowsDataService),
       ],
     });
   });
@@ -78,6 +81,7 @@ describe('CheckAuthService', () => {
     storagePersistenceService = TestBed.inject(StoragePersistenceService);
     currentUrlService = TestBed.inject(CurrentUrlService);
     publicEventsService = TestBed.inject(PublicEventsService);
+    flowsDataService = TestBed.inject(FlowsDataService);
   });
 
   afterEach(() => {
@@ -630,6 +634,47 @@ describe('CheckAuthService', () => {
         ]);
       });
     }));
+
+    it('resets a previously abandoned code flow when the current url is NOT a callback', waitForAsync(() => {
+      const allConfigs = [
+        { configId: 'configId1', authority: 'some-authority' },
+      ];
+
+      spyOn(callBackService, 'isCallback').and.returnValue(false);
+      spyOn(currentUrlService, 'getCurrentUrl').and.returnValue(
+        'http://localhost:4200'
+      );
+      spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
+        false
+      );
+      const resetSpy = spyOn(flowsDataService, 'resetCodeFlowInProgress');
+
+      checkAuthService.checkAuth(allConfigs[0], allConfigs).subscribe(() => {
+        expect(resetSpy).toHaveBeenCalledOnceWith(allConfigs[0]);
+      });
+    }));
+
+    it('does NOT reset the code flow when the current url IS a callback', waitForAsync(() => {
+      const allConfigs = [
+        { configId: 'configId1', authority: 'some-authority' },
+      ];
+
+      spyOn(callBackService, 'isCallback').and.returnValue(true);
+      spyOn(callBackService, 'handleCallbackAndFireEvents').and.returnValue(
+        of({} as CallbackContext)
+      );
+      spyOn(currentUrlService, 'getCurrentUrl').and.returnValue(
+        'http://localhost:4200'
+      );
+      spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
+        false
+      );
+      const resetSpy = spyOn(flowsDataService, 'resetCodeFlowInProgress');
+
+      checkAuthService.checkAuth(allConfigs[0], allConfigs).subscribe(() => {
+        expect(resetSpy).not.toHaveBeenCalled();
+      });
+    }));
   });
 
   describe('checkAuthIncludingServer', () => {
@@ -833,7 +878,8 @@ describe('CheckAuthService', () => {
       const allConfigs = [
         { configId: 'configId1', authority: 'some-authority1' },
         { configId: 'configId2', authority: 'some-authority2' },
-      ];      const spy = spyOn(
+      ];
+      const spy = spyOn(
         checkAuthService as any,
         'checkAuthWithConfig'
       ).and.callThrough();
@@ -863,7 +909,8 @@ describe('CheckAuthService', () => {
       const allConfigs = [
         { configId: 'configId1', authority: 'some-authority1' },
         { configId: 'configId2', authority: 'some-authority2' },
-      ];      const spy = spyOn(
+      ];
+      const spy = spyOn(
         checkAuthService as any,
         'checkAuthWithConfig'
       ).and.callThrough();

--- a/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auth-state/check-auth.service.ts
@@ -6,6 +6,7 @@ import { CallbackService } from '../callback/callback.service';
 import { PeriodicallyTokenCheckService } from '../callback/periodically-token-check.service';
 import { RefreshSessionService } from '../callback/refresh-session.service';
 import { OpenIdConfiguration } from '../config/openid-configuration';
+import { FlowsDataService } from '../flows/flows-data.service';
 import { CheckSessionService } from '../iframe/check-session.service';
 import { SilentRenewService } from '../iframe/silent-renew.service';
 import { LoggerService } from '../logging/logger.service';
@@ -37,6 +38,7 @@ export class CheckAuthService {
     StoragePersistenceService
   );
   private readonly publicEventsService = inject(PublicEventsService);
+  private readonly flowsDataService = inject(FlowsDataService);
 
   checkAuth(
     configuration: OpenIdConfiguration | null,
@@ -214,6 +216,14 @@ export class CheckAuthService {
     }
 
     const isCallback = this.callbackService.isCallback(currentUrl, config);
+
+    if (!isCallback) {
+      // No authorization callback present, so any previously started code flow
+      // was abandoned (e.g. the user returned to the app without the callback
+      // URL). Reset the flag so the periodic token check is not blocked
+      // indefinitely after authenticating via silent renew. See issue #2221.
+      this.flowsDataService.resetCodeFlowInProgress(config);
+    }
 
     this.loggerService.logDebug(
       config,


### PR DESCRIPTION
## Summary

Fixes #2221 — the `storageCodeFlowInProgress` flag was never reset when a code flow is abandoned and the session is later established via silent renew, permanently disabling periodic token renewal.

### Root cause

`resetCodeFlowInProgress` is only called in `CodeFlowCallbackService.authenticatedCallbackWithCode`, which is reached **only** when the current URL contains an authorization code (`isCallback === true`).

When a user calls `authorize()` (which sets `storageCodeFlowInProgress = true`), authenticates at the IdP, but returns to the app **without** the callback URL, the flag is never reset. If the session is then established via `checkAuthIncludingServer` → `forceRefreshSession` (iframe silent renew), `shouldStartPeriodicallyCheckForConfig` keeps reading `isCodeFlowInProgress === true` and always returns `false` — so tokens are silently never renewed.

Unlike `isSilentRenewRunning`, `isCodeFlowInProgress` has no self-healing timeout.

### Fix

Reset the flag in `checkAuthWithConfig` whenever the current URL is **not** a callback. If the app loads without a callback URL, there is no in-flight code flow to protect, so the flag should be cleared. This is the minimal, defensive fix suggested in the issue, and it does not interfere with iframe silent renew (gated by the separate `isSilentRenewRunning` flag) or the existing reset on the callback path.

### Tests

Added two tests to `check-auth.service.spec.ts` (written test-first):
- resets a previously abandoned code flow when the current URL is **not** a callback
- does **not** reset the code flow when the current URL **is** a callback (the existing callback-path reset remains the single source of truth during real flows)

### Verification

- ✅ 995/995 lib tests pass (`npm run test-lib-ci`)
- ✅ `npm run lint-lib` clean
- ✅ Prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
