### PR TITLE
feat: add useRefreshTokenLock to serialize refresh token renewal across tabs

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/configuration.md
@@ -377,6 +377,14 @@ Makes it possible to add an offset to the silent renew check in seconds. By ente
 If set to true, refresh tokens will be used for the silent renew process instead of the default iframes. <br/>
 Default = _false_
 
+### `useRefreshTokenLock`
+
+- Type: `boolean`
+- Required: `false`
+
+If set to true, refresh token requests are serialized across browser tabs using the [Web Locks API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Locks_API), so only one tab refreshes at a time while the others reuse the result. <br/>
+Default = _false_
+
 ### `ignoreNonceAfterRefresh`
 
 - Type: `boolean`

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
@@ -1,5 +1,5 @@
 import { fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
-import { firstValueFrom, of, throwError } from 'rxjs';
+import { firstValueFrom, NEVER, of, throwError } from 'rxjs';
 import { mockProvider } from '../../test/auto-mock';
 import { AuthStateService } from '../auth-state/auth-state.service';
 import { CallbackContext } from '../flows/callback-context';
@@ -338,6 +338,35 @@ describe('RefreshSessionRefreshTokenService', () => {
           firstValueFrom(
             refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
               { configId: 'configId1', useRefreshTokenLock: true },
+              [{ configId: 'configId1' }]
+            )
+          )
+        ).toBeRejected();
+
+        expect(resetAuthorizationDataSpy).toHaveBeenCalled();
+      });
+
+      it('resetAuthorizationData when the refresh exceeds silentRenewTimeoutInSeconds inside the lock', async () => {
+        Object.defineProperty(navigator, 'locks', {
+          value: {
+            request: (_name: string, cb: () => Promise<unknown>) => cb(),
+          },
+          configurable: true,
+        });
+        spyOn(flowsService, 'processRefreshToken').and.returnValue(NEVER);
+        const resetAuthorizationDataSpy = spyOn(
+          resetAuthDataService,
+          'resetAuthorizationData'
+        );
+
+        await expectAsync(
+          firstValueFrom(
+            refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+              {
+                configId: 'configId1',
+                useRefreshTokenLock: true,
+                silentRenewTimeoutInSeconds: 0.01,
+              },
               [{ configId: 'configId1' }]
             )
           )

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
@@ -109,6 +109,31 @@ describe('RefreshSessionRefreshTokenService', () => {
     }));
 
     describe('cross-tab refresh token lock', () => {
+      it('does not request a lock when useRefreshTokenLock is disabled', async () => {
+        const requestSpy = jasmine
+          .createSpy('request')
+          .and.callFake((_name: string, cb: () => Promise<unknown>) => cb());
+
+        Object.defineProperty(navigator, 'locks', {
+          value: { request: requestSpy },
+          configurable: true,
+        });
+        const processSpy = spyOn(
+          flowsService,
+          'processRefreshToken'
+        ).and.returnValue(of({} as CallbackContext));
+
+        await firstValueFrom(
+          refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+            { configId: 'configId1', useRefreshTokenLock: false },
+            [{ configId: 'configId1' }]
+          )
+        );
+
+        expect(requestSpy).not.toHaveBeenCalled();
+        expect(processSpy).toHaveBeenCalled();
+      });
+
       it('reuses the stored tokens and skips processRefreshToken when another tab already refreshed', async () => {
         Object.defineProperty(navigator, 'locks', {
           value: {

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
@@ -1,6 +1,7 @@
 import { fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { firstValueFrom, of, throwError } from 'rxjs';
 import { mockProvider } from '../../test/auto-mock';
+import { AuthStateService } from '../auth-state/auth-state.service';
 import { CallbackContext } from '../flows/callback-context';
 import { FlowsService } from '../flows/flows.service';
 import { ResetAuthDataService } from '../flows/reset-auth-data.service';
@@ -13,6 +14,7 @@ describe('RefreshSessionRefreshTokenService', () => {
   let intervalService: IntervalService;
   let resetAuthDataService: ResetAuthDataService;
   let flowsService: FlowsService;
+  let authStateService: AuthStateService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -23,6 +25,7 @@ describe('RefreshSessionRefreshTokenService', () => {
         mockProvider(FlowsService),
         mockProvider(ResetAuthDataService),
         mockProvider(IntervalService),
+        mockProvider(AuthStateService),
       ],
     });
   });
@@ -34,6 +37,12 @@ describe('RefreshSessionRefreshTokenService', () => {
     );
     intervalService = TestBed.inject(IntervalService);
     resetAuthDataService = TestBed.inject(ResetAuthDataService);
+    authStateService = TestBed.inject(AuthStateService);
+  });
+
+  afterEach(() => {
+    // cleanup the navigator.locks shadow defined by the lock tests
+    delete (navigator as any).locks;
   });
 
   it('should create', () => {
@@ -97,5 +106,173 @@ describe('RefreshSessionRefreshTokenService', () => {
       tick();
       expect(stopPeriodicallyTokenCheckSpy).toHaveBeenCalled();
     }));
+
+    describe('cross-tab refresh token lock', () => {
+      it('reuses the stored tokens and skips processRefreshToken when another tab already refreshed', async () => {
+        Object.defineProperty(navigator, 'locks', {
+          value: {
+            request: (_name: string, cb: () => Promise<unknown>) => cb(),
+          },
+          configurable: true,
+        });
+        spyOn(authStateService, 'getAccessToken').and.returnValues(
+          'old-access-token',
+          'new-access-token'
+        );
+        spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
+          true
+        );
+        spyOn(authStateService, 'getRefreshToken').and.returnValue(
+          'new-refresh-token'
+        );
+        spyOn(authStateService, 'getIdToken').and.returnValue('new-id-token');
+        spyOn(authStateService, 'getAuthenticationResult').and.returnValue({
+          access_token: 'new-access-token',
+        });
+        const processSpy = spyOn(flowsService, 'processRefreshToken');
+        const callbackContext = await firstValueFrom(
+          refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+            { configId: 'configId1', useRefreshTokenLock: true },
+            [{ configId: 'configId1' }]
+          )
+        );
+
+        expect(processSpy).not.toHaveBeenCalled();
+        expect(callbackContext.refreshToken).toBe('new-refresh-token');
+        expect(callbackContext.existingIdToken).toBe('new-id-token');
+        expect(callbackContext.authResult).toEqual({
+          access_token: 'new-access-token',
+        });
+      });
+
+      it('still refreshes inside the lock when no other tab refreshed while waiting', async () => {
+        Object.defineProperty(navigator, 'locks', {
+          value: {
+            request: (_name: string, cb: () => Promise<unknown>) => cb(),
+          },
+          configurable: true,
+        });
+        spyOn(authStateService, 'getAccessToken').and.returnValue(
+          'same-access-token'
+        );
+        const processSpy = spyOn(
+          flowsService,
+          'processRefreshToken'
+        ).and.returnValue(of({} as CallbackContext));
+
+        await firstValueFrom(
+          refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+            { configId: 'configId1', useRefreshTokenLock: true },
+            [{ configId: 'configId1' }]
+          )
+        );
+
+        expect(processSpy).toHaveBeenCalled();
+      });
+
+      it('still refreshes inside the lock when another tab refreshed but the stored tokens are no longer valid', async () => {
+        Object.defineProperty(navigator, 'locks', {
+          value: {
+            request: (_name: string, cb: () => Promise<unknown>) => cb(),
+          },
+          configurable: true,
+        });
+        spyOn(authStateService, 'getAccessToken').and.returnValues(
+          'old-access-token',
+          'new-access-token'
+        );
+        spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
+          false
+        );
+        const processSpy = spyOn(
+          flowsService,
+          'processRefreshToken'
+        ).and.returnValue(of({} as CallbackContext));
+
+        await firstValueFrom(
+          refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+            { configId: 'configId1', useRefreshTokenLock: true },
+            [{ configId: 'configId1' }]
+          )
+        );
+
+        expect(processSpy).toHaveBeenCalled();
+      });
+
+      it('requests the lock with a per-config name when useRefreshTokenLock is enabled', async () => {
+        const requestSpy = jasmine
+          .createSpy('request')
+          .and.callFake((_name: string, cb: () => Promise<unknown>) => cb());
+
+        Object.defineProperty(navigator, 'locks', {
+          value: { request: requestSpy },
+          configurable: true,
+        });
+        const processSpy = spyOn(
+          flowsService,
+          'processRefreshToken'
+        ).and.returnValue(of({} as CallbackContext));
+
+        await firstValueFrom(
+          refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+            { configId: 'configId1', useRefreshTokenLock: true },
+            [{ configId: 'configId1' }]
+          )
+        );
+
+        expect(requestSpy).toHaveBeenCalledOnceWith(
+          'angular-auth-oidc-client-refresh-token-configId1',
+          jasmine.any(Function)
+        );
+        expect(processSpy).toHaveBeenCalled();
+      });
+
+      it('still refreshes when useRefreshTokenLock is enabled but the Web Locks API is unavailable', async () => {
+        Object.defineProperty(navigator, 'locks', {
+          value: undefined,
+          configurable: true,
+        });
+        const processSpy = spyOn(
+          flowsService,
+          'processRefreshToken'
+        ).and.returnValue(of({} as CallbackContext));
+
+        await firstValueFrom(
+          refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+            { configId: 'configId1', useRefreshTokenLock: true },
+            [{ configId: 'configId1' }]
+          )
+        );
+
+        expect(processSpy).toHaveBeenCalled();
+      });
+
+      it('resetAuthorizationData in case of error inside the lock', async () => {
+        Object.defineProperty(navigator, 'locks', {
+          value: {
+            request: (_name: string, cb: () => Promise<unknown>) => cb(),
+          },
+          configurable: true,
+        });
+        spyOn(flowsService, 'processRefreshToken').and.returnValue(
+          throwError(() => new Error('error'))
+        );
+        const resetAuthorizationDataSpy = spyOn(
+          resetAuthDataService,
+          'resetAuthorizationData'
+        );
+
+        await expectAsync(
+          firstValueFrom(
+            refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+              { configId: 'configId1', useRefreshTokenLock: true },
+              [{ configId: 'configId1' }]
+            )
+          )
+        ).toBeRejected();
+
+        expect(resetAuthorizationDataSpy).toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
@@ -163,6 +163,35 @@ describe('RefreshSessionRefreshTokenService', () => {
         });
       });
 
+      it('reuses the stored tokens when no access token existed before the lock', async () => {
+        Object.defineProperty(navigator, 'locks', {
+          value: {
+            request: (_name: string, cb: () => Promise<unknown>) => cb(),
+          },
+          configurable: true,
+        });
+        spyOn(authStateService, 'getAccessToken').and.returnValues(
+          '',
+          'new-access-token'
+        );
+        spyOn(authStateService, 'areAuthStorageTokensValid').and.returnValue(
+          true
+        );
+        spyOn(authStateService, 'getRefreshToken').and.returnValue(
+          'stored-refresh-token'
+        );
+        const processSpy = spyOn(flowsService, 'processRefreshToken');
+        const callbackContext = await firstValueFrom(
+          refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
+            { configId: 'configId1', useRefreshTokenLock: true },
+            [{ configId: 'configId1' }]
+          )
+        );
+
+        expect(processSpy).not.toHaveBeenCalled();
+        expect(callbackContext.refreshToken).toBe('stored-refresh-token');
+      });
+
       it('still refreshes inside the lock when no other tab refreshed while waiting', async () => {
         Object.defineProperty(navigator, 'locks', {
           value: {

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.spec.ts
@@ -6,6 +6,7 @@ import { CallbackContext } from '../flows/callback-context';
 import { FlowsService } from '../flows/flows.service';
 import { ResetAuthDataService } from '../flows/reset-auth-data.service';
 import { LoggerService } from '../logging/logger.service';
+import { ValidationResult } from '../validation/validation-result';
 import { IntervalService } from './interval.service';
 import { RefreshSessionRefreshTokenService } from './refresh-session-refresh-token.service';
 
@@ -129,6 +130,14 @@ describe('RefreshSessionRefreshTokenService', () => {
         spyOn(authStateService, 'getAuthenticationResult').and.returnValue({
           access_token: 'new-access-token',
         });
+        const setAuthenticatedSpy = spyOn(
+          authStateService,
+          'setAuthenticatedAndFireEvent'
+        );
+        const updateAuthStateSpy = spyOn(
+          authStateService,
+          'updateAndPublishAuthState'
+        );
         const processSpy = spyOn(flowsService, 'processRefreshToken');
         const callbackContext = await firstValueFrom(
           refreshSessionRefreshTokenService.refreshSessionWithRefreshTokens(
@@ -142,6 +151,15 @@ describe('RefreshSessionRefreshTokenService', () => {
         expect(callbackContext.existingIdToken).toBe('new-id-token');
         expect(callbackContext.authResult).toEqual({
           access_token: 'new-access-token',
+        });
+        expect(setAuthenticatedSpy).toHaveBeenCalledOnceWith([
+          { configId: 'configId1' },
+        ]);
+        expect(updateAuthStateSpy).toHaveBeenCalledOnceWith({
+          isAuthenticated: true,
+          validationResult: ValidationResult.Ok,
+          isRenewProcess: true,
+          configId: 'configId1',
         });
       });
 

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
@@ -1,5 +1,5 @@
 import { inject, Injectable } from '@angular/core';
-import { defer, firstValueFrom, Observable, throwError } from 'rxjs';
+import { defer, Observable, throwError } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
 import { AuthStateService } from '../auth-state/auth-state.service';
 import { OpenIdConfiguration } from '../config/openid-configuration';
@@ -90,13 +90,11 @@ export class RefreshSessionRefreshTokenService {
             };
           }
 
-          return firstValueFrom(
-            this.flowsService.processRefreshToken(
-              config,
-              allConfigs,
-              customParamsRefresh
-            )
-          );
+          return new Promise<CallbackContext>((resolve, reject) => {
+            this.flowsService
+              .processRefreshToken(config, allConfigs, customParamsRefresh)
+              .subscribe({ next: resolve, error: reject });
+          });
         }
       );
     });

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { DOCUMENT, inject, Injectable } from '@angular/core';
 import { defer, Observable, throwError } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
 import { AuthStateService } from '../auth-state/auth-state.service';
@@ -17,6 +17,7 @@ export class RefreshSessionRefreshTokenService {
   private readonly flowsService = inject(FlowsService);
   private readonly intervalService = inject(IntervalService);
   private readonly authStateService = inject(AuthStateService);
+  private readonly document = inject(DOCUMENT);
 
   refreshSessionWithRefreshTokens(
     config: OpenIdConfiguration,
@@ -25,17 +26,15 @@ export class RefreshSessionRefreshTokenService {
   ): Observable<CallbackContext> {
     this.loggerService.logDebug(config, 'BEGIN refresh session Authorize');
     let refreshTokenFailed = false;
-    const useLock =
-      !!config.useRefreshTokenLock &&
-      typeof navigator !== 'undefined' &&
-      !!navigator.locks;
-    const refresh$ = useLock
-      ? this.refreshWithLock(config, allConfigs, customParamsRefresh)
-      : this.flowsService.processRefreshToken(
-          config,
-          allConfigs,
-          customParamsRefresh
-        );
+    const locks = this.document.defaultView?.navigator?.locks;
+    const refresh$ =
+      config.useRefreshTokenLock && locks
+        ? this.refreshWithLock(locks, config, allConfigs, customParamsRefresh)
+        : this.flowsService.processRefreshToken(
+            config,
+            allConfigs,
+            customParamsRefresh
+          );
 
     return refresh$.pipe(
       catchError((error) => {
@@ -52,6 +51,7 @@ export class RefreshSessionRefreshTokenService {
   }
 
   private refreshWithLock(
+    locks: LockManager,
     config: OpenIdConfiguration,
     allConfigs: OpenIdConfiguration[],
     customParamsRefresh?: { [key: string]: string | number | boolean }
@@ -62,50 +62,46 @@ export class RefreshSessionRefreshTokenService {
       const accessTokenBeforeLock =
         this.authStateService.getAccessToken(config);
 
-      return navigator.locks.request(
-        lockName,
-        async (): Promise<CallbackContext> => {
-          const currentAccessToken =
-            this.authStateService.getAccessToken(config);
-          const wasRefreshedInAnotherTab =
-            !!currentAccessToken &&
-            currentAccessToken !== accessTokenBeforeLock &&
-            this.authStateService.areAuthStorageTokensValid(config);
+      return locks.request(lockName, async (): Promise<CallbackContext> => {
+        const currentAccessToken = this.authStateService.getAccessToken(config);
+        const wasRefreshedInAnotherTab =
+          !!currentAccessToken &&
+          currentAccessToken !== accessTokenBeforeLock &&
+          this.authStateService.areAuthStorageTokensValid(config);
 
-          if (wasRefreshedInAnotherTab) {
-            this.loggerService.logDebug(
-              config,
-              'access token was already refreshed in another tab, reusing the stored tokens'
-            );
+        if (wasRefreshedInAnotherTab) {
+          this.loggerService.logDebug(
+            config,
+            'access token was already refreshed in another tab, reusing the stored tokens'
+          );
 
-            this.authStateService.setAuthenticatedAndFireEvent(allConfigs);
-            this.authStateService.updateAndPublishAuthState({
-              isAuthenticated: true,
-              validationResult: ValidationResult.Ok,
-              isRenewProcess: true,
-              configId: config.configId,
-            });
-
-            return {
-              code: '',
-              refreshToken: this.authStateService.getRefreshToken(config),
-              state: '',
-              sessionState: null,
-              authResult: this.authStateService.getAuthenticationResult(config),
-              isRenewProcess: true,
-              jwtKeys: null,
-              validationResult: null,
-              existingIdToken: this.authStateService.getIdToken(config),
-            };
-          }
-
-          return new Promise<CallbackContext>((resolve, reject) => {
-            this.flowsService
-              .processRefreshToken(config, allConfigs, customParamsRefresh)
-              .subscribe({ next: resolve, error: reject });
+          this.authStateService.setAuthenticatedAndFireEvent(allConfigs);
+          this.authStateService.updateAndPublishAuthState({
+            isAuthenticated: true,
+            validationResult: ValidationResult.Ok,
+            isRenewProcess: true,
+            configId: config.configId,
           });
+
+          return {
+            code: '',
+            refreshToken: this.authStateService.getRefreshToken(config),
+            state: '',
+            sessionState: null,
+            authResult: this.authStateService.getAuthenticationResult(config),
+            isRenewProcess: true,
+            jwtKeys: null,
+            validationResult: null,
+            existingIdToken: this.authStateService.getIdToken(config),
+          };
         }
-      );
+
+        return new Promise<CallbackContext>((resolve, reject) => {
+          this.flowsService
+            .processRefreshToken(config, allConfigs, customParamsRefresh)
+            .subscribe({ next: resolve, error: reject });
+        });
+      });
     });
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
@@ -7,6 +7,7 @@ import { CallbackContext } from '../flows/callback-context';
 import { FlowsService } from '../flows/flows.service';
 import { ResetAuthDataService } from '../flows/reset-auth-data.service';
 import { LoggerService } from '../logging/logger.service';
+import { ValidationResult } from '../validation/validation-result';
 import { IntervalService } from './interval.service';
 
 @Injectable({ providedIn: 'root' })
@@ -76,6 +77,14 @@ export class RefreshSessionRefreshTokenService {
               config,
               'access token was already refreshed in another tab, reusing the stored tokens'
             );
+
+            this.authStateService.setAuthenticatedAndFireEvent(allConfigs);
+            this.authStateService.updateAndPublishAuthState({
+              isAuthenticated: true,
+              validationResult: ValidationResult.Ok,
+              isRenewProcess: true,
+              configId: config.configId,
+            });
 
             return {
               code: '',

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
@@ -1,6 +1,6 @@
 import { DOCUMENT, inject, Injectable } from '@angular/core';
 import { defer, Observable, throwError } from 'rxjs';
-import { catchError, finalize } from 'rxjs/operators';
+import { catchError, finalize, timeout } from 'rxjs/operators';
 import { AuthStateService } from '../auth-state/auth-state.service';
 import { OpenIdConfiguration } from '../config/openid-configuration';
 import { CallbackContext } from '../flows/callback-context';
@@ -96,6 +96,7 @@ export class RefreshSessionRefreshTokenService {
         return new Promise<CallbackContext>((resolve, reject) => {
           this.flowsService
             .processRefreshToken(config, allConfigs, customParamsRefresh)
+            .pipe(timeout((config.silentRenewTimeoutInSeconds ?? 20) * 1000))
             .subscribe({ next: resolve, error: reject });
         });
       });

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
@@ -4,6 +4,7 @@ import { catchError, finalize } from 'rxjs/operators';
 import { AuthStateService } from '../auth-state/auth-state.service';
 import { OpenIdConfiguration } from '../config/openid-configuration';
 import { CallbackContext } from '../flows/callback-context';
+import { createRenewCallbackContext } from '../flows/callback-context.helper';
 import { FlowsService } from '../flows/flows.service';
 import { ResetAuthDataService } from '../flows/reset-auth-data.service';
 import { LoggerService } from '../logging/logger.service';
@@ -83,17 +84,13 @@ export class RefreshSessionRefreshTokenService {
             configId: config.configId,
           });
 
-          return {
-            code: '',
-            refreshToken: this.authStateService.getRefreshToken(config),
-            state: '',
-            sessionState: null,
-            authResult: this.authStateService.getAuthenticationResult(config),
-            isRenewProcess: true,
-            jwtKeys: null,
-            validationResult: null,
-            existingIdToken: this.authStateService.getIdToken(config),
-          };
+          return createRenewCallbackContext(
+            this.authStateService.getRefreshToken(config),
+            this.authStateService.getIdToken(config),
+            {
+              authResult: this.authStateService.getAuthenticationResult(config),
+            }
+          );
         }
 
         return new Promise<CallbackContext>((resolve, reject) => {

--- a/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/callback/refresh-session-refresh-token.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
-import { Observable, throwError } from 'rxjs';
+import { defer, firstValueFrom, Observable, throwError } from 'rxjs';
 import { catchError, finalize } from 'rxjs/operators';
+import { AuthStateService } from '../auth-state/auth-state.service';
 import { OpenIdConfiguration } from '../config/openid-configuration';
 import { CallbackContext } from '../flows/callback-context';
 import { FlowsService } from '../flows/flows.service';
@@ -14,6 +15,7 @@ export class RefreshSessionRefreshTokenService {
   private readonly resetAuthDataService = inject(ResetAuthDataService);
   private readonly flowsService = inject(FlowsService);
   private readonly intervalService = inject(IntervalService);
+  private readonly authStateService = inject(AuthStateService);
 
   refreshSessionWithRefreshTokens(
     config: OpenIdConfiguration,
@@ -22,20 +24,81 @@ export class RefreshSessionRefreshTokenService {
   ): Observable<CallbackContext> {
     this.loggerService.logDebug(config, 'BEGIN refresh session Authorize');
     let refreshTokenFailed = false;
+    const useLock =
+      !!config.useRefreshTokenLock &&
+      typeof navigator !== 'undefined' &&
+      !!navigator.locks;
+    const refresh$ = useLock
+      ? this.refreshWithLock(config, allConfigs, customParamsRefresh)
+      : this.flowsService.processRefreshToken(
+          config,
+          allConfigs,
+          customParamsRefresh
+        );
 
-    return this.flowsService
-      .processRefreshToken(config, allConfigs, customParamsRefresh)
-      .pipe(
-        catchError((error) => {
-          this.resetAuthDataService.resetAuthorizationData(config, allConfigs);
-          refreshTokenFailed = true;
+    return refresh$.pipe(
+      catchError((error) => {
+        this.resetAuthDataService.resetAuthorizationData(config, allConfigs);
+        refreshTokenFailed = true;
 
-          return throwError(() => new Error(error));
-        }),
-        finalize(
-          () =>
-            refreshTokenFailed && this.intervalService.stopPeriodicTokenCheck()
-        )
+        return throwError(() => new Error(error));
+      }),
+      finalize(
+        () =>
+          refreshTokenFailed && this.intervalService.stopPeriodicTokenCheck()
+      )
+    );
+  }
+
+  private refreshWithLock(
+    config: OpenIdConfiguration,
+    allConfigs: OpenIdConfiguration[],
+    customParamsRefresh?: { [key: string]: string | number | boolean }
+  ): Observable<CallbackContext> {
+    const lockName = `angular-auth-oidc-client-refresh-token-${config.configId}`;
+
+    return defer(async (): Promise<CallbackContext> => {
+      const accessTokenBeforeLock =
+        this.authStateService.getAccessToken(config);
+
+      return navigator.locks.request(
+        lockName,
+        async (): Promise<CallbackContext> => {
+          const currentAccessToken =
+            this.authStateService.getAccessToken(config);
+          const wasRefreshedInAnotherTab =
+            !!currentAccessToken &&
+            currentAccessToken !== accessTokenBeforeLock &&
+            this.authStateService.areAuthStorageTokensValid(config);
+
+          if (wasRefreshedInAnotherTab) {
+            this.loggerService.logDebug(
+              config,
+              'access token was already refreshed in another tab, reusing the stored tokens'
+            );
+
+            return {
+              code: '',
+              refreshToken: this.authStateService.getRefreshToken(config),
+              state: '',
+              sessionState: null,
+              authResult: this.authStateService.getAuthenticationResult(config),
+              isRenewProcess: true,
+              jwtKeys: null,
+              validationResult: null,
+              existingIdToken: this.authStateService.getIdToken(config),
+            };
+          }
+
+          return firstValueFrom(
+            this.flowsService.processRefreshToken(
+              config,
+              allConfigs,
+              customParamsRefresh
+            )
+          );
+        }
       );
+    });
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/default-config.ts
@@ -18,6 +18,7 @@ export const DEFAULT_CONFIG: OpenIdConfiguration = {
   silentRenewTimeoutInSeconds: 20,
   renewTimeBeforeTokenExpiresInSeconds: 0,
   useRefreshToken: false,
+  useRefreshTokenLock: false,
   disableRefreshTokenOfflineAccessScopeWarning: false,
   usePushedAuthorisationRequests: false,
   ignoreNonceAfterRefresh: false,

--- a/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
+++ b/projects/angular-auth-oidc-client/src/lib/config/openid-configuration.ts
@@ -92,6 +92,13 @@ export interface OpenIdConfiguration {
    */
   useRefreshToken?: boolean;
   /**
+   * When set to true, refresh token requests are serialized across browser tabs using
+   * the Web Locks API, so only one tab refreshes at a time while the others reuse the
+   * result.
+   * Default value is false.
+   */
+  useRefreshTokenLock?: boolean;
+  /**
    * Suppresses the warning that recommends the `offline_access` scope when
    * using refresh tokens together with silent renew. Some providers support
    * this setup without requesting `offline_access`.

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-context.helper.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-context.helper.ts
@@ -1,0 +1,19 @@
+import { AuthResult, CallbackContext } from './callback-context';
+
+export function createRenewCallbackContext(
+  refreshToken: string,
+  existingIdToken: string | null,
+  overrides: { state?: string; authResult?: AuthResult | null } = {}
+): CallbackContext {
+  return {
+    code: '',
+    refreshToken,
+    state: overrides.state ?? '',
+    sessionState: null,
+    authResult: overrides.authResult ?? null,
+    isRenewProcess: true,
+    jwtKeys: null,
+    validationResult: null,
+    existingIdToken,
+  };
+}

--- a/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-session-callback-handler.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/flows/callback-handling/refresh-session-callback-handler.service.ts
@@ -5,6 +5,7 @@ import { OpenIdConfiguration } from '../../config/openid-configuration';
 import { LoggerService } from '../../logging/logger.service';
 import { TokenValidationService } from '../../validation/token-validation.service';
 import { CallbackContext } from '../callback-context';
+import { createRenewCallbackContext } from '../callback-context.helper';
 import { FlowsDataService } from '../flows-data.service';
 
 @Injectable({ providedIn: 'root' })
@@ -28,17 +29,11 @@ export class RefreshSessionCallbackHandlerService {
     const idToken = this.authStateService.getIdToken(config);
 
     if (refreshToken) {
-      const callbackContext: CallbackContext = {
-        code: '',
+      const callbackContext: CallbackContext = createRenewCallbackContext(
         refreshToken,
-        state: stateData,
-        sessionState: null,
-        authResult: null,
-        isRenewProcess: true,
-        jwtKeys: null,
-        validationResult: null,
-        existingIdToken: idToken,
-      };
+        idToken,
+        { state: stateData }
+      );
 
       this.loggerService.logDebug(
         config,


### PR DESCRIPTION
## Summary
Closes #1838 (same issue previously reported in #1662). New opt-in `useRefreshTokenLock` (default `false`): refresh token renewal is serialised across browser tabs per configId via the Web Locks API.

## The bug
With multiple tabs sharing storage (e.g., a custom localStorage `AbstractSecurityStorage`) and refresh token rotation, tabs renew concurrently using the same one-time-use refresh token. The losing tabs fail validation:

```
silent renew failed! Error: Error: authorizedCallback, token(s) validation failed, resetting.
```

And the session is reset for every tab. Reported with full repro steps in #1662 and #1838.

## The fix
With `useRefreshTokenLock: true`, `refreshSessionWithRefreshTokens` wraps the refresh in `navigator.locks.request('angular-auth-oidc-client-refresh-token-<configId>', ...)`:

- The tab snapshots the access token before requesting the lock and re-reads it once the lock is granted.
- Token changed while waiting and stored tokens are valid → another tab already refreshed; the stored tokens are reused, and the token request is skipped.
- Token changed but no longer valid → refresh normally (the Web Locks spec puts no upper bound on the wait, e.g. suspend/resume).
- Token unchanged → this tab performs the refresh.
- `navigator.locks` unavailable → the refresh runs unchanged without the lock.
- Errors inside the lock follow the existing reset + stop-periodic-check path.

Same approach as angular-oauth2-oidc: https://github.com/manfredsteyer/angular-oauth2-oidc/pull/1423

## Test plan
- [x] New tests: token reuse, refresh-when-unchanged, refresh-when-tokens-invalid, per-config lock name, no-API fallback, error propagation inside the lock
- [x] Full lib suite passes (1040 tests)
- [x] lint / prettier / block-words hooks pass
