### PR TITLE
fix: keep the auto-login redirect route per browser tab

### DIFF
--- a/docs/site/angular-auth-oidc-client/docs/documentation/auto-login.md
+++ b/docs/site/angular-auth-oidc-client/docs/documentation/auto-login.md
@@ -7,6 +7,8 @@ sidebar_position: 9
 
 The library supports route-based automatic login thanks to the functional route guard: `autoLoginPartialRoutesGuard`. The guard implements the necessary handlers for both `canActivate` and `canMatch`, and will preserve the route upon completing a successful login.
 
+The preserved route is kept per browser tab (`sessionStorage`), so logins running in multiple tabs at the same time each return to their own route.
+
 ## Common Scenarios
 
 Here are a couple of the common use cases.

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.spec.ts
@@ -1,7 +1,11 @@
+import { DOCUMENT } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { Router } from '@angular/router';
 import { RouterTestingModule } from '@angular/router/testing';
 import { mockProvider } from '../../test/auto-mock';
+import { OpenIdConfiguration } from '../config/openid-configuration';
+import { AbstractSecurityStorage } from '../storage/abstract-security-storage';
+import { DefaultLocalStorageService } from '../storage/default-localstorage.service';
 import { StoragePersistenceService } from '../storage/storage-persistence.service';
 import { AutoLoginService } from './auto-login.service';
 
@@ -21,6 +25,10 @@ describe('AutoLoginService ', () => {
     router = TestBed.inject(Router);
     autoLoginService = TestBed.inject(AutoLoginService);
     storagePersistenceService = TestBed.inject(StoragePersistenceService);
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem('configId1-redirect');
   });
 
   it('should create', () => {
@@ -56,7 +64,26 @@ describe('AutoLoginService ', () => {
       });
     });
 
-    it('if route is saved, router and delete are called', () => {
+    it('navigates to a route saved in this tab and clears it everywhere', () => {
+      const deleteSpy = spyOn(storagePersistenceService, 'remove');
+      const routerSpy = spyOn(router, 'navigateByUrl');
+      const readSpy = spyOn(storagePersistenceService, 'read');
+
+      sessionStorage.setItem('configId1-redirect', 'saved-route');
+
+      autoLoginService.checkSavedRedirectRouteAndNavigate({
+        configId: 'configId1',
+      });
+
+      expect(readSpy).not.toHaveBeenCalled();
+      expect(sessionStorage.getItem('configId1-redirect')).toBeNull();
+      expect(deleteSpy).toHaveBeenCalledOnceWith('redirect', {
+        configId: 'configId1',
+      });
+      expect(routerSpy).toHaveBeenCalledOnceWith('saved-route');
+    });
+
+    it('navigates to a route saved by a previous library version in the configured storage and clears it', () => {
       const deleteSpy = spyOn(storagePersistenceService, 'remove');
       const routerSpy = spyOn(router, 'navigateByUrl');
       const readSpy = spyOn(storagePersistenceService, 'read').and.returnValue(
@@ -84,9 +111,10 @@ describe('AutoLoginService ', () => {
       autoLoginService.saveRedirectRoute(null, 'some-route');
 
       expect(writeSpy).not.toHaveBeenCalled();
+      expect(sessionStorage.getItem('configId1-redirect')).toBeNull();
     });
 
-    it('calls storageService with correct params', () => {
+    it('saves the route per tab and leaves the shared storage untouched', () => {
       const writeSpy = spyOn(storagePersistenceService, 'write');
 
       autoLoginService.saveRedirectRoute(
@@ -94,9 +122,101 @@ describe('AutoLoginService ', () => {
         'some-route'
       );
 
-      expect(writeSpy).toHaveBeenCalledOnceWith('redirect', 'some-route', {
-        configId: 'configId1',
-      });
+      expect(sessionStorage.getItem('configId1-redirect')).toBe('some-route');
+      expect(writeSpy).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('AutoLoginService without sessionStorage', () => {
+  let autoLoginService: AutoLoginService;
+  let storagePersistenceService: StoragePersistenceService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        AutoLoginService,
+        mockProvider(StoragePersistenceService),
+        { provide: DOCUMENT, useValue: {} },
+      ],
+    });
+    autoLoginService = TestBed.inject(AutoLoginService);
+    storagePersistenceService = TestBed.inject(StoragePersistenceService);
+  });
+
+  it('falls back to the configured storage when sessionStorage is unavailable', () => {
+    const writeSpy = spyOn(storagePersistenceService, 'write');
+
+    autoLoginService.saveRedirectRoute({ configId: 'configId1' }, 'some-route');
+
+    expect(writeSpy).toHaveBeenCalledOnceWith('redirect', 'some-route', {
+      configId: 'configId1',
+    });
+  });
+});
+
+// Two tabs of the same app share one localStorage slot because configId is
+// deterministic ('0-clientId' in both tabs). Real storage chain; the route
+// must never land in that shared slot.
+describe('AutoLoginService multi-tab redirect', () => {
+  const config: OpenIdConfiguration = { configId: '0-clientId' };
+  let autoLoginService: AutoLoginService;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [RouterTestingModule],
+      providers: [
+        AutoLoginService,
+        {
+          provide: AbstractSecurityStorage,
+          useClass: DefaultLocalStorageService,
+        },
+      ],
+    });
+    autoLoginService = TestBed.inject(AutoLoginService);
+    router = TestBed.inject(Router);
+    localStorage.removeItem('0-clientId');
+    sessionStorage.removeItem('0-clientId-redirect');
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('0-clientId');
+    sessionStorage.removeItem('0-clientId-redirect');
+  });
+
+  it('keeps the deep link out of the storage shared with other tabs', () => {
+    autoLoginService.saveRedirectRoute(config, '/orders/123');
+
+    expect(localStorage.getItem('0-clientId')).toBeNull();
+    expect(sessionStorage.getItem('0-clientId-redirect')).toBe('/orders/123');
+  });
+
+  it('restores the deep link saved in this tab after the callback', () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+
+    autoLoginService.saveRedirectRoute(config, '/orders/123');
+    autoLoginService.checkSavedRedirectRouteAndNavigate(config);
+
+    expect(navigateSpy).toHaveBeenCalledOnceWith('/orders/123');
+    expect(sessionStorage.getItem('0-clientId-redirect')).toBeNull();
+  });
+
+  it('uses and clears a deep link a previous library version saved to the shared storage', () => {
+    const navigateSpy = spyOn(router, 'navigateByUrl');
+
+    localStorage.setItem(
+      '0-clientId',
+      JSON.stringify({ redirect: '/legacy-route' })
+    );
+
+    autoLoginService.checkSavedRedirectRouteAndNavigate(config);
+
+    expect(navigateSpy).toHaveBeenCalledOnceWith('/legacy-route');
+
+    const sharedSlot = JSON.parse(localStorage.getItem('0-clientId') ?? '{}');
+
+    expect(sharedSlot.redirect).toBeUndefined();
   });
 });

--- a/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.ts
+++ b/projects/angular-auth-oidc-client/src/lib/auto-login/auto-login.service.ts
@@ -1,4 +1,4 @@
-import { inject, Injectable } from '@angular/core';
+import { DOCUMENT, inject, Injectable } from '@angular/core';
 import { Router } from '@angular/router';
 import { OpenIdConfiguration } from '../config/openid-configuration';
 import { StoragePersistenceService } from '../storage/storage-persistence.service';
@@ -9,6 +9,7 @@ const STORAGE_KEY = 'redirect';
 export class AutoLoginService {
   private readonly storageService = inject(StoragePersistenceService);
   private readonly router = inject(Router);
+  private readonly document = inject(DOCUMENT);
 
   checkSavedRedirectRouteAndNavigate(config: OpenIdConfiguration | null): void {
     if (!config) {
@@ -23,7 +24,7 @@ export class AutoLoginService {
   }
 
   /**
-   * Saves the redirect URL to storage.
+   * Saves the redirect URL per browser tab, so concurrent logins in other tabs cannot overwrite it.
    *
    * @param config The OpenId configuration.
    * @param url The redirect URL to save.
@@ -33,20 +34,34 @@ export class AutoLoginService {
       return;
     }
 
-    this.storageService.write(STORAGE_KEY, url, config);
+    const tabLocalStorage = this.document.defaultView?.sessionStorage;
+
+    if (tabLocalStorage) {
+      tabLocalStorage.setItem(`${config.configId}-${STORAGE_KEY}`, url);
+    } else {
+      this.storageService.write(STORAGE_KEY, url, config);
+    }
   }
 
   /**
    * Gets the stored redirect URL from storage.
    */
-  private getStoredRedirectRoute(config: OpenIdConfiguration): string {
-    return this.storageService.read(STORAGE_KEY, config);
+  private getStoredRedirectRoute(config: OpenIdConfiguration): string | null {
+    const tabLocalRoute = this.document.defaultView?.sessionStorage?.getItem(
+      `${config.configId}-${STORAGE_KEY}`
+    );
+
+    // the configured storage still serves logins started before the route became tab-local
+    return tabLocalRoute ?? this.storageService.read(STORAGE_KEY, config);
   }
 
   /**
    * Removes the redirect URL from storage.
    */
   private deleteStoredRedirectRoute(config: OpenIdConfiguration): void {
+    this.document.defaultView?.sessionStorage?.removeItem(
+      `${config.configId}-${STORAGE_KEY}`
+    );
     this.storageService.remove(STORAGE_KEY, config);
   }
 }

--- a/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.spec.ts
+++ b/projects/angular-auth-oidc-client/src/lib/storage/browser-storage.service.spec.ts
@@ -235,9 +235,11 @@ describe('BrowserStorageService', () => {
 
   describe('hasStorage', () => {
     it('returns false if there is no storage', () => {
+      const originalStorage = Storage;
+
       (Storage as any) = undefined;
       expect((service as any).hasStorage()).toBeFalse();
-      Storage = Storage;
+      (Storage as any) = originalStorage;
     });
   });
 });


### PR DESCRIPTION
## Summary
The auto-login guards save the pending redirect route in the configured storage, which is shared across tabs (e.g. a localStorage `AbstractSecurityStorage`) and keyed by the deterministic configId — so concurrent logins in multiple tabs overwrite each other's saved route. The route is now stored per browser tab (`sessionStorage`).

## The bug
With a shared storage and two tabs logging in concurrently (same configId, one `redirect` slot):

- Tab A's guard saves `/orders/123`; tab B's guard overwrites it with `/orders/456` before the login completes.
- Whichever tab returns from the STS first navigates to the *other* tab's deep link and consumes the slot; the second tab restores nothing.
- An already-authenticated tab that merely hits a guarded route also consumes the pending slot and navigates away, since the guards call `checkSavedRedirectRouteAndNavigate` when authenticated.

The redirect round trip always returns to the tab that saved the route, so the slot is inherently tab-local state.

## The fix
`AutoLoginService` writes the route to `sessionStorage` (per tab, key `<configId>-redirect`), accessed via `inject(DOCUMENT).defaultView` like the other window globals in this library:

- Reads fall back once to the configured storage, so a login started before this change still restores its route; deletion clears both locations.
- `sessionStorage` unavailable (SSR) → the previous behavior is kept unchanged.
- The guards are untouched — they already go through `AutoLoginService`.

Trade-off: a route saved in one tab is no longer restored by a login completing in a *different* tab — that cross-tab restore was the same mechanism as the overwriting.

## Test plan
- [x] New tests: route kept out of the shared storage, restore + cleanup in the saving tab, legacy slot consumed and cleared, sessionStorage-unavailable fallback
- [x] Full lib suite passes (1053 tests)
- [x] lint / prettier / block-words hooks pass